### PR TITLE
feat: submodule-aware git operations + PR review fixes (Phases 41-42)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build hooks
-        run: npm run build:hooks
-
       - name: Run tests with coverage
         shell: bash
         run: npm run test:coverage

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -1036,6 +1036,11 @@ async function main() {
       break;
     }
 
+    case 'git-context': {
+      workspace.cmdGitContext(cwd, raw);
+      break;
+    }
+
     case 'discover-test-command': {
       const result = commands.discoverTestCommand(cwd);
       coreOutput(result, raw);

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -1032,12 +1032,48 @@ async function main() {
     }
 
     case 'detect-workspace': {
+      // Support --field <name> --raw for scalar extraction
+      const dwFieldIdx = args.indexOf('--field');
+      const dwField = dwFieldIdx !== -1 ? args[dwFieldIdx + 1] : null;
+      if (dwField && raw) {
+        const dwResult = workspace.cmdDetectWorkspace(cwd, false, true);
+        if (dwResult && dwResult[dwField] !== undefined) {
+          process.stdout.write(String(dwResult[dwField]));
+        }
+        process.exit(0);
+      }
       workspace.cmdDetectWorkspace(cwd, raw);
       break;
     }
 
     case 'git-context': {
+      // Support --field <name> --raw for scalar extraction
+      const gcFieldIdx = args.indexOf('--field');
+      const gcField = gcFieldIdx !== -1 ? args[gcFieldIdx + 1] : null;
+      if (gcField && raw) {
+        const gcResult = workspace.cmdGitContext(cwd, false, true);
+        if (gcResult && gcResult[gcField] !== undefined) {
+          process.stdout.write(String(gcResult[gcField]));
+        }
+        process.exit(0);
+      }
       workspace.cmdGitContext(cwd, raw);
+      break;
+    }
+
+    case 'ssh-check': {
+      const sshUrl = args[1] && !args[1].startsWith('--') ? args[1] : '';
+      // Support --field <name> --raw for scalar extraction
+      const scFieldIdx = args.indexOf('--field');
+      const scField = scFieldIdx !== -1 ? args[scFieldIdx + 1] : null;
+      if (scField && raw) {
+        const scResult = workspace.cmdSshCheck(sshUrl, false, true);
+        if (scResult && scResult[scField] !== undefined) {
+          process.stdout.write(String(scResult[scField]));
+        }
+        process.exit(0);
+      }
+      workspace.cmdSshCheck(sshUrl, raw);
       break;
     }
 

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -87,7 +87,16 @@ function output(result, raw, rawValue) {
     // Write to tmpfile and output the path prefixed with @file: so callers can detect it.
     if (json.length > 50000) {
       reapStaleTempFiles();
-      const tmpPath = path.join(require('os').tmpdir(), `gsd-${Date.now()}.json`);
+      let tmpDir = require('os').tmpdir();
+      try {
+        fs.mkdirSync(tmpDir, { recursive: true });
+      } catch {
+        // os.tmpdir() directory may not be writable (e.g. sandbox sets TMPDIR=/tmp/claude
+        // but /tmp is restricted). Fall back to a known-writable sibling directory.
+        tmpDir = path.join(path.dirname(tmpDir), path.basename(tmpDir) + '-1000');
+        fs.mkdirSync(tmpDir, { recursive: true });
+      }
+      const tmpPath = path.join(tmpDir, `gsd-${Date.now()}.json`);
       fs.writeFileSync(tmpPath, json, 'utf-8');
       data = '@file:' + tmpPath;
     } else {

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -93,7 +93,8 @@ function output(result, raw, rawValue) {
       } catch {
         // os.tmpdir() directory may not be writable (e.g. sandbox sets TMPDIR=/tmp/claude
         // but /tmp is restricted). Fall back to a known-writable sibling directory.
-        tmpDir = path.join(path.dirname(tmpDir), path.basename(tmpDir) + '-1000');
+        const uid = typeof process.getuid === 'function' ? process.getuid() : 1000;
+        tmpDir = path.join(path.dirname(tmpDir), path.basename(tmpDir) + '-' + uid);
         fs.mkdirSync(tmpDir, { recursive: true });
       }
       const tmpPath = path.join(tmpDir, `gsd-${Date.now()}.json`);

--- a/gsd-ng/bin/lib/init.cjs
+++ b/gsd-ng/bin/lib/init.cjs
@@ -8,6 +8,7 @@ const { execSync } = require('child_process');
 const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone, normalizePhaseName, toPosixPath, output, error, planningPaths } = require('./core.cjs');
 const { validatePhaseNumber } = require('./security.cjs');
 const { adjustQuickTable } = require('./state.cjs');
+const { resolveGitContext } = require('./workspace.cjs');
 
 function cmdInitExecutePhase(cwd, phase, raw) {
   if (!phase) {
@@ -108,6 +109,30 @@ function cmdInitExecutePhase(cwd, phase, raw) {
     roadmap_path: '.planning/ROADMAP.md',
     config_path: '.planning/config.json',
   };
+
+  // Resolve submodule git context for workflows that need push/PR routing
+  let gitCtx = null;
+  try {
+    gitCtx = resolveGitContext(cwd);
+  } catch {
+    // If git-context resolution fails, leave fields null — workflows fall back to workspace-level config
+  }
+
+  if (gitCtx) {
+    result.submodule_is_active = gitCtx.is_submodule;
+    result.submodule_git_cwd = gitCtx.git_cwd;
+    result.submodule_remote = gitCtx.remote;
+    result.submodule_remote_url = gitCtx.remote_url;
+    result.submodule_target_branch = gitCtx.target_branch;
+    result.submodule_ambiguous = gitCtx.ambiguous;
+  } else {
+    result.submodule_is_active = false;
+    result.submodule_git_cwd = null;
+    result.submodule_remote = null;
+    result.submodule_remote_url = null;
+    result.submodule_target_branch = null;
+    result.submodule_ambiguous = false;
+  }
 
   output(result, raw);
 }

--- a/gsd-ng/bin/lib/workspace.cjs
+++ b/gsd-ng/bin/lib/workspace.cjs
@@ -311,6 +311,26 @@ function resolveGitContext(cwd) {
     };
   }
 
+  // Ambiguous: multiple submodules exist but none have changes — can't determine target
+  if (submodulePaths.length > 1 && hitPaths.length === 0) {
+    return {
+      is_submodule: true,
+      submodule_path: null,
+      git_cwd: null,
+      remote: null,
+      remote_url: null,
+      ssh_url: false,
+      target_branch: null,
+      current_branch: null,
+      ambiguous: true,
+      ambiguous_paths: submodulePaths,
+      platform: null,
+      cli: null,
+      cli_installed: false,
+      cli_install_url: null,
+    };
+  }
+
   // Resolve active submodule: matched submodule or fallback to first
   const activePath = hitPaths[0] || submodulePaths[0];
   const subCwd = path.join(cwd, activePath);
@@ -375,9 +395,11 @@ function resolveGitContext(cwd) {
  *
  * @param {string} cwd - Working directory
  * @param {boolean} raw - Whether to output raw value
+ * @param {boolean} silent - If true, return result without calling output()
  */
-function cmdDetectWorkspace(cwd, raw) {
+function cmdDetectWorkspace(cwd, raw, silent) {
   const result = detectWorkspaceType(cwd);
+  if (silent) return result;
   output(result, raw);
 }
 
@@ -386,9 +408,64 @@ function cmdDetectWorkspace(cwd, raw) {
  *
  * @param {string} cwd - Working directory
  * @param {boolean} raw - Whether to output raw value
+ * @param {boolean} silent - If true, return result without calling output()
  */
-function cmdGitContext(cwd, raw) {
+function cmdGitContext(cwd, raw, silent) {
   const result = resolveGitContext(cwd);
+  if (silent) return result;
+  output(result, raw);
+}
+
+/**
+ * Check SSH agent status for a given remote URL.
+ * Returns structured JSON with ssh_required, agent_running, status, message.
+ *
+ * @param {string} remoteUrl - The git remote URL to check
+ * @param {boolean} raw - Whether to output raw JSON
+ * @param {boolean} silent - If true, return result without output()/process.exit()
+ */
+function cmdSshCheck(remoteUrl, raw, silent) {
+  const sshRequired = !!(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
+
+  if (!sshRequired) {
+    const result = { ssh_required: false, agent_running: false, status: 'not_required', message: 'Remote does not use SSH' };
+    if (silent) return result;
+    output(result, raw);
+    return;
+  }
+
+  let agentRunning = false;
+  let status = 'agent_not_running';
+  let message = 'SSH agent is not running';
+
+  try {
+    const { execSync } = require('child_process');
+    execSync('ssh-add -l', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    // Exit code 0: identities loaded
+    agentRunning = true;
+    status = 'ok';
+    message = 'SSH agent has identities loaded';
+  } catch (err) {
+    if (err.status === 1) {
+      // Exit code 1: agent running but no identities
+      agentRunning = true;
+      status = 'no_identities';
+      message = 'SSH agent is running but no identities are loaded. Run: ssh-add';
+    } else {
+      // Exit code 2 or stderr contains agent socket error: agent not running
+      const stderr = (err.stderr || '').toString();
+      if (err.status === 2 || stderr.includes('Could not open') || stderr.includes('not open')) {
+        status = 'agent_not_running';
+        message = 'SSH agent is not running. Run: eval "$(ssh-agent -s)" && ssh-add';
+      } else {
+        status = 'agent_not_running';
+        message = 'SSH agent check failed: ' + (stderr || err.message);
+      }
+    }
+  }
+
+  const result = { ssh_required: true, agent_running: agentRunning, status, message };
+  if (silent) return result;
   output(result, raw);
 }
 
@@ -402,4 +479,5 @@ module.exports = {
   cmdDetectWorkspace,
   resolveGitContext,
   cmdGitContext,
+  cmdSshCheck,
 };

--- a/gsd-ng/bin/lib/workspace.cjs
+++ b/gsd-ng/bin/lib/workspace.cjs
@@ -4,8 +4,9 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error } = require('./core.cjs');
+const { output, error, execGit, loadConfig, planningPaths } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
+const { cmdDetectPlatform } = require('./commands.cjs');
 
 // ─── Workspace topology detection ────────────────────────────────────────────
 
@@ -226,7 +227,148 @@ function seedMemoryTemplate(templatePath, targetDir, filename) {
   }
 }
 
-// ─── CLI command ──────────────────────────────────────────────────────────────
+// ─── Git context resolution ───────────────────────────────────────────────────
+
+/**
+ * Resolve the git context for the current workspace. Handles standalone,
+ * submodule (single), and submodule (multiple / ambiguous) workspace types.
+ *
+ * Returns a resolved object with remote, branch, platform and routing metadata
+ * so git-touching workflows can operate on the correct repository.
+ *
+ * @param {string} cwd - Project root directory
+ * @returns {object} Resolved git context object
+ */
+function resolveGitContext(cwd) {
+  const { type, submodule_paths: submodulePaths } = detectWorkspaceType(cwd);
+
+  // ── Standalone workspace ───────────────────────────────────────────────────
+  if (type !== 'submodule' || submodulePaths.length === 0) {
+    const config = loadConfig(cwd);
+    const remote = config.remote || 'origin';
+    const targetBranch = config.target_branch || 'main';
+
+    const remoteResult = execGit(cwd, ['remote', 'get-url', remote]);
+    const remoteUrl = remoteResult.exitCode === 0 ? (remoteResult.stdout || null) : null;
+
+    const branchResult = execGit(cwd, ['branch', '--show-current']);
+    const currentBranch = branchResult.exitCode === 0 ? (branchResult.stdout || null) : null;
+
+    const sshUrl = Boolean(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
+
+    const platformInfo = cmdDetectPlatform(cwd, remote, null, true) || {};
+
+    return {
+      is_submodule: false,
+      submodule_path: null,
+      git_cwd: cwd,
+      remote,
+      remote_url: remoteUrl,
+      ssh_url: sshUrl,
+      target_branch: targetBranch,
+      current_branch: currentBranch,
+      ambiguous: false,
+      ambiguous_paths: [],
+      platform: platformInfo.platform || null,
+      cli: platformInfo.cli || null,
+      cli_installed: platformInfo.cli_installed || false,
+      cli_install_url: platformInfo.cli_install_url || null,
+    };
+  }
+
+  // ── Submodule workspace ────────────────────────────────────────────────────
+
+  // Detect which submodule(s) have changes in the workspace diff
+  const headDiff = execGit(cwd, ['diff', '--name-only', 'HEAD']);
+  const cachedDiff = execGit(cwd, ['diff', '--cached', '--name-only']);
+
+  const changedFiles = [
+    ...(headDiff.exitCode === 0 && headDiff.stdout ? headDiff.stdout.split('\n').filter(Boolean) : []),
+    ...(cachedDiff.exitCode === 0 && cachedDiff.stdout ? cachedDiff.stdout.split('\n').filter(Boolean) : []),
+  ];
+
+  const hitPaths = submodulePaths.filter(sp =>
+    changedFiles.some(f => f === sp || f.startsWith(sp + '/'))
+  );
+
+  // Ambiguous: multiple submodules have changes
+  if (hitPaths.length > 1) {
+    return {
+      is_submodule: true,
+      submodule_path: null,
+      git_cwd: null,
+      remote: null,
+      remote_url: null,
+      ssh_url: false,
+      target_branch: null,
+      current_branch: null,
+      ambiguous: true,
+      ambiguous_paths: hitPaths,
+      platform: null,
+      cli: null,
+      cli_installed: false,
+      cli_install_url: null,
+    };
+  }
+
+  // Resolve active submodule: matched submodule or fallback to first
+  const activePath = hitPaths[0] || submodulePaths[0];
+  const subCwd = path.join(cwd, activePath);
+
+  // Read submodule config overrides from .planning/config.json
+  let configSubmodule = {};
+  try {
+    const pp = planningPaths(cwd);
+    const rawConfig = fs.readFileSync(pp.config, 'utf-8');
+    const parsedConfig = JSON.parse(rawConfig);
+    configSubmodule = (parsedConfig.git && parsedConfig.git.submodule) || {};
+  } catch {
+    // No config or malformed — use defaults
+  }
+
+  const remote = configSubmodule.remote || 'origin';
+
+  const remoteResult = execGit(subCwd, ['remote', 'get-url', remote]);
+  const remoteUrl = remoteResult.exitCode === 0 ? (remoteResult.stdout || null) : null;
+
+  const branchResult = execGit(subCwd, ['branch', '--show-current']);
+  const currentBranch = branchResult.exitCode === 0 ? (branchResult.stdout || null) : null;
+
+  // Resolve target branch: config override > git tracking > fallback 'main'
+  let targetBranch = configSubmodule.target_branch || null;
+  if (!targetBranch && currentBranch) {
+    const mergeResult = execGit(subCwd, ['config', `branch.${currentBranch}.merge`]);
+    if (mergeResult.exitCode === 0 && mergeResult.stdout) {
+      targetBranch = mergeResult.stdout.replace(/^refs\/heads\//, '') || null;
+    }
+  }
+  if (!targetBranch) {
+    targetBranch = 'main';
+  }
+
+  const sshUrl = Boolean(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
+
+  const platformInfo = cmdDetectPlatform(subCwd, remote, null, true) || {};
+
+  return {
+    is_submodule: true,
+    submodule_path: activePath,
+    git_cwd: subCwd,
+    remote,
+    remote_url: remoteUrl,
+    ssh_url: sshUrl,
+    target_branch: targetBranch,
+    current_branch: currentBranch,
+    ambiguous: false,
+    ambiguous_paths: [],
+    platform: platformInfo.platform || null,
+    cli: platformInfo.cli || null,
+    cli_installed: platformInfo.cli_installed || false,
+    cli_install_url: platformInfo.cli_install_url || null,
+  };
+}
+
+// ─── CLI commands ─────────────────────────────────────────────────────────────
 
 /**
  * CLI wrapper for detectWorkspaceType. Outputs JSON via output().
@@ -239,6 +381,17 @@ function cmdDetectWorkspace(cwd, raw) {
   output(result, raw);
 }
 
+/**
+ * CLI wrapper for resolveGitContext. Outputs JSON via output().
+ *
+ * @param {string} cwd - Working directory
+ * @param {boolean} raw - Whether to output raw value
+ */
+function cmdGitContext(cwd, raw) {
+  const result = resolveGitContext(cwd);
+  output(result, raw);
+}
+
 // ─── Exports ──────────────────────────────────────────────────────────────────
 
 module.exports = {
@@ -247,4 +400,6 @@ module.exports = {
   generateMemoryMd,
   seedMemoryTemplate,
   cmdDetectWorkspace,
+  resolveGitContext,
+  cmdGitContext,
 };

--- a/gsd-ng/references/planning-config.md
+++ b/gsd-ng/references/planning-config.md
@@ -319,4 +319,26 @@ Snapshot builds append `+{short_hash}` (e.g., `1.2.3+abc1234`) per SemVer 2.0.0 
 
 </commit_format_config>
 
+<submodule_git_config>
+
+### Submodule-Aware Git Operations
+
+When the workspace contains git submodules (`.gitmodules` exists), GSD automatically routes git push, PR creation, and branch operations to the correct repository:
+
+1. **Auto-detection:** `git-context` inspects `git diff` to identify which submodule has changes
+2. **Remote resolution:** Uses the submodule's own `origin` remote, not the workspace remote
+3. **Target branch:** Reads from `git.submodule.target_branch` config, falls back to git tracking info, then `main`
+4. **Platform detection:** `git-context` includes `platform`, `cli`, `cli_installed` fields derived from the submodule's remote URL
+
+| Config Key | Default | Description |
+|------------|---------|-------------|
+| `git.submodule.target_branch` | (auto-detect) | Override the target branch for submodule PRs |
+| `git.submodule.remote` | `"origin"` | Override the remote name used for submodule git operations |
+
+**When to configure:** Set `git.submodule.target_branch` when the submodule's integration branch differs from what git tracking reports. Common case: submodule tracks `develop` but git reports `main`.
+
+**Multi-submodule workspaces:** If multiple submodules have uncommitted changes, GSD surfaces the ambiguity and asks the user to resolve before continuing with push or PR creation.
+
+</submodule_git_config>
+
 </planning_config>

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -31,8 +31,6 @@ if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 
 Extract from init JSON:
 - `BRANCHING_STRATEGY` ← `branching_strategy`
-- `TARGET_BRANCH` ← `target_branch`
-- `REMOTE` ← `remote`
 - `BRANCH_NAME` ← `branch_name` (GSD work branch)
 - `REVIEW_BRANCH_TEMPLATE` ← `review_branch_template`
 - `PR_DRAFT` ← `pr_draft`
@@ -40,6 +38,26 @@ Extract from init JSON:
 - `PHASE_NAME` ← `phase_name`
 - `PHASE_SLUG` ← `phase_slug`
 - `PHASE_DIR_NAME` ← basename of `phase_dir`
+
+Resolve submodule-aware git routing via git-context:
+
+```bash
+GIT_CTX=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context)
+if [[ "$GIT_CTX" == @file:* ]]; then GIT_CTX=$(cat "${GIT_CTX#@file:}"); fi
+GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.git_cwd||'.')}catch{process.stdout.write('.')}" "$GIT_CTX")
+PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.remote||'origin')}catch{process.stdout.write('origin')}" "$GIT_CTX")
+PUSH_TARGET=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.target_branch||'main')}catch{process.stdout.write('main')}" "$GIT_CTX")
+AMBIGUOUS=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ambiguous||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
+SSH_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ssh_url||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
+PLATFORM=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.platform||'')}catch{process.stdout.write('')}" "$GIT_CTX")
+CLI=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.cli||'')}catch{process.stdout.write('')}" "$GIT_CTX")
+CLI_INSTALLED=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.cli_installed||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
+CLI_INSTALL_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.cli_install_url||'')}catch{process.stdout.write('')}" "$GIT_CTX")
+```
+
+Use `$PUSH_REMOTE`, `$PUSH_TARGET`, and `$GIT_CWD` for all git and platform operations below instead of `$REMOTE` and `$TARGET_BRANCH`.
+
+**Ambiguous check:** If `$AMBIGUOUS` is `"true"`, tell the user: "Multiple submodules have changes. Cannot determine target repo for PR. Commit to only one submodule, or specify manually." Then stop — do not proceed with PR creation.
 
 Parse flags:
 - `--draft` / `--no-draft`: Override `pr_draft` config
@@ -65,44 +83,26 @@ fi
 </step>
 
 <step name="detect_platform">
-Detect the git hosting platform:
+Platform, CLI, and CLI availability are already extracted from git-context output above (`$PLATFORM`, `$CLI`, `$CLI_INSTALLED`, `$CLI_INSTALL_URL`). No separate detect-platform call is needed.
 
-```bash
-PLATFORM=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform "$REMOTE" --field platform --raw 2>/dev/null || echo "")
-CLI=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform "$REMOTE" --field cli --raw 2>/dev/null || echo "")
-CLI_INSTALLED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform "$REMOTE" --field cli_installed --raw 2>/dev/null || echo "false")
-PLATFORM_SOURCE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform "$REMOTE" --field source --raw 2>/dev/null || echo "unknown")
-CLI_INSTALL_URL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform "$REMOTE" --field cli_install_url --raw 2>/dev/null || echo "")
-```
+**If `$PLATFORM` is empty:**
 
-**If platform is null (unknown):**
-```
-Warning: Could not detect git hosting platform from remote URL.
-Set platform manually: node gsd-tools.cjs config-set git.platform github
-Supported values: github, gitlab, forgejo, gitea
-PR creation disabled for this session. Push features still work.
-```
-STOP — return without creating PR.
+Warn the user: "Could not detect git hosting platform from remote URL. Set platform manually: `node gsd-tools.cjs config-set git.platform github`. Supported: github, gitlab, forgejo, gitea." Stop — return without creating PR.
 
-**If CLI not installed:**
-```
-Warning: {cli} CLI not found. Install from {cli_install_url} to enable PR creation.
-Push-only features still work. PR creation disabled for this session.
+**If `$CLI_INSTALLED` is `"false"`:**
 
-Do NOT use raw API calls as a workaround — install the CLI tool.
-```
-STOP — return without creating PR. Do NOT fall back to curl/API.
+Warn the user: "{CLI} CLI not found. Install from {CLI_INSTALL_URL} to enable PR creation. Do NOT use raw API calls as a workaround — install the CLI tool." Stop — return without creating PR.
 </step>
 
 <step name="validate_target_branch">
 Verify the target branch exists on the remote before attempting PR creation:
 
 ```bash
-if ! git ls-remote --heads "$REMOTE" "$TARGET_BRANCH" | grep -q "$TARGET_BRANCH"; then
-  echo "Error: Target branch '$TARGET_BRANCH' not found on remote '$REMOTE'."
+if ! git -C "$GIT_CWD" ls-remote --heads "$PUSH_REMOTE" "$PUSH_TARGET" | grep -q "$PUSH_TARGET"; then
+  echo "Error: Target branch '$PUSH_TARGET' not found on remote '$PUSH_REMOTE'."
   echo "Available branches:"
-  git ls-remote --heads "$REMOTE" | head -10
-  echo "Set target branch: node gsd-tools.cjs config-set git.target_branch {branch}"
+  git -C "$GIT_CWD" ls-remote --heads "$PUSH_REMOTE" | head -10
+  echo "Set target branch: node gsd-tools.cjs config-set git.submodule.target_branch {branch}"
   exit 1
 fi
 ```
@@ -117,14 +117,14 @@ No review branch, no squash. Open PR directly from current branch.
 
 ```bash
 if [ "$BRANCHING_STRATEGY" = "none" ]; then
-  CURRENT_BRANCH=$(git branch --show-current)
+  CURRENT_BRANCH=$(git -C "$GIT_CWD" branch --show-current)
   HEAD_BRANCH="$CURRENT_BRANCH"
   # Skip to build_pr_description — no review branch needed
 fi
 ```
 
 For none strategy: skip `determine_type`, `create_review_branch`, and `push_review_branch` steps.
-Skip to `build_pr_description` step. The PR will be opened from the current branch against `target_branch`.
+Skip to `build_pr_description` step. The PR will be opened from the current branch against `$PUSH_TARGET`.
 </step>
 
 <step name="determine_type">
@@ -172,24 +172,24 @@ REVIEW_BRANCH=$(echo "$REVIEW_BRANCH_TEMPLATE" | \
 
 Save the current work branch for later:
 ```bash
-CURRENT_BRANCH=$(git branch --show-current)
+CURRENT_BRANCH=$(git -C "$GIT_CWD" branch --show-current)
 ```
 
 Create or reset review branch from target_branch:
 ```bash
-if git show-ref --verify --quiet "refs/heads/$REVIEW_BRANCH" 2>/dev/null; then
+if git -C "$GIT_CWD" show-ref --verify --quiet "refs/heads/$REVIEW_BRANCH" 2>/dev/null; then
   # Review branch exists — this is an update (re-squash)
-  git checkout "$REVIEW_BRANCH"
-  git reset --hard "$TARGET_BRANCH"
+  git -C "$GIT_CWD" checkout "$REVIEW_BRANCH"
+  git -C "$GIT_CWD" reset --hard "$PUSH_TARGET"
 else
-  git checkout -b "$REVIEW_BRANCH" "$TARGET_BRANCH"
+  git -C "$GIT_CWD" checkout -b "$REVIEW_BRANCH" "$PUSH_TARGET"
 fi
 ```
 
 Squash work branch onto review branch:
 ```bash
 # Single squash of all work from the GSD work branch
-git merge --squash "$CURRENT_BRANCH" 2>&1
+git -C "$GIT_CWD" merge --squash "$CURRENT_BRANCH" 2>&1
 
 # Build squash commit message from plan summaries
 SQUASH_MSG=""
@@ -205,7 +205,7 @@ if [ -z "$SQUASH_MSG" ]; then
   SQUASH_MSG="Phase ${PHASE_NUMBER}: ${PHASE_NAME}"
 fi
 
-git commit -m "$(printf "feat: Phase ${PHASE_NUMBER} - ${PHASE_NAME}\n\n${SQUASH_MSG}")"
+git -C "$GIT_CWD" commit -m "$(printf "feat: Phase ${PHASE_NUMBER} - ${PHASE_NAME}\n\n${SQUASH_MSG}")"
 ```
 
 Set HEAD_BRANCH for PR creation:
@@ -220,14 +220,14 @@ Push the review branch (or current branch for none strategy) to remote:
 ```bash
 # For review branches, use --force-with-lease (squash rewrites history)
 if [ "$BRANCHING_STRATEGY" != "none" ]; then
-  PUSH_OUT=$(git push --force-with-lease -u "$REMOTE" "$HEAD_BRANCH" 2>&1)
+  PUSH_OUT=$(git -C "$GIT_CWD" push --force-with-lease -u "$PUSH_REMOTE" "$HEAD_BRANCH" 2>&1)
 else
-  # For none strategy, regular push
-  UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
+  # For none strategy, regular push with upstream tracking (safe to use -u unconditionally)
+  UPSTREAM=$(git -C "$GIT_CWD" rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
   if [ -n "$UPSTREAM" ]; then
-    PUSH_OUT=$(git push "$REMOTE" "$HEAD_BRANCH" 2>&1)
+    PUSH_OUT=$(git -C "$GIT_CWD" push "$PUSH_REMOTE" "$HEAD_BRANCH" 2>&1)
   else
-    PUSH_OUT=$(git push -u "$REMOTE" "$HEAD_BRANCH" 2>&1)
+    PUSH_OUT=$(git -C "$GIT_CWD" push -u "$PUSH_REMOTE" "$HEAD_BRANCH" 2>&1)
   fi
 fi
 PUSH_EXIT=$?
@@ -236,7 +236,7 @@ if [ $PUSH_EXIT -ne 0 ]; then
   echo "Error: Push failed — $PUSH_OUT"
   echo "Fix the issue and retry: /gsd:create-pr ${PHASE_ARG}"
   # Return to work branch before exiting
-  git checkout "$CURRENT_BRANCH" 2>/dev/null
+  git -C "$GIT_CWD" checkout "$CURRENT_BRANCH" 2>/dev/null || true
   exit 1
 fi
 ```
@@ -246,7 +246,7 @@ STOP on push failure — cannot create PR without pushed branch.
 Return to work branch after push (for phase/milestone strategies):
 ```bash
 if [ "$BRANCHING_STRATEGY" != "none" ]; then
-  git checkout "$CURRENT_BRANCH" 2>/dev/null || true
+  git -C "$GIT_CWD" checkout "$CURRENT_BRANCH" 2>/dev/null || true
 fi
 ```
 </step>
@@ -378,7 +378,7 @@ fi
 case "$PLATFORM" in
   github)
     PR_URL=$(gh pr create \
-      --base "$TARGET_BRANCH" \
+      --base "$PUSH_TARGET" \
       --head "$HEAD_BRANCH" \
       --title "$PR_TITLE" \
       --body-file "$PR_BODY_FILE" \
@@ -388,7 +388,7 @@ case "$PLATFORM" in
 
   gitlab)
     PR_URL=$(glab mr create \
-      --target-branch "$TARGET_BRANCH" \
+      --target-branch "$PUSH_TARGET" \
       --source-branch "$HEAD_BRANCH" \
       --title "$PR_TITLE" \
       --description "$(cat "$PR_BODY_FILE")" \
@@ -398,7 +398,7 @@ case "$PLATFORM" in
 
   forgejo)
     PR_URL=$(fj pr create \
-      --base "$TARGET_BRANCH" \
+      --base "$PUSH_TARGET" \
       --head "$HEAD_BRANCH" \
       --title "$PR_TITLE" \
       --body "$(cat "$PR_BODY_FILE")" 2>&1)
@@ -407,7 +407,7 @@ case "$PLATFORM" in
 
   gitea)
     PR_URL=$(tea pr create \
-      --base "$TARGET_BRANCH" \
+      --base "$PUSH_TARGET" \
       --head "$HEAD_BRANCH" \
       --title "$PR_TITLE" \
       --description "$(cat "$PR_BODY_FILE")" 2>&1)
@@ -436,7 +436,7 @@ else
   echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
   echo ""
   echo "  Phase:  ${PHASE_NUMBER} - ${PHASE_NAME}"
-  echo "  Branch: ${HEAD_BRANCH} -> ${TARGET_BRANCH}"
+  echo "  Branch: ${HEAD_BRANCH} -> ${PUSH_TARGET}"
   echo "  Draft:  ${PR_DRAFT}"
   echo "  URL:    ${PR_URL}"
   echo ""

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -39,20 +39,22 @@ Extract from init JSON:
 - `PHASE_SLUG` ← `phase_slug`
 - `PHASE_DIR_NAME` ← basename of `phase_dir`
 
-Resolve submodule-aware git routing via git-context:
+Resolve submodule-aware git routing from $INIT (already loaded with @file: handling above):
 
 ```bash
-GIT_CTX=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context)
-if [[ "$GIT_CTX" == @file:* ]]; then GIT_CTX=$(cat "${GIT_CTX#@file:}"); fi
-GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.git_cwd||'.')}catch{process.stdout.write('.')}" "$GIT_CTX")
-PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.remote||'origin')}catch{process.stdout.write('origin')}" "$GIT_CTX")
-PUSH_TARGET=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.target_branch||'main')}catch{process.stdout.write('main')}" "$GIT_CTX")
-AMBIGUOUS=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ambiguous||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
-SSH_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ssh_url||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
-PLATFORM=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.platform||'')}catch{process.stdout.write('')}" "$GIT_CTX")
-CLI=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.cli||'')}catch{process.stdout.write('')}" "$GIT_CTX")
-CLI_INSTALLED=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.cli_installed||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
-CLI_INSTALL_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.cli_install_url||'')}catch{process.stdout.write('')}" "$GIT_CTX")
+# Read submodule fields from $INIT (already loaded with @file: handling above)
+IS_SUBMODULE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.submodule_is_active||false))}catch{process.stdout.write('false')}" "$INIT")
+GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_git_cwd||'.')}catch{process.stdout.write('.')}" "$INIT")
+PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_remote||'origin')}catch{process.stdout.write('origin')}" "$INIT")
+PUSH_TARGET=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_target_branch||'main')}catch{process.stdout.write('main')}" "$INIT")
+AMBIGUOUS=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.submodule_ambiguous||false))}catch{process.stdout.write('false')}" "$INIT")
+SUBMODULE_REMOTE_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_remote_url||'')}catch{process.stdout.write('')}" "$INIT")
+
+# Platform/CLI fields from detect-platform (per user decision: stays separate from init)
+PLATFORM=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field platform --raw)
+CLI=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli --raw)
+CLI_INSTALLED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli_installed --raw)
+CLI_INSTALL_URL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli_install_url --raw)
 ```
 
 Use `$PUSH_REMOTE`, `$PUSH_TARGET`, and `$GIT_CWD` for all git and platform operations below instead of `$REMOTE` and `$TARGET_BRANCH`.
@@ -83,7 +85,7 @@ fi
 </step>
 
 <step name="detect_platform">
-Platform, CLI, and CLI availability are already extracted from git-context output above (`$PLATFORM`, `$CLI`, `$CLI_INSTALLED`, `$CLI_INSTALL_URL`). No separate detect-platform call is needed.
+Platform, CLI, and CLI availability are already extracted from the detect-platform calls above (`$PLATFORM`, `$CLI`, `$CLI_INSTALLED`, `$CLI_INSTALL_URL`). No additional call is needed.
 
 **If `$PLATFORM` is empty:**
 
@@ -102,7 +104,11 @@ if ! git -C "$GIT_CWD" ls-remote --heads "$PUSH_REMOTE" "$PUSH_TARGET" | grep -q
   echo "Error: Target branch '$PUSH_TARGET' not found on remote '$PUSH_REMOTE'."
   echo "Available branches:"
   git -C "$GIT_CWD" ls-remote --heads "$PUSH_REMOTE" | head -10
-  echo "Set target branch: node gsd-tools.cjs config-set git.submodule.target_branch {branch}"
+  if [ "$IS_SUBMODULE" = "true" ]; then
+    echo "Set target branch: node gsd-tools.cjs config-set git.submodule.target_branch {branch}"
+  else
+    echo "Set target branch: node gsd-tools.cjs config-set git.target_branch {branch}"
+  fi
   exit 1
 fi
 ```

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -336,54 +336,43 @@ After all waves:
 
 **Post-phase push (when configured):**
 
-Read from init JSON: `auto_push`, `remote`, `branch_name`, `branching_strategy`.
+Read from init JSON: `auto_push`, `branch_name`, `branching_strategy`.
 
 ```bash
 # Only push if auto_push is enabled and we're on a GSD-managed branch
 if [ "$AUTO_PUSH" = "true" ] && [ "$BRANCHING_STRATEGY" != "none" ] && [ -n "$BRANCH_NAME" ]; then
 
-  # SSH pre-push check (git.ssh_check defaults to true)
+  # Resolve submodule-aware git routing
+  GIT_CTX=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context)
+  if [[ "$GIT_CTX" == @file:* ]]; then GIT_CTX=$(cat "${GIT_CTX#@file:}"); fi
+  GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.git_cwd||'.')}catch{process.stdout.write('.')}" "$GIT_CTX")
+  PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.remote||'origin')}catch{process.stdout.write('origin')}" "$GIT_CTX")
+  AMBIGUOUS=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ambiguous||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
+  SSH_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ssh_url||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
+```
+
+**Ambiguous check:** If `$AMBIGUOUS` is `"true"`, warn the user that multiple submodules have changes — extract `ambiguous_paths` from `$GIT_CTX` and list them. Skip the push. Do not proceed.
+
+**SSH pre-push check:** Read SSH check setting:
+
+```bash
   SSH_CHECK=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.ssh_check --raw 2>/dev/null || echo "true")
-  if [ "$SSH_CHECK" = "true" ]; then
-    REMOTE_URL=$(git remote get-url "${REMOTE:-origin}" 2>/dev/null || echo "")
-    if echo "$REMOTE_URL" | grep -qE '^git@|^ssh://'; then
-      SSH_STATUS=$(ssh-add -l 2>&1); SSH_EXIT=$?
-      if [ $SSH_EXIT -ne 0 ] || echo "$SSH_STATUS" | grep -q "no identities"; then
-        echo ""
-        echo "WARNING: SSH agent has no identities loaded. Git push will likely fail."
-        echo "Run in your terminal: ssh-add ~/.ssh/id_ed25519"
-        echo "(or the path to your SSH key)"
-        echo ""
-        echo "After loading your key, press Enter to retry push, or type 'skip' to skip push."
-        # Note: In Claude Code Bash tool, read may not block — the warning itself is the value.
-        # The push will proceed and fail with a clear error message if key is still not loaded.
-      fi
-      # Check SSH signing key requirement
-      SIGN_FORMAT=$(git config gpg.format 2>/dev/null || echo "")
-      if [ "$SIGN_FORMAT" = "ssh" ] && [ $SSH_EXIT -ne 0 ]; then
-        echo "Note: SSH-signed commits also require the signing key loaded in ssh-agent."
-      fi
-    fi
-  fi
+```
 
-  echo "Pushing $BRANCH_NAME to $REMOTE..."
+If `$SSH_CHECK` is `"true"` and `$SSH_URL` is `"true"`, check SSH agent status with `ssh-add -l`. If no identities are loaded, warn the user to load their SSH key before pushing. Also check if `gpg.format` is `ssh` via `git -C "$GIT_CWD" config gpg.format` — if so, note that the signing key also needs to be loaded.
 
-  # Check if branch already has upstream tracking
-  UPSTREAM=$(git rev-parse --abbrev-ref --symbolic-full-name "@{u}" 2>/dev/null || echo "")
-  if [ -n "$UPSTREAM" ]; then
-    PUSH_OUT=$(git push "$REMOTE" "$BRANCH_NAME" 2>&1)
-    PUSH_EXIT=$?
-  else
-    # First push — set upstream tracking
-    PUSH_OUT=$(git push -u "$REMOTE" "$BRANCH_NAME" 2>&1)
-    PUSH_EXIT=$?
-  fi
+```bash
+  echo "Pushing $BRANCH_NAME to $PUSH_REMOTE..."
+
+  # Push with upstream tracking (safe to use -u unconditionally — git ignores it when upstream exists)
+  PUSH_OUT=$(git -C "$GIT_CWD" push -u "$PUSH_REMOTE" "$BRANCH_NAME" 2>&1)
+  PUSH_EXIT=$?
 
   if [ $PUSH_EXIT -ne 0 ]; then
-    echo "Warning: Push to $REMOTE failed: $PUSH_OUT"
-    echo "Local commits are safe. Push manually: git push -u $REMOTE $BRANCH_NAME"
+    echo "Warning: Push to $PUSH_REMOTE failed: $PUSH_OUT"
+    echo "Local commits are safe. Push manually: git -C \"$GIT_CWD\" push -u $PUSH_REMOTE $BRANCH_NAME"
   else
-    echo "Pushed $BRANCH_NAME to $REMOTE"
+    echo "Pushed $BRANCH_NAME to $PUSH_REMOTE"
   fi
 fi
 ```

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -162,8 +162,8 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
    Resolve workspace topology for agent context injection:
    ```bash
+   WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type --raw 2>/dev/null || echo "standalone")
    WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
-   WORKSPACE_TYPE=$(node -e "try{const w=JSON.parse(process.argv[1]);process.stdout.write(w.type||'standalone')}catch{process.stdout.write('standalone')}" "$WORKSPACE_JSON")
    SUBMODULE_PATHS=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p.join(', ')||'none')}catch{process.stdout.write('none')}" "$WORKSPACE_JSON")
    PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
    ```
@@ -342,24 +342,32 @@ Read from init JSON: `auto_push`, `branch_name`, `branching_strategy`.
 # Only push if auto_push is enabled and we're on a GSD-managed branch
 if [ "$AUTO_PUSH" = "true" ] && [ "$BRANCHING_STRATEGY" != "none" ] && [ -n "$BRANCH_NAME" ]; then
 
-  # Resolve submodule-aware git routing
-  GIT_CTX=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context)
-  if [[ "$GIT_CTX" == @file:* ]]; then GIT_CTX=$(cat "${GIT_CTX#@file:}"); fi
-  GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.git_cwd||'.')}catch{process.stdout.write('.')}" "$GIT_CTX")
-  PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.remote||'origin')}catch{process.stdout.write('origin')}" "$GIT_CTX")
-  AMBIGUOUS=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ambiguous||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
-  SSH_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.ssh_url||false))}catch{process.stdout.write('false')}" "$GIT_CTX")
+  # Read submodule fields from $INIT (already loaded with @file: handling)
+  GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_git_cwd||'.')}catch{process.stdout.write('.')}" "$INIT")
+  PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_remote||'origin')}catch{process.stdout.write('origin')}" "$INIT")
+  AMBIGUOUS=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.submodule_ambiguous||false))}catch{process.stdout.write('false')}" "$INIT")
+  SUBMODULE_REMOTE_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_remote_url||'')}catch{process.stdout.write('')}" "$INIT")
 ```
 
-**Ambiguous check:** If `$AMBIGUOUS` is `"true"`, warn the user that multiple submodules have changes — extract `ambiguous_paths` from `$GIT_CTX` and list them. Skip the push. Do not proceed.
+**Ambiguous check:** If `$AMBIGUOUS` is `"true"`, warn the user that multiple submodules have changes — extract `ambiguous_paths` from `$INIT` and list them. Skip the push. Do not proceed.
 
-**SSH pre-push check:** Read SSH check setting:
+**SSH pre-push check:**
 
 ```bash
   SSH_CHECK=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.ssh_check --raw 2>/dev/null || echo "true")
+  if [ "$SSH_CHECK" = "true" ] && [ -n "$SUBMODULE_REMOTE_URL" ]; then
+    SSH_STATUS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" ssh-check "$SUBMODULE_REMOTE_URL" --field status --raw)
+    if [ "$SSH_STATUS" != "ok" ] && [ "$SSH_STATUS" != "not_required" ]; then
+      SSH_MSG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" ssh-check "$SUBMODULE_REMOTE_URL" --field message --raw)
+      echo "WARNING: SSH check failed — $SSH_MSG"
+      # Also check for SSH signing
+      GPG_FORMAT=$(git -C "$GIT_CWD" config gpg.format 2>/dev/null || echo "")
+      if [ "$GPG_FORMAT" = "ssh" ]; then
+        echo "NOTE: gpg.format=ssh detected — your signing key also needs to be loaded in the SSH agent."
+      fi
+    fi
+  fi
 ```
-
-If `$SSH_CHECK` is `"true"` and `$SSH_URL` is `"true"`, check SSH agent status with `ssh-add -l`. If no identities are loaded, warn the user to load their SSH key before pushing. Also check if `gpg.format` is `ssh` via `git -C "$GIT_CWD" config gpg.format` — if so, note that the signing key also needs to be loaded.
 
 ```bash
   echo "Pushing $BRANCH_NAME to $PUSH_REMOTE..."

--- a/gsd-ng/workflows/quick.md
+++ b/gsd-ng/workflows/quick.md
@@ -566,8 +566,8 @@ Offer: 1) Force proceed, 2) Abort
 Spawn gsd-executor with plan reference:
 
 ```bash
+WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type --raw 2>/dev/null || echo "standalone")
 WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
-WORKSPACE_TYPE=$(node -e "try{const w=JSON.parse(process.argv[1]);process.stdout.write(w.type||'standalone')}catch{process.stdout.write('standalone')}" "$WORKSPACE_JSON")
 SUBMODULE_PATHS=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p.join(', ')||'none')}catch{process.stdout.write('none')}" "$WORKSPACE_JSON")
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 ```

--- a/gsd-ng/workflows/squash.md
+++ b/gsd-ng/workflows/squash.md
@@ -128,9 +128,12 @@ Push squashed branch with --force-with-lease?
 
 If yes:
 ```bash
-REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.remote --raw 2>/dev/null || echo "origin")
-BRANCH=$(git branch --show-current)
-git push --force-with-lease "$REMOTE" "$BRANCH"
+GIT_CTX=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context)
+if [[ "$GIT_CTX" == @file:* ]]; then GIT_CTX=$(cat "${GIT_CTX#@file:}"); fi
+GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.git_cwd||'.')}catch{process.stdout.write('.')}" "$GIT_CTX")
+PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.remote||'origin')}catch{process.stdout.write('origin')}" "$GIT_CTX")
+BRANCH=$(git -C "$GIT_CWD" branch --show-current)
+git -C "$GIT_CWD" push --force-with-lease "$PUSH_REMOTE" "$BRANCH"
 ```
 </step>
 

--- a/gsd-ng/workflows/squash.md
+++ b/gsd-ng/workflows/squash.md
@@ -128,10 +128,8 @@ Push squashed branch with --force-with-lease?
 
 If yes:
 ```bash
-GIT_CTX=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context)
-if [[ "$GIT_CTX" == @file:* ]]; then GIT_CTX=$(cat "${GIT_CTX#@file:}"); fi
-GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.git_cwd||'.')}catch{process.stdout.write('.')}" "$GIT_CTX")
-PUSH_REMOTE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.remote||'origin')}catch{process.stdout.write('origin')}" "$GIT_CTX")
+GIT_CWD=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context --field git_cwd --raw 2>/dev/null || echo ".")
+PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context --field remote --raw 2>/dev/null || echo "origin")
 BRANCH=$(git -C "$GIT_CWD" branch --show-current)
 git -C "$GIT_CWD" push --force-with-lease "$PUSH_REMOTE" "$BRANCH"
 ```

--- a/gsd-ng/workflows/validate-phase.md
+++ b/gsd-ng/workflows/validate-phase.md
@@ -114,8 +114,8 @@ Call AskUserQuestion with gap table and options:
 ## 5. Spawn gsd-nyquist-auditor
 
 ```bash
+WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type --raw 2>/dev/null || echo "standalone")
 WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
-WORKSPACE_TYPE=$(node -e "try{const w=JSON.parse(process.argv[1]);process.stdout.write(w.type||'standalone')}catch{process.stdout.write('standalone')}" "$WORKSPACE_JSON")
 SUBMODULE_PATHS=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p.join(', ')||'none')}catch{process.stdout.write('none')}" "$WORKSPACE_JSON")
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 ```

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "prepublishOnly": "npm run build:hooks",
     "pretest": "npm run build:hooks",
     "test": "node scripts/run-tests.cjs",
-    "test:coverage": "c8 --check-coverage --lines 70 --reporter text --include 'gsd-ng/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs"
+    "test:coverage": "npm run build:hooks && c8 --check-coverage --lines 70 --reporter text --include 'gsd-ng/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "build:hooks": "node scripts/build-hooks.js",
     "build:tarball": "npm run build:hooks && node scripts/build-tarball.js",
     "prepublishOnly": "npm run build:hooks",
+    "pretest": "npm run build:hooks",
     "test": "node scripts/run-tests.cjs",
     "test:coverage": "c8 --check-coverage --lines 70 --reporter text --include 'gsd-ng/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs"
   }

--- a/tests/helpers.cjs
+++ b/tests/helpers.cjs
@@ -88,4 +88,107 @@ function cleanup(tmpDir) {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 }
 
-module.exports = { runGsdTools, createTempProject, createTempGitProject, cleanup, resolveTmpDir, TOOLS_PATH };
+/**
+ * Create a submodule workspace with one or more submodule repos.
+ *
+ * Each submodule directory is initialized as its own git repo AND
+ * registered as a gitlink in the workspace index (simulating `git submodule add`
+ * without requiring a real accessible remote).
+ *
+ * @param {Array<{name: string, path: string, remoteUrl: string}>} submoduleDefs - Submodule definitions
+ * @param {object} opts - Optional scaffolding
+ * @param {boolean} opts.roadmap - If true, seed .planning/ROADMAP.md with minimal phase content
+ * @param {boolean} opts.state - If true, seed .planning/STATE.md with minimal content
+ * @param {string} opts.phaseDir - If provided, create this phase directory under .planning/phases/
+ * @returns {{ workspaceDir: string, subDirs: string[] }}
+ */
+function createSubmoduleWorkspace(submoduleDefs, opts = {}) {
+  // submoduleDefs = [{ name, path, remoteUrl }]
+  const workspaceDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-ws-test-'));
+  fs.mkdirSync(path.join(workspaceDir, '.planning', 'phases'), { recursive: true });
+  execSync('git init', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git config commit.gpgsign false', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git remote add origin "https://github.com/workspace/root.git"', { cwd: workspaceDir, stdio: 'pipe' });
+
+  // Build .gitmodules content
+  let gitmodulesContent = '';
+  const subDirs = [];
+
+  for (const def of submoduleDefs) {
+    const subDir = path.join(workspaceDir, def.path);
+    fs.mkdirSync(subDir, { recursive: true });
+
+    // Init submodule repo
+    execSync('git init', { cwd: subDir, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: subDir, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: subDir, stdio: 'pipe' });
+    execSync('git config commit.gpgsign false', { cwd: subDir, stdio: 'pipe' });
+    execSync(`git remote add origin "${def.remoteUrl}"`, { cwd: subDir, stdio: 'pipe' });
+    fs.writeFileSync(path.join(subDir, 'README.md'), `# ${def.name}\n`);
+    execSync('git add README.md', { cwd: subDir, stdio: 'pipe' });
+    execSync('git commit -m "initial"', { cwd: subDir, stdio: 'pipe' });
+
+    // Register the submodule as a gitlink in the workspace index.
+    // This uses `git update-index --add --cacheinfo 160000,<sha>,<path>` to
+    // create a gitlink (mode 160000) pointing to the submodule's HEAD commit.
+    const subHeadResult = execSync('git rev-parse HEAD', { cwd: subDir, encoding: 'utf-8', stdio: 'pipe' }).trim();
+    execSync(
+      `git update-index --add --cacheinfo 160000,${subHeadResult},${def.path}`,
+      { cwd: workspaceDir, stdio: 'pipe' }
+    );
+
+    gitmodulesContent += `[submodule "${def.name}"]\n\tpath = ${def.path}\n\turl = ${def.remoteUrl}\n`;
+    subDirs.push(subDir);
+  }
+
+  fs.writeFileSync(path.join(workspaceDir, '.gitmodules'), gitmodulesContent);
+  execSync('git add .gitmodules', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git commit -m "add submodules"', { cwd: workspaceDir, stdio: 'pipe' });
+
+  // Optional scaffolding for init tests
+  if (opts.roadmap) {
+    fs.writeFileSync(
+      path.join(workspaceDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase Details\n\n### Phase 1: Test\n**Goal:** Test phase\n**Requirements:** none\n**Depends on:** nothing\n**Plans:** 1 plans\n\nPlans:\n- [ ] 01-01-PLAN.md\n'
+    );
+  }
+  if (opts.state) {
+    fs.writeFileSync(
+      path.join(workspaceDir, '.planning', 'STATE.md'),
+      '---\ngsd_state_version: 1.0\nmilestone: test\ncurrent_phase: 1\ncurrent_plan: Not started\nstatus: testing\n---\n\n# Project State\n'
+    );
+  }
+  if (opts.phaseDir) {
+    const pDir = path.join(workspaceDir, '.planning', 'phases', opts.phaseDir);
+    fs.mkdirSync(pDir, { recursive: true });
+    fs.writeFileSync(path.join(pDir, '01-01-PLAN.md'), '---\nphase: 01-test\nplan: 01\ntype: execute\nwave: 1\ndepends_on: []\nfiles_modified: []\nautonomous: true\nrequirements: []\nmust_haves:\n  truths: []\n  artifacts: []\n  key_links: []\n---\n\n<objective>Test</objective>\n');
+  }
+
+  return { workspaceDir, subDirs };
+}
+
+/**
+ * Simulate a submodule update in the workspace git (advances the gitlink).
+ * Creates a new commit in the submodule and updates the workspace gitlink,
+ * making the submodule path appear in `git diff --name-only HEAD`.
+ *
+ * @param {string} workspaceDir - Root workspace directory
+ * @param {string} submodulePath - Relative path to the submodule within workspace
+ */
+function touchSubmodule(workspaceDir, submodulePath) {
+  const subDir = path.join(workspaceDir, submodulePath);
+  // Create a new commit in the submodule to advance its HEAD
+  fs.writeFileSync(path.join(subDir, 'touched.txt'), String(Date.now()));
+  execSync('git add touched.txt', { cwd: subDir, stdio: 'pipe' });
+  execSync('git commit -m "touched"', { cwd: subDir, stdio: 'pipe' });
+  // Update the workspace gitlink to point to the new commit (staged, not committed)
+  const newSha = execSync('git rev-parse HEAD', { cwd: subDir, encoding: 'utf-8', stdio: 'pipe' }).trim();
+  execSync(
+    `git update-index --cacheinfo 160000,${newSha},${submodulePath}`,
+    { cwd: workspaceDir, stdio: 'pipe' }
+  );
+}
+
+module.exports = { runGsdTools, createTempProject, createTempGitProject, cleanup, resolveTmpDir, TOOLS_PATH, createSubmoduleWorkspace, touchSubmodule };

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -1078,24 +1078,38 @@ describe('init phase-op validates phase number (SEC-02)', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('init execute-phase submodule fields', () => {
+  const { createSubmoduleWorkspace } = require('./helpers.cjs');
+  const cleanupDir = (dir) => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} };
+
   // Test via CLI since cmdInitExecutePhase calls output() -> process.exit()
   test('init execute-phase output includes submodule fields', () => {
-    // Use the actual workspace as test target — it has real .planning/ and .gitmodules
-    // gsd-ng/tests/ -> gsd-ng/ -> workspace root
-    const workspaceRoot = path.join(__dirname, '..', '..');
-    const result = runGsdTools(['init', 'execute-phase', '41'], workspaceRoot);
-    assert.ok(result.success, `init should succeed: ${result.error}`);
-    const parsed = JSON.parse(result.output);
-    // Must have submodule fields
-    assert.ok('submodule_is_active' in parsed, 'missing submodule_is_active field');
-    assert.ok('submodule_git_cwd' in parsed, 'missing submodule_git_cwd field');
-    assert.ok('submodule_remote' in parsed, 'missing submodule_remote field');
-    assert.ok('submodule_remote_url' in parsed, 'missing submodule_remote_url field');
-    assert.ok('submodule_target_branch' in parsed, 'missing submodule_target_branch field');
-    assert.ok('submodule_ambiguous' in parsed, 'missing submodule_ambiguous field');
-    // This workspace IS a submodule workspace
-    assert.strictEqual(parsed.submodule_is_active, true);
-    assert.ok(parsed.submodule_git_cwd && parsed.submodule_git_cwd.endsWith('gsd-ng'), `git_cwd should end with gsd-ng, got: ${parsed.submodule_git_cwd}`);
+    // Use isolated temp submodule workspace — no dependency on real workspace or phase numbers
+    const { workspaceDir } = createSubmoduleWorkspace([
+      { name: 'mylib', path: 'mylib', remoteUrl: 'https://github.com/user/mylib.git' },
+    ], { roadmap: true, state: true, phaseDir: '01-test' });
+    try {
+      const result = runGsdTools(['init', 'execute-phase', '1'], workspaceDir);
+      assert.ok(result.success, `init should succeed: ${result.error}`);
+      const parsed = JSON.parse(result.output);
+
+      // Verify all submodule_* fields are present
+      assert.ok('submodule_is_active' in parsed, 'missing submodule_is_active field');
+      assert.ok('submodule_git_cwd' in parsed, 'missing submodule_git_cwd field');
+      assert.ok('submodule_remote' in parsed, 'missing submodule_remote field');
+      assert.ok('submodule_remote_url' in parsed, 'missing submodule_remote_url field');
+      assert.ok('submodule_target_branch' in parsed, 'missing submodule_target_branch field');
+      assert.ok('submodule_ambiguous' in parsed, 'missing submodule_ambiguous field');
+
+      // This is a submodule workspace
+      assert.strictEqual(parsed.submodule_is_active, true, 'should detect submodule workspace');
+      // git_cwd should point to the submodule directory
+      assert.ok(
+        parsed.submodule_git_cwd && parsed.submodule_git_cwd.includes('mylib'),
+        `submodule_git_cwd should reference mylib, got: ${parsed.submodule_git_cwd}`
+      );
+    } finally {
+      cleanupDir(workspaceDir);
+    }
   });
 });
 

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -1074,5 +1074,31 @@ describe('init phase-op validates phase number (SEC-02)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// init execute-phase submodule fields (SUB-06)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('init execute-phase submodule fields', () => {
+  // Test via CLI since cmdInitExecutePhase calls output() -> process.exit()
+  test('init execute-phase output includes submodule fields', () => {
+    // Use the actual workspace as test target — it has real .planning/ and .gitmodules
+    // gsd-ng/tests/ -> gsd-ng/ -> workspace root
+    const workspaceRoot = path.join(__dirname, '..', '..');
+    const result = runGsdTools(['init', 'execute-phase', '41'], workspaceRoot);
+    assert.ok(result.success, `init should succeed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    // Must have submodule fields
+    assert.ok('submodule_is_active' in parsed, 'missing submodule_is_active field');
+    assert.ok('submodule_git_cwd' in parsed, 'missing submodule_git_cwd field');
+    assert.ok('submodule_remote' in parsed, 'missing submodule_remote field');
+    assert.ok('submodule_remote_url' in parsed, 'missing submodule_remote_url field');
+    assert.ok('submodule_target_branch' in parsed, 'missing submodule_target_branch field');
+    assert.ok('submodule_ambiguous' in parsed, 'missing submodule_ambiguous field');
+    // This workspace IS a submodule workspace
+    assert.strictEqual(parsed.submodule_is_active, true);
+    assert.ok(parsed.submodule_git_cwd && parsed.submodule_git_cwd.endsWith('gsd-ng'), `git_cwd should end with gsd-ng, got: ${parsed.submodule_git_cwd}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // roadmap analyze command
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/workspace.test.cjs
+++ b/tests/workspace.test.cjs
@@ -7,7 +7,7 @@ const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { runGsdTools, createTempProject, createTempGitProject, cleanup, resolveTmpDir } = require('./helpers.cjs');
+const { runGsdTools, createTempProject, createTempGitProject, cleanup, resolveTmpDir, createSubmoduleWorkspace, touchSubmodule } = require('./helpers.cjs');
 
 // ─────────────────────────────────────────────────────────────────────────────
 // detectWorkspaceType — workspace topology detection
@@ -512,81 +512,7 @@ function createTempGitRepo(remoteUrl) {
   return tmpDir;
 }
 
-/**
- * Helper: create a submodule workspace with one or more submodule repos.
- *
- * Each submodule directory is initialized as its own git repo AND
- * registered as a gitlink in the workspace index (simulating `git submodule add`
- * without requiring a real accessible remote).
- *
- * Returns { workspaceDir, subDirs[] }
- */
-function createSubmoduleWorkspace(submoduleDefs) {
-  // submoduleDefs = [{ name, path, remoteUrl }]
-  const workspaceDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-ws-test-'));
-  fs.mkdirSync(path.join(workspaceDir, '.planning', 'phases'), { recursive: true });
-  execSync('git init', { cwd: workspaceDir, stdio: 'pipe' });
-  execSync('git config user.email "test@test.com"', { cwd: workspaceDir, stdio: 'pipe' });
-  execSync('git config user.name "Test"', { cwd: workspaceDir, stdio: 'pipe' });
-  execSync('git config commit.gpgsign false', { cwd: workspaceDir, stdio: 'pipe' });
-  execSync('git remote add origin "https://github.com/workspace/root.git"', { cwd: workspaceDir, stdio: 'pipe' });
-
-  // Build .gitmodules content
-  let gitmodulesContent = '';
-  const subDirs = [];
-
-  for (const def of submoduleDefs) {
-    const subDir = path.join(workspaceDir, def.path);
-    fs.mkdirSync(subDir, { recursive: true });
-
-    // Init submodule repo
-    execSync('git init', { cwd: subDir, stdio: 'pipe' });
-    execSync('git config user.email "test@test.com"', { cwd: subDir, stdio: 'pipe' });
-    execSync('git config user.name "Test"', { cwd: subDir, stdio: 'pipe' });
-    execSync('git config commit.gpgsign false', { cwd: subDir, stdio: 'pipe' });
-    execSync(`git remote add origin "${def.remoteUrl}"`, { cwd: subDir, stdio: 'pipe' });
-    fs.writeFileSync(path.join(subDir, 'README.md'), `# ${def.name}\n`);
-    execSync('git add README.md', { cwd: subDir, stdio: 'pipe' });
-    execSync('git commit -m "initial"', { cwd: subDir, stdio: 'pipe' });
-
-    // Register the submodule as a gitlink in the workspace index.
-    // This uses `git update-index --add --cacheinfo 160000,<sha>,<path>` to
-    // create a gitlink (mode 160000) pointing to the submodule's HEAD commit.
-    const subHeadResult = execSync('git rev-parse HEAD', { cwd: subDir, encoding: 'utf-8', stdio: 'pipe' }).trim();
-    execSync(
-      `git update-index --add --cacheinfo 160000,${subHeadResult},${def.path}`,
-      { cwd: workspaceDir, stdio: 'pipe' }
-    );
-
-    gitmodulesContent += `[submodule "${def.name}"]\n\tpath = ${def.path}\n\turl = ${def.remoteUrl}\n`;
-    subDirs.push(subDir);
-  }
-
-  fs.writeFileSync(path.join(workspaceDir, '.gitmodules'), gitmodulesContent);
-  execSync('git add .gitmodules', { cwd: workspaceDir, stdio: 'pipe' });
-  execSync('git commit -m "add submodules"', { cwd: workspaceDir, stdio: 'pipe' });
-
-  return { workspaceDir, subDirs };
-}
-
-/**
- * Helper: simulate a submodule update in the workspace git (advances the gitlink).
- * Creates a new commit in the submodule and updates the workspace gitlink,
- * making the submodule path appear in `git diff --name-only HEAD`.
- */
-function touchSubmodule(workspaceDir, submodulePath) {
-  const subDir = path.join(workspaceDir, submodulePath);
-  // Create a new commit in the submodule to advance its HEAD
-  fs.writeFileSync(path.join(subDir, 'touched.txt'), String(Date.now()));
-  execSync('git add touched.txt', { cwd: subDir, stdio: 'pipe' });
-  execSync('git commit -m "touched"', { cwd: subDir, stdio: 'pipe' });
-  // Update the workspace gitlink to point to the new commit (staged, not committed)
-  const newSha = execSync('git rev-parse HEAD', { cwd: subDir, encoding: 'utf-8', stdio: 'pipe' }).trim();
-  execSync(
-    `git update-index --cacheinfo 160000,${newSha},${submodulePath}`,
-    { cwd: workspaceDir, stdio: 'pipe' }
-  );
-}
+// createSubmoduleWorkspace and touchSubmodule are imported from ./helpers.cjs
 
 describe('resolveGitContext', () => {
   const workspace = require('../gsd-ng/bin/lib/workspace.cjs');

--- a/tests/workspace.test.cjs
+++ b/tests/workspace.test.cjs
@@ -6,7 +6,8 @@ const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');
-const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+const { execSync } = require('child_process');
+const { runGsdTools, createTempProject, createTempGitProject, cleanup, resolveTmpDir } = require('./helpers.cjs');
 
 // ─────────────────────────────────────────────────────────────────────────────
 // detectWorkspaceType — workspace topology detection
@@ -485,5 +486,279 @@ describe('cmdDetectWorkspace via gsd-tools', () => {
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.type, 'submodule');
     assert.deepStrictEqual(parsed.submodule_paths, ['mylib']);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// resolveGitContext / cmdGitContext — git context routing
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Helper: create a temp git repo with a remote.
+ * Returns the temp dir path.
+ */
+function createTempGitRepo(remoteUrl) {
+  const tmpDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-git-test-'));
+  fs.mkdirSync(path.join(tmpDir, '.planning', 'phases'), { recursive: true });
+  execSync('git init', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config commit.gpgsign false', { cwd: tmpDir, stdio: 'pipe' });
+  execSync(`git remote add origin "${remoteUrl}"`, { cwd: tmpDir, stdio: 'pipe' });
+  // Create initial commit so branch exists
+  fs.writeFileSync(path.join(tmpDir, 'README.md'), '# Test\n');
+  execSync('git add README.md', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tmpDir, stdio: 'pipe' });
+  return tmpDir;
+}
+
+/**
+ * Helper: create a submodule workspace with one or more submodule repos.
+ *
+ * Each submodule directory is initialized as its own git repo AND
+ * registered as a gitlink in the workspace index (simulating `git submodule add`
+ * without requiring a real accessible remote).
+ *
+ * Returns { workspaceDir, subDirs[] }
+ */
+function createSubmoduleWorkspace(submoduleDefs) {
+  // submoduleDefs = [{ name, path, remoteUrl }]
+  const workspaceDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-ws-test-'));
+  fs.mkdirSync(path.join(workspaceDir, '.planning', 'phases'), { recursive: true });
+  execSync('git init', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git config commit.gpgsign false', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git remote add origin "https://github.com/workspace/root.git"', { cwd: workspaceDir, stdio: 'pipe' });
+
+  // Build .gitmodules content
+  let gitmodulesContent = '';
+  const subDirs = [];
+
+  for (const def of submoduleDefs) {
+    const subDir = path.join(workspaceDir, def.path);
+    fs.mkdirSync(subDir, { recursive: true });
+
+    // Init submodule repo
+    execSync('git init', { cwd: subDir, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: subDir, stdio: 'pipe' });
+    execSync('git config user.name "Test"', { cwd: subDir, stdio: 'pipe' });
+    execSync('git config commit.gpgsign false', { cwd: subDir, stdio: 'pipe' });
+    execSync(`git remote add origin "${def.remoteUrl}"`, { cwd: subDir, stdio: 'pipe' });
+    fs.writeFileSync(path.join(subDir, 'README.md'), `# ${def.name}\n`);
+    execSync('git add README.md', { cwd: subDir, stdio: 'pipe' });
+    execSync('git commit -m "initial"', { cwd: subDir, stdio: 'pipe' });
+
+    // Register the submodule as a gitlink in the workspace index.
+    // This uses `git update-index --add --cacheinfo 160000,<sha>,<path>` to
+    // create a gitlink (mode 160000) pointing to the submodule's HEAD commit.
+    const subHeadResult = execSync('git rev-parse HEAD', { cwd: subDir, encoding: 'utf-8', stdio: 'pipe' }).trim();
+    execSync(
+      `git update-index --add --cacheinfo 160000,${subHeadResult},${def.path}`,
+      { cwd: workspaceDir, stdio: 'pipe' }
+    );
+
+    gitmodulesContent += `[submodule "${def.name}"]\n\tpath = ${def.path}\n\turl = ${def.remoteUrl}\n`;
+    subDirs.push(subDir);
+  }
+
+  fs.writeFileSync(path.join(workspaceDir, '.gitmodules'), gitmodulesContent);
+  execSync('git add .gitmodules', { cwd: workspaceDir, stdio: 'pipe' });
+  execSync('git commit -m "add submodules"', { cwd: workspaceDir, stdio: 'pipe' });
+
+  return { workspaceDir, subDirs };
+}
+
+/**
+ * Helper: simulate a submodule update in the workspace git (advances the gitlink).
+ * Creates a new commit in the submodule and updates the workspace gitlink,
+ * making the submodule path appear in `git diff --name-only HEAD`.
+ */
+function touchSubmodule(workspaceDir, submodulePath) {
+  const subDir = path.join(workspaceDir, submodulePath);
+  // Create a new commit in the submodule to advance its HEAD
+  fs.writeFileSync(path.join(subDir, 'touched.txt'), String(Date.now()));
+  execSync('git add touched.txt', { cwd: subDir, stdio: 'pipe' });
+  execSync('git commit -m "touched"', { cwd: subDir, stdio: 'pipe' });
+  // Update the workspace gitlink to point to the new commit (staged, not committed)
+  const newSha = execSync('git rev-parse HEAD', { cwd: subDir, encoding: 'utf-8', stdio: 'pipe' }).trim();
+  execSync(
+    `git update-index --cacheinfo 160000,${newSha},${submodulePath}`,
+    { cwd: workspaceDir, stdio: 'pipe' }
+  );
+}
+
+describe('resolveGitContext', () => {
+  const workspace = require('../gsd-ng/bin/lib/workspace.cjs');
+  let tmpDir;
+
+  afterEach(() => {
+    if (tmpDir) cleanup(tmpDir);
+    tmpDir = null;
+  });
+
+  test('Test 1: standalone workspace returns is_submodule=false, git_cwd=cwd, correct remote/branch', () => {
+    tmpDir = createTempGitRepo('https://github.com/user/standalone.git');
+    const result = workspace.resolveGitContext(tmpDir);
+
+    assert.strictEqual(result.is_submodule, false, 'is_submodule should be false');
+    assert.strictEqual(result.git_cwd, tmpDir, 'git_cwd should be cwd');
+    assert.ok(result.remote, 'remote should be set');
+    assert.ok(result.remote_url, 'remote_url should be set');
+    assert.ok(result.current_branch, 'current_branch should be set');
+    assert.ok(result.target_branch, 'target_branch should be set');
+    assert.strictEqual(result.ssh_url, false, 'ssh_url should be false for https remote');
+  });
+
+  test('Test 2: submodule workspace with diff in submodule returns is_submodule=true, correct submodule_path', () => {
+    const { workspaceDir, subDirs } = createSubmoduleWorkspace([
+      { name: 'mylib', path: 'mylib', remoteUrl: 'https://github.com/user/mylib.git' },
+    ]);
+    tmpDir = workspaceDir;
+
+    // Advance the submodule and update gitlink in workspace index (simulate submodule change)
+    touchSubmodule(workspaceDir, 'mylib');
+
+    const result = workspace.resolveGitContext(workspaceDir);
+
+    assert.strictEqual(result.is_submodule, true, 'is_submodule should be true');
+    assert.strictEqual(result.submodule_path, 'mylib', 'submodule_path should be mylib');
+    assert.ok(result.git_cwd, 'git_cwd should be set');
+    assert.ok(result.git_cwd.endsWith('mylib'), 'git_cwd should end with submodule path');
+  });
+
+  test('Test 3: submodule workspace with diff in one of multiple submodules returns correct active submodule', () => {
+    const { workspaceDir, subDirs } = createSubmoduleWorkspace([
+      { name: 'lib-a', path: 'lib-a', remoteUrl: 'https://github.com/user/lib-a.git' },
+      { name: 'lib-b', path: 'lib-b', remoteUrl: 'https://github.com/user/lib-b.git' },
+    ]);
+    tmpDir = workspaceDir;
+
+    // Only advance lib-b
+    touchSubmodule(workspaceDir, 'lib-b');
+
+    const result = workspace.resolveGitContext(workspaceDir);
+
+    assert.strictEqual(result.is_submodule, true, 'is_submodule should be true');
+    assert.strictEqual(result.submodule_path, 'lib-b', 'should resolve to lib-b (only one with diff)');
+    assert.strictEqual(result.ambiguous, false, 'should not be ambiguous');
+  });
+
+  test('Test 4: submodule workspace with diffs in multiple submodules sets ambiguous=true', () => {
+    const { workspaceDir, subDirs } = createSubmoduleWorkspace([
+      { name: 'lib-a', path: 'lib-a', remoteUrl: 'https://github.com/user/lib-a.git' },
+      { name: 'lib-b', path: 'lib-b', remoteUrl: 'https://github.com/user/lib-b.git' },
+    ]);
+    tmpDir = workspaceDir;
+
+    // Advance both submodules
+    touchSubmodule(workspaceDir, 'lib-a');
+    touchSubmodule(workspaceDir, 'lib-b');
+
+    const result = workspace.resolveGitContext(workspaceDir);
+
+    assert.strictEqual(result.is_submodule, true, 'is_submodule should be true');
+    assert.strictEqual(result.ambiguous, true, 'should be ambiguous');
+    assert.ok(result.ambiguous_paths.includes('lib-a'), 'ambiguous_paths should include lib-a');
+    assert.ok(result.ambiguous_paths.includes('lib-b'), 'ambiguous_paths should include lib-b');
+  });
+
+  test('Test 5: submodule workspace with no diff match but single submodule falls back to that submodule', () => {
+    const { workspaceDir, subDirs } = createSubmoduleWorkspace([
+      { name: 'mylib', path: 'mylib', remoteUrl: 'https://github.com/user/mylib.git' },
+    ]);
+    tmpDir = workspaceDir;
+    // No staged changes — should fall back to the only submodule
+
+    const result = workspace.resolveGitContext(workspaceDir);
+
+    assert.strictEqual(result.is_submodule, true, 'is_submodule should be true');
+    assert.strictEqual(result.submodule_path, 'mylib', 'should fall back to the only submodule');
+    assert.strictEqual(result.ambiguous, false, 'should not be ambiguous');
+  });
+
+  test('Test 6: resolveGitContext reads git.submodule.target_branch from config as override', () => {
+    const { workspaceDir, subDirs } = createSubmoduleWorkspace([
+      { name: 'mylib', path: 'mylib', remoteUrl: 'https://github.com/user/mylib.git' },
+    ]);
+    tmpDir = workspaceDir;
+
+    // Write config with target_branch override
+    const configPath = path.join(workspaceDir, '.planning', 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({
+      git: {
+        submodule: {
+          target_branch: 'develop',
+        },
+      },
+    }, null, 2));
+
+    const result = workspace.resolveGitContext(workspaceDir);
+
+    assert.strictEqual(result.is_submodule, true, 'is_submodule should be true');
+    assert.strictEqual(result.target_branch, 'develop', 'target_branch should be from config override');
+  });
+
+  test('Test 7: resolveGitContext includes platform, cli, cli_installed fields for github remote', () => {
+    tmpDir = createTempGitRepo('https://github.com/user/myrepo.git');
+    const result = workspace.resolveGitContext(tmpDir);
+
+    assert.ok('platform' in result, 'result should have platform field');
+    assert.ok('cli' in result, 'result should have cli field');
+    assert.ok('cli_installed' in result, 'result should have cli_installed field');
+    assert.strictEqual(result.platform, 'github', 'platform should be github for github.com remote');
+    assert.strictEqual(result.cli, 'gh', 'cli should be gh for github platform');
+  });
+
+  test('Test 8: ssh_url is true for git@ URL, false for https://', () => {
+    // SSH URL
+    const sshDir = createTempGitRepo('git@github.com:user/repo.git');
+    try {
+      const sshResult = workspace.resolveGitContext(sshDir);
+      assert.strictEqual(sshResult.ssh_url, true, 'ssh_url should be true for git@ URL');
+    } finally {
+      cleanup(sshDir);
+    }
+
+    // HTTPS URL
+    tmpDir = createTempGitRepo('https://github.com/user/repo.git');
+    const httpsResult = workspace.resolveGitContext(tmpDir);
+    assert.strictEqual(httpsResult.ssh_url, false, 'ssh_url should be false for https:// URL');
+  });
+});
+
+describe('cmdGitContext CLI integration', () => {
+  let tmpDir;
+
+  afterEach(() => {
+    if (tmpDir) cleanup(tmpDir);
+    tmpDir = null;
+  });
+
+  test('Test 9: CLI git-context outputs valid JSON with expected top-level keys including platform, cli, ssh_url', () => {
+    tmpDir = createTempGitRepo('https://github.com/user/myrepo.git');
+
+    const result = runGsdTools(['git-context', '--cwd', tmpDir], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    let parsed;
+    assert.doesNotThrow(() => {
+      parsed = JSON.parse(result.output);
+    }, 'output should be valid JSON');
+
+    // Check all required top-level keys
+    const requiredKeys = [
+      'is_submodule', 'submodule_path', 'git_cwd', 'remote', 'remote_url',
+      'ssh_url', 'target_branch', 'current_branch', 'ambiguous', 'ambiguous_paths',
+      'platform', 'cli', 'cli_installed', 'cli_install_url',
+    ];
+    for (const key of requiredKeys) {
+      assert.ok(key in parsed, `result should have key: ${key}`);
+    }
+
+    assert.strictEqual(parsed.is_submodule, false, 'standalone workspace is_submodule should be false');
+    assert.strictEqual(parsed.platform, 'github', 'platform should be github');
+    assert.strictEqual(parsed.cli, 'gh', 'cli should be gh');
+    assert.ok(typeof parsed.ssh_url === 'boolean', 'ssh_url should be a boolean');
   });
 });

--- a/tests/workspace.test.cjs
+++ b/tests/workspace.test.cjs
@@ -725,6 +725,84 @@ describe('resolveGitContext', () => {
     const httpsResult = workspace.resolveGitContext(tmpDir);
     assert.strictEqual(httpsResult.ssh_url, false, 'ssh_url should be false for https:// URL');
   });
+
+  test('Test 9: multiple submodules with no diffs returns ambiguous=true', () => {
+    const { workspaceDir } = createSubmoduleWorkspace([
+      { name: 'lib-a', path: 'lib-a', remoteUrl: 'https://github.com/user/lib-a.git' },
+      { name: 'lib-b', path: 'lib-b', remoteUrl: 'https://github.com/user/lib-b.git' },
+    ]);
+    tmpDir = workspaceDir;
+
+    // Do NOT touch either submodule — no diffs
+    const result = workspace.resolveGitContext(workspaceDir);
+
+    assert.strictEqual(result.ambiguous, true, 'should be ambiguous when multiple submodules have no diffs');
+    assert.strictEqual(result.ambiguous_paths.length, 2, 'should list both submodule paths');
+    assert.ok(result.ambiguous_paths.includes('lib-a'), 'should include lib-a');
+    assert.ok(result.ambiguous_paths.includes('lib-b'), 'should include lib-b');
+    assert.strictEqual(result.submodule_path, null, 'should not pick a submodule');
+    assert.strictEqual(result.git_cwd, null, 'should not resolve git_cwd');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// --field extraction — scalar extraction from git-context and detect-workspace
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('--field extraction on git-context and detect-workspace', () => {
+  test('git-context --field is_submodule --raw returns scalar string', () => {
+    const result = runGsdTools(['git-context', '--field', 'is_submodule', '--raw']);
+    assert.ok(result.success, `should succeed: ${result.error}`);
+    // Output should be "true" or "false", not JSON
+    assert.ok(['true', 'false'].includes(result.output.trim()), `expected boolean string, got: ${result.output}`);
+  });
+
+  test('detect-workspace --field type --raw returns workspace type string', () => {
+    const result = runGsdTools(['detect-workspace', '--field', 'type', '--raw']);
+    assert.ok(result.success, `should succeed: ${result.error}`);
+    assert.ok(['standalone', 'submodule'].includes(result.output.trim()), `expected type string, got: ${result.output}`);
+  });
+
+  test('detect-workspace --field type --raw returns no JSON braces', () => {
+    const result = runGsdTools(['detect-workspace', '--field', 'type', '--raw']);
+    assert.ok(result.success);
+    assert.ok(!result.output.includes('{'), 'output should not contain JSON braces');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ssh-check command — SSH agent status detection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ssh-check command', () => {
+  test('ssh-check with HTTPS URL returns not_required', () => {
+    const result = runGsdTools(['ssh-check', 'https://github.com/user/repo.git']);
+    assert.ok(result.success, `should succeed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.ssh_required, false);
+    assert.strictEqual(parsed.status, 'not_required');
+  });
+
+  test('ssh-check with SSH URL returns ssh_required=true', () => {
+    const result = runGsdTools(['ssh-check', 'git@github.com:user/repo.git']);
+    assert.ok(result.success, `should succeed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.ssh_required, true);
+    assert.ok(['ok', 'no_identities', 'agent_not_running'].includes(parsed.status), `unexpected status: ${parsed.status}`);
+  });
+
+  test('ssh-check with --field status --raw returns scalar', () => {
+    const result = runGsdTools(['ssh-check', 'https://github.com/user/repo.git', '--field', 'status', '--raw']);
+    assert.ok(result.success, `should succeed: ${result.error}`);
+    assert.strictEqual(result.output.trim(), 'not_required');
+  });
+
+  test('ssh-check with no URL returns not_required', () => {
+    const result = runGsdTools(['ssh-check']);
+    assert.ok(result.success, `should succeed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.status, 'not_required');
+  });
 });
 
 describe('cmdGitContext CLI integration', () => {


### PR DESCRIPTION
## Summary

- **Phase 41:** Submodule-aware git operations — detect workspace topology and route git push, PR CLI, and branch operations to the correct repository when source code lives in a submodule
- **Phase 42:** Fix Phase 41 PR review findings — `--field` extraction for git-context/detect-workspace, `ssh-check` command, ambiguous multi-submodule fallback, dynamic UID tmpdir, workflow `node -e` cleanup, test helper extraction
- **Fix:** Add `pretest`/`test:coverage` build:hooks step so DIST-01 passes both locally and in CI

## Test plan

- [x] 1251/1251 tests passing locally
- [x] CI green on all 4 matrix jobs (ubuntu/macos x Node 20/22)
- [x] Phase 42 verification: 11/11 must-haves verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)