### PR TITLE
fix(ci): correct softprops/action-gh-release SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           fi
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@da05d552573ad5afe4a7eb7111b6cb4ef7282db1 # v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: dist/gsd-ng.tar.gz
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Fix invalid commit SHA for `softprops/action-gh-release` that caused the Release workflow to fail on `v1.0.0-dev.1` tag

## Note

The publish failure was a separate issue — package.json had `version: 1.0.0` at the tagged commit, so the prerelease detection didn't trigger the `dev` dist-tag. Going forward, version must be bumped before tagging.