### PR TITLE
feat(ci): prerelease support for npm and GitHub Releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,4 +25,14 @@ jobs:
         run: npm ci
 
       - name: Publish to npm
-        run: npm publish --access public
+        shell: bash
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          if [[ "$VERSION" == *-* ]]; then
+            TAG=$(echo "$VERSION" | sed 's/.*-\([a-z]*\).*/\1/')
+            echo "Publishing $VERSION under '$TAG' tag"
+            npm publish --access public --tag "$TAG"
+          else
+            echo "Publishing $VERSION under 'latest' tag"
+            npm publish --access public
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,20 @@ jobs:
       - name: Build tarball
         run: node scripts/build-tarball.js
 
+      - name: Detect prerelease
+        id: meta
+        shell: bash
+        run: |
+          TAG=${GITHUB_REF#refs/tags/}
+          if [[ "$TAG" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload to GitHub Release
         uses: softprops/action-gh-release@da05d552573ad5afe4a7eb7111b6cb4ef7282db1 # v2
         with:
           files: dist/gsd-ng.tar.gz
           generate_release_notes: true
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}


### PR DESCRIPTION
## Summary

- publish.yml detects prerelease version suffix and publishes under matching npm dist-tag (e.g., `1.0.0-dev.2` → `dev` tag, `1.0.0-beta.1` → `beta` tag, `1.0.0` → `latest`)
- release.yml marks GitHub Releases as prerelease when tag contains a hyphen

## Test plan

- [ ] Tag `v1.0.0-dev.2` triggers publish under `dev` tag
- [ ] Tag `v1.0.0` triggers publish under `latest` tag
- [ ] GitHub Release marked as prerelease for dev tags