### PR TITLE
fix: add submodule-awareness to create-pr and squash workflows

### DIFF
--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -63,6 +63,28 @@ fi
 ```
 </step>
 
+<step name="detect_workspace">
+Detect the workspace topology so git operations target the correct repository. When workspace type is 'submodule', git operations (push, ls-remote, checkout, merge) must target the submodule directory so they operate against the correct repository and remote.
+
+```bash
+WORKSPACE_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
+WORKSPACE_TYPE=$(node -e "try{const w=JSON.parse(process.argv[1]);process.stdout.write(w.type||'standalone')}catch{process.stdout.write('standalone')}" "$WORKSPACE_JSON")
+SUBMODULE_PATH=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p[0]||'')}catch{process.stdout.write('')}" "$WORKSPACE_JSON")
+```
+
+When WORKSPACE_TYPE is "submodule" and SUBMODULE_PATH is non-empty:
+```bash
+if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
+  # Override REMOTE and TARGET_BRANCH from the submodule's git context
+  REMOTE=$(git -C "$SUBMODULE_PATH" remote | head -1)
+  TARGET_BRANCH=$(git -C "$SUBMODULE_PATH" symbolic-ref refs/remotes/${REMOTE}/HEAD 2>/dev/null | sed "s|refs/remotes/${REMOTE}/||" || echo "main")
+  GIT_PREFIX="git -C $SUBMODULE_PATH"
+else
+  GIT_PREFIX="git"
+fi
+```
+</step>
+
 <step name="detect_platform">
 Detect the git hosting platform:
 
@@ -97,10 +119,10 @@ STOP — return without creating PR. Do NOT fall back to curl/API.
 Verify the target branch exists on the remote before attempting PR creation:
 
 ```bash
-if ! git ls-remote --heads "$REMOTE" "$TARGET_BRANCH" | grep -q "$TARGET_BRANCH"; then
+if ! $GIT_PREFIX ls-remote --heads "$REMOTE" "$TARGET_BRANCH" | grep -q "$TARGET_BRANCH"; then
   echo "Error: Target branch '$TARGET_BRANCH' not found on remote '$REMOTE'."
   echo "Available branches:"
-  git ls-remote --heads "$REMOTE" | head -10
+  $GIT_PREFIX ls-remote --heads "$REMOTE" | head -10
   echo "Set target branch: node gsd-tools.cjs config-set git.target_branch {branch}"
   exit 1
 fi
@@ -116,7 +138,7 @@ No review branch, no squash. Open PR directly from current branch.
 
 ```bash
 if [ "$BRANCHING_STRATEGY" = "none" ]; then
-  CURRENT_BRANCH=$(git branch --show-current)
+  CURRENT_BRANCH=$($GIT_PREFIX branch --show-current)
   HEAD_BRANCH="$CURRENT_BRANCH"
   # Skip to build_pr_description — no review branch needed
 fi
@@ -171,24 +193,24 @@ REVIEW_BRANCH=$(echo "$REVIEW_BRANCH_TEMPLATE" | \
 
 Save the current work branch for later:
 ```bash
-CURRENT_BRANCH=$(git branch --show-current)
+CURRENT_BRANCH=$($GIT_PREFIX branch --show-current)
 ```
 
 Create or reset review branch from target_branch:
 ```bash
-if git show-ref --verify --quiet "refs/heads/$REVIEW_BRANCH" 2>/dev/null; then
+if $GIT_PREFIX show-ref --verify --quiet "refs/heads/$REVIEW_BRANCH" 2>/dev/null; then
   # Review branch exists — this is an update (re-squash)
-  git checkout "$REVIEW_BRANCH"
-  git reset --hard "$TARGET_BRANCH"
+  $GIT_PREFIX checkout "$REVIEW_BRANCH"
+  $GIT_PREFIX reset --hard "$TARGET_BRANCH"
 else
-  git checkout -b "$REVIEW_BRANCH" "$TARGET_BRANCH"
+  $GIT_PREFIX checkout -b "$REVIEW_BRANCH" "$TARGET_BRANCH"
 fi
 ```
 
 Squash work branch onto review branch:
 ```bash
 # Single squash of all work from the GSD work branch
-git merge --squash "$CURRENT_BRANCH" 2>&1
+$GIT_PREFIX merge --squash "$CURRENT_BRANCH" 2>&1
 
 # Build squash commit message from plan summaries
 SQUASH_MSG=""
@@ -204,7 +226,7 @@ if [ -z "$SQUASH_MSG" ]; then
   SQUASH_MSG="Phase ${PHASE_NUMBER}: ${PHASE_NAME}"
 fi
 
-git commit -m "$(printf "feat: Phase ${PHASE_NUMBER} - ${PHASE_NAME}\n\n${SQUASH_MSG}")"
+$GIT_PREFIX commit -m "$(printf "feat: Phase ${PHASE_NUMBER} - ${PHASE_NAME}\n\n${SQUASH_MSG}")"
 ```
 
 Set HEAD_BRANCH for PR creation:
@@ -219,14 +241,14 @@ Push the review branch (or current branch for none strategy) to remote:
 ```bash
 # For review branches, use --force-with-lease (squash rewrites history)
 if [ "$BRANCHING_STRATEGY" != "none" ]; then
-  PUSH_OUT=$(git push --force-with-lease -u "$REMOTE" "$HEAD_BRANCH" 2>&1)
+  PUSH_OUT=$($GIT_PREFIX push --force-with-lease -u "$REMOTE" "$HEAD_BRANCH" 2>&1)
 else
   # For none strategy, regular push
-  UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
+  UPSTREAM=$($GIT_PREFIX rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
   if [ -n "$UPSTREAM" ]; then
-    PUSH_OUT=$(git push "$REMOTE" "$HEAD_BRANCH" 2>&1)
+    PUSH_OUT=$($GIT_PREFIX push "$REMOTE" "$HEAD_BRANCH" 2>&1)
   else
-    PUSH_OUT=$(git push -u "$REMOTE" "$HEAD_BRANCH" 2>&1)
+    PUSH_OUT=$($GIT_PREFIX push -u "$REMOTE" "$HEAD_BRANCH" 2>&1)
   fi
 fi
 PUSH_EXIT=$?
@@ -235,7 +257,7 @@ if [ $PUSH_EXIT -ne 0 ]; then
   echo "Error: Push failed — $PUSH_OUT"
   echo "Fix the issue and retry: /gsd:create-pr ${PHASE_ARG}"
   # Return to work branch before exiting
-  git checkout "$CURRENT_BRANCH" 2>/dev/null
+  $GIT_PREFIX checkout "$CURRENT_BRANCH" 2>/dev/null
   exit 1
 fi
 ```
@@ -245,7 +267,7 @@ STOP on push failure — cannot create PR without pushed branch.
 Return to work branch after push (for phase/milestone strategies):
 ```bash
 if [ "$BRANCHING_STRATEGY" != "none" ]; then
-  git checkout "$CURRENT_BRANCH" 2>/dev/null || true
+  $GIT_PREFIX checkout "$CURRENT_BRANCH" 2>/dev/null || true
 fi
 ```
 </step>
@@ -347,42 +369,87 @@ if [ "$PR_DRAFT" = "true" ]; then
   DRAFT_FLAG="--draft"
 fi
 
+# When in a submodule workspace, run the PR CLI from inside the submodule
+# so the CLI detects the correct repository context and remote.
+PR_CLI_PREFIX=""
+if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
+  PR_CLI_PREFIX="(cd \"$SUBMODULE_PATH\" &&"
+  PR_CLI_SUFFIX=")"
+else
+  PR_CLI_PREFIX=""
+  PR_CLI_SUFFIX=""
+fi
+
 case "$PLATFORM" in
   github)
-    PR_URL=$(gh pr create \
-      --base "$TARGET_BRANCH" \
-      --head "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
-      --body-file "$PR_BODY_FILE" \
-      $DRAFT_FLAG 2>&1)
+    if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
+      PR_URL=$(cd "$SUBMODULE_PATH" && gh pr create \
+        --base "$TARGET_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --body-file "$PR_BODY_FILE" \
+        $DRAFT_FLAG 2>&1)
+    else
+      PR_URL=$(gh pr create \
+        --base "$TARGET_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --body-file "$PR_BODY_FILE" \
+        $DRAFT_FLAG 2>&1)
+    fi
     PR_EXIT=$?
     ;;
 
   gitlab)
-    PR_URL=$(glab mr create \
-      --target-branch "$TARGET_BRANCH" \
-      --source-branch "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
-      --description "$(cat "$PR_BODY_FILE")" \
-      $DRAFT_FLAG 2>&1)
+    if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
+      PR_URL=$(cd "$SUBMODULE_PATH" && glab mr create \
+        --target-branch "$TARGET_BRANCH" \
+        --source-branch "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --description "$(cat "$PR_BODY_FILE")" \
+        $DRAFT_FLAG 2>&1)
+    else
+      PR_URL=$(glab mr create \
+        --target-branch "$TARGET_BRANCH" \
+        --source-branch "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --description "$(cat "$PR_BODY_FILE")" \
+        $DRAFT_FLAG 2>&1)
+    fi
     PR_EXIT=$?
     ;;
 
   forgejo)
-    PR_URL=$(fj pr create \
-      --base "$TARGET_BRANCH" \
-      --head "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
-      --body "$(cat "$PR_BODY_FILE")" 2>&1)
+    if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
+      PR_URL=$(cd "$SUBMODULE_PATH" && fj pr create \
+        --base "$TARGET_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --body "$(cat "$PR_BODY_FILE")" 2>&1)
+    else
+      PR_URL=$(fj pr create \
+        --base "$TARGET_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --body "$(cat "$PR_BODY_FILE")" 2>&1)
+    fi
     PR_EXIT=$?
     ;;
 
   gitea)
-    PR_URL=$(tea pr create \
-      --base "$TARGET_BRANCH" \
-      --head "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
-      --description "$(cat "$PR_BODY_FILE")" 2>&1)
+    if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
+      PR_URL=$(cd "$SUBMODULE_PATH" && tea pr create \
+        --base "$TARGET_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --description "$(cat "$PR_BODY_FILE")" 2>&1)
+    else
+      PR_URL=$(tea pr create \
+        --base "$TARGET_BRANCH" \
+        --head "$HEAD_BRANCH" \
+        --title "$PR_TITLE" \
+        --description "$(cat "$PR_BODY_FILE")" 2>&1)
+    fi
     PR_EXIT=$?
     ;;
 
@@ -445,4 +512,5 @@ fi
 - [ ] Work branch restored as current branch after PR creation
 - [ ] force-with-lease used for review branch re-push (squash rewrites history)
 - [ ] Repo template detection with notice when overridden by user config
+- [ ] Submodule workspace detected and git operations target submodule remote
 </success_criteria>

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -372,17 +372,6 @@ if [ "$PR_DRAFT" = "true" ]; then
   DRAFT_FLAG="--draft"
 fi
 
-# When in a submodule workspace, run the PR CLI from inside the submodule
-# so the CLI detects the correct repository context and remote.
-PR_CLI_PREFIX=""
-if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
-  PR_CLI_PREFIX="(cd \"$SUBMODULE_PATH\" &&"
-  PR_CLI_SUFFIX=")"
-else
-  PR_CLI_PREFIX=""
-  PR_CLI_SUFFIX=""
-fi
-
 case "$PLATFORM" in
   github)
     if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -75,9 +75,12 @@ SUBMODULE_PATH=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.subm
 When WORKSPACE_TYPE is "submodule" and SUBMODULE_PATH is non-empty:
 ```bash
 if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
-  # Override REMOTE and TARGET_BRANCH from the submodule's git context
+  # Override REMOTE from the submodule's git context
   REMOTE=$(git -C "$SUBMODULE_PATH" remote | head -1)
-  TARGET_BRANCH=$(git -C "$SUBMODULE_PATH" symbolic-ref refs/remotes/${REMOTE}/HEAD 2>/dev/null | sed "s|refs/remotes/${REMOTE}/||" || echo "main")
+  # Preserve user-configured TARGET_BRANCH; only auto-detect if not already set
+  if ! git -C "$SUBMODULE_PATH" ls-remote --heads "$REMOTE" "$TARGET_BRANCH" 2>/dev/null | grep -q "$TARGET_BRANCH"; then
+    TARGET_BRANCH=$(git -C "$SUBMODULE_PATH" symbolic-ref refs/remotes/${REMOTE}/HEAD 2>/dev/null | sed "s|refs/remotes/${REMOTE}/||" || echo "main")
+  fi
   GIT_PREFIX="git -C $SUBMODULE_PATH"
 else
   GIT_PREFIX="git"

--- a/gsd-ng/workflows/squash.md
+++ b/gsd-ng/workflows/squash.md
@@ -68,6 +68,27 @@ if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 Extract PHASE_NUMBER, PHASE_NAME, PHASE_SLUG, TARGET_BRANCH, REMOTE from init JSON.
 </step>
 
+<step name="detect_workspace">
+Detect the workspace topology so git operations target the correct repository. When workspace type is 'submodule', git operations (push, branch) must target the submodule directory so they operate against the correct repository and remote.
+
+```bash
+WORKSPACE_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
+WORKSPACE_TYPE=$(node -e "try{const w=JSON.parse(process.argv[1]);process.stdout.write(w.type||'standalone')}catch{process.stdout.write('standalone')}" "$WORKSPACE_JSON")
+SUBMODULE_PATH=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p[0]||'')}catch{process.stdout.write('')}" "$WORKSPACE_JSON")
+```
+
+When WORKSPACE_TYPE is "submodule" and SUBMODULE_PATH is non-empty:
+```bash
+if [ "$WORKSPACE_TYPE" = "submodule" ] && [ -n "$SUBMODULE_PATH" ]; then
+  # Override REMOTE from the submodule's git context
+  REMOTE=$(git -C "$SUBMODULE_PATH" remote | head -1)
+  GIT_PREFIX="git -C $SUBMODULE_PATH"
+else
+  GIT_PREFIX="git"
+fi
+```
+</step>
+
 <step name="select_strategy">
 If --strategy flag provided, use it.
 
@@ -128,9 +149,9 @@ Push squashed branch with --force-with-lease?
 
 If yes:
 ```bash
-REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.remote --raw 2>/dev/null || echo "origin")
-BRANCH=$(git branch --show-current)
-git push --force-with-lease "$REMOTE" "$BRANCH"
+# REMOTE already resolved in detect_phase + detect_workspace steps
+BRANCH=$($GIT_PREFIX branch --show-current)
+$GIT_PREFIX push --force-with-lease "$REMOTE" "$BRANCH"
 ```
 </step>
 
@@ -159,4 +180,5 @@ Cleanup:  git tag -d ${BACKUP_TAG}
 - [ ] Squash executed with correct strategy
 - [ ] --force-with-lease used for push (never bare --force)
 - [ ] Restore command displayed for safety
+- [ ] Submodule workspace detected and push targets submodule remote
 </success_criteria>


### PR DESCRIPTION
## Summary

- `create-pr.md` and `squash.md` now call `detect-workspace` to identify submodule topology
- When workspace type is `submodule`, all git operations route through `git -C $SUBMODULE_PATH` and PR CLI commands `cd` into the submodule directory
- Standalone workspaces are unaffected (`GIT_PREFIX` defaults to `git`)

## Context

Both workflows used workspace-level `$REMOTE` and `$TARGET_BRANCH` for push and PR creation. In submodule workspaces, the actual code and target repo is the submodule's remote, not the workspace's. This caused "branch not found" errors and PRs targeting the wrong repository.

## Test Plan

- [ ] Run `/gsd:create-pr` from a submodule workspace — PR targets submodule repo
- [ ] Run `/gsd:create-pr` from a standalone workspace — behavior unchanged
- [ ] Run `/gsd:squash` from a submodule workspace — push targets submodule remote

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng)*