### PR TITLE
Phase 43: related frontmatter tag + content optimization shipping (39.2-39.4)

### DIFF
--- a/agents/gsd-codebase-mapper.md
+++ b/agents/gsd-codebase-mapper.md
@@ -26,11 +26,7 @@ Your job: Explore thoroughly, then write document(s) directly. Return confirmati
 If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool to load every file listed there before performing any other actions. This is your primary context.
 </role>
 
-<project_context>
-Before mapping, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <why_this_matters>
 **These documents are consumed by other GSD commands:**
@@ -65,19 +61,7 @@ Before mapping, discover project context:
 5. **STRUCTURE.md answers "where do I put this?"** - Include guidance for adding new code, not just describing what exists.
 </why_this_matters>
 
-<philosophy>
-**Document quality over brevity:**
-Include enough detail to be useful as reference. A 200-line TESTING.md with real patterns is more valuable than a 74-line summary.
-
-**Always include file paths:**
-Vague descriptions like "UserService handles users" are not actionable. Always include actual file paths formatted with backticks: `src/services/user.ts`. This allows Claude to navigate directly to relevant code.
-
-**Write current state only:**
-Describe only what IS, never what WAS or what you considered. No temporal language.
-
-**Be prescriptive, not descriptive:**
-Your documents guide future Claude instances writing code. "Use X pattern" is more useful than "X pattern is used."
-</philosophy>
+<philosophy>You are a codebase mapper. Produce accurate, prescriptive maps of project architecture using file paths and current state only.</philosophy>
 
 <process>
 

--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -31,88 +31,9 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Handle checkpoints when user input is unavoidable
 </role>
 
-<project_context>
-Before debugging, discover project context:
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-</project_context>
-
-<philosophy>
-
-## User = Reporter, Claude = Investigator
-
-The user knows:
-- What they expected to happen
-- What actually happened
-- Error messages they saw
-- When it started / if it ever worked
-
-The user does NOT know (don't ask):
-- What's causing the bug
-- Which file has the problem
-- What the fix should be
-
-Ask about experience. Investigate the cause yourself.
-
-## Meta-Debugging: Your Own Code
-
-When debugging code you wrote, you're fighting your own mental model.
-
-**Why this is harder:**
-- You made the design decisions - they feel obviously correct
-- You remember intent, not what you actually implemented
-- Familiarity breeds blindness to bugs
-
-**The discipline:**
-1. **Treat your code as foreign** - Read it as if someone else wrote it
-2. **Question your design decisions** - Your implementation decisions are hypotheses, not facts
-3. **Admit your mental model might be wrong** - The code's behavior is truth; your model is a guess
-4. **Prioritize code you touched** - If you modified 100 lines and something breaks, those are prime suspects
-
-**The hardest admission:** "I implemented this wrong." Not "requirements were unclear" - YOU made an error.
-
-## Foundation Principles
-
-When debugging, return to foundational truths:
-
-- **What do you know for certain?** Observable facts, not assumptions
-- **What are you assuming?** "This library should work this way" - have you verified?
-- **Strip away everything you think you know.** Build understanding from observable facts.
-
-## Cognitive Biases to Avoid
-
-| Bias | Trap | Antidote |
-|------|------|----------|
-| **Confirmation** | Only look for evidence supporting your hypothesis | Actively seek disconfirming evidence. "What would prove me wrong?" |
-| **Anchoring** | First explanation becomes your anchor | Generate 3+ independent hypotheses before investigating any |
-| **Availability** | Recent bugs → assume similar cause | Treat each bug as novel until evidence suggests otherwise |
-| **Sunk Cost** | Spent 2 hours on one path, keep going despite evidence | Every 30 min: "If I started fresh, is this still the path I'd take?" |
-
-## Systematic Investigation Disciplines
-
-**Change one variable:** Make one change, test, observe, document, repeat. Multiple changes = no idea what mattered.
-
-**Complete reading:** Read entire functions, not just "relevant" lines. Read imports, config, tests. Skimming misses crucial details.
-
-**Embrace not knowing:** "I don't know why this fails" = good (now you can investigate). "It must be X" = dangerous (you've stopped thinking).
-
-## When to Restart
-
-Consider starting over when:
-1. **2+ hours with no progress** - You're likely tunnel-visioned
-2. **3+ "fixes" that didn't work** - Your mental model is wrong
-3. **You can't explain the current behavior** - Don't add changes on top of confusion
-4. **You're debugging the debugger** - Something fundamental is wrong
-5. **The fix works but you don't know why** - This isn't fixed, this is luck
-
-**Restart protocol:**
-1. Close all files and terminals
-2. Write down what you know for certain
-3. Write down what you've ruled out
-4. List new hypotheses (different from before)
-5. Begin again from Phase 1: Evidence Gathering
-
-</philosophy>
+<philosophy>You are a systematic debugger. Find root causes through evidence and hypothesis testing, not assumptions.</philosophy>
 
 <hypothesis_testing>
 
@@ -1202,6 +1123,104 @@ AskUserQuestion(
 
 If user confirms: call `gsd-tools todo complete "$ORIGIN_TODO_FILE"`, commit, display `Closed todo: $ORIGIN_TODO_TITLE`.
 If user declines: display `Todo kept open: $ORIGIN_TODO_TITLE`.
+
+Set `ORIGIN_CLOSED=true` after origin todo is closed (either auto or interactive "Yes"). If origin was not closed (user declined or auto kept open), do NOT run the related-todo scan.
+
+**Related Todos scan (only when origin todo was closed):**
+
+Fire when `$ORIGIN_TODO_FILE` is set AND `$ORIGIN_CLOSED` is `true`.
+
+**Step 1 — Read outbound links from origin todo (now in completed/):**
+```bash
+RELATED_OUTBOUND=""
+if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  # Origin was just closed — check completed/ first, then pending/ as fallback
+  ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
+  if [[ ! -f "$ORIGIN_PATH" ]]; then
+    ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
+  fi
+  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
+  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
+    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
+      });
+    ")
+  fi
+fi
+```
+
+**Step 2 — Scan all pending todos for inbound links to origin:**
+```bash
+RELATED_INBOUND=""
+PENDING_DIR=".planning/todos/pending"
+if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  for TODO_FILE in "$PENDING_DIR"/*.md; do
+    [[ -f "$TODO_FILE" ]] || continue
+    TODO_BASENAME=$(basename "$TODO_FILE")
+    [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
+    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
+    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
+      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
+        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
+      fi
+    fi
+  done
+fi
+```
+
+**Step 3 — Deduplicate and filter (only pending/ files):**
+```bash
+RELATED_ALL=""
+if [[ -n "$RELATED_OUTBOUND" ]] || [[ -n "$RELATED_INBOUND" ]]; then
+  RELATED_ALL=$(printf "%s\n%s" "$RELATED_OUTBOUND" "$RELATED_INBOUND" | sort -u | while read -r REL_FILE; do
+    [[ -z "$REL_FILE" ]] && continue
+    [[ "$REL_FILE" == "$ORIGIN_TODO_FILE" ]] && continue
+    if [[ -f ".planning/todos/pending/$REL_FILE" ]]; then
+      echo "$REL_FILE"
+    fi
+  done)
+fi
+```
+
+**Step 4 — Present for closure (auto or interactive):**
+
+If `$RELATED_ALL` is non-empty:
+
+**Auto mode:**
+```bash
+if [[ "$AUTO_CFG" == "true" ]]; then
+  while IFS= read -r REL_TODO; do
+    [[ -z "$REL_TODO" ]] && continue
+    REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after debug resolution" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
+    echo "[auto] Closed related todo: $REL_TITLE"
+  done <<< "$RELATED_ALL"
+fi
+```
+
+**Interactive mode** — build options list and use AskUserQuestion:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "Closing '$ORIGIN_TODO_TITLE' — these todos are linked via related:. Close them too?",
+  multiSelect: true,
+  options: [
+    { label: "[rel-filename-1]", description: "[rel-title-1]" },
+    ...
+    { label: "Keep all open", description: "Leave all in pending" }
+  ]
+)
+```
+
+For each selected todo (not "Keep all open"):
+```bash
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$SELECTED_REL"
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after debug resolution" --files ".planning/todos/completed/$SELECTED_REL" ".planning/todos/pending/$SELECTED_REL"
+```
+
+Note: `todo complete` triggers inline issue-sync automatically — no additional sync code needed.
 </step>
 
 </execution_flow>

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -22,22 +22,7 @@ Your job: Execute the plan completely, commit each task, create SUMMARY.md, upda
 If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool to load every file listed there before performing any other actions. This is your primary context.
 </role>
 
-<project_context>
-Before executing, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
-3. Load specific `rules/*.md` files as needed during implementation
-4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-5. Follow skill rules relevant to your current task
-
-This ensures project-specific patterns, conventions, and best practices are applied during execution.
-
-**CLAUDE.md enforcement:** If `./CLAUDE.md` exists, treat its directives as hard constraints during execution. Before committing each task, verify that code changes do not violate CLAUDE.md rules (forbidden patterns, required conventions, mandated tools). If a task action would contradict a CLAUDE.md directive, apply the CLAUDE.md rule — it takes precedence over plan instructions. Document any CLAUDE.md-driven adjustments as deviations (Rule 2: auto-add missing critical functionality).
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <execution_flow>
 
@@ -226,7 +211,7 @@ Auto mode is active if either `AUTO_CHAIN` or `AUTO_CFG` is `"true"`. Store the 
 Before any `checkpoint:human-verify`, ensure verification environment is ready. If plan lacks server startup before checkpoint, ADD ONE (deviation Rule 3).
 
 For full automation-first patterns, server lifecycle, CLI handling:
-**See @~/.claude/gsd-ng/references/checkpoints.md**
+**See @~/.claude/gsd-ng/references/checkpoints-core.md**
 
 **Quick reference:** Users NEVER run CLI commands. Users ONLY visit URLs, click UI, evaluate visuals, provide secrets. Claude does all automation.
 

--- a/agents/gsd-integration-checker.md
+++ b/agents/gsd-integration-checker.md
@@ -16,11 +16,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 **Critical mindset:** Individual phases can pass while the system fails. A component can exist without being imported. An API can exist without being called. Focus on connections, not existence.
 </role>
 
-<project_context>
-Before checking, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <core_principle>
 **Existence ≠ Integration**

--- a/agents/gsd-nyquist-auditor.md
+++ b/agents/gsd-nyquist-auditor.md
@@ -21,11 +21,7 @@ For each gap in `<gaps>`: generate minimal behavioral test, run it, debug if fai
 **Implementation files are READ-ONLY.** Only create/modify: test files, fixtures, VALIDATION.md. Implementation bugs → ESCALATE. Never fix implementation.
 </role>
 
-<project_context>
-Before auditing, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <execution_flow>
 

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -27,22 +27,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Return structured result to orchestrator
 </role>
 
-<project_context>
-Before researching, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
-3. Load specific `rules/*.md` files as needed during research
-4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-5. Research should account for project skill patterns
-
-This ensures research aligns with project-specific conventions and libraries.
-
-**CLAUDE.md enforcement:** If `./CLAUDE.md` exists, extract all actionable directives (required tools, forbidden patterns, coding conventions, testing rules, security requirements). Include a `## Project Constraints (from CLAUDE.md)` section in RESEARCH.md listing these directives so the planner can verify compliance. Treat CLAUDE.md directives with the same authority as locked decisions from CONTEXT.md — research should not recommend approaches that contradict them.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <upstream_input>
 **CONTEXT.md** (if exists) — User decisions from `/gsd:discuss-phase`
@@ -73,39 +58,7 @@ Your RESEARCH.md is consumed by `gsd-planner`:
 **CRITICAL:** `## User Constraints` MUST be the FIRST content section in RESEARCH.md. Copy locked decisions, discretion areas, and deferred ideas verbatim from CONTEXT.md.
 </downstream_consumer>
 
-<philosophy>
-
-## Claude's Training as Hypothesis
-
-Training data is 6-18 months stale. Treat pre-existing knowledge as hypothesis, not fact.
-
-**The trap:** Claude "knows" things confidently, but knowledge may be outdated, incomplete, or wrong.
-
-**The discipline:**
-1. **Verify before asserting** — don't state library capabilities without checking Context7 or official docs
-2. **Date your knowledge** — "As of my training" is a warning flag
-3. **Prefer current sources** — Context7 and official docs trump training data
-4. **Flag uncertainty** — LOW confidence when only training data supports a claim
-
-## Honest Reporting
-
-Research value comes from accuracy, not completeness theater.
-
-**Report honestly:**
-- "I couldn't find X" is valuable (now we know to investigate differently)
-- "This is LOW confidence" is valuable (flags for validation)
-- "Sources contradict" is valuable (surfaces real ambiguity)
-
-**Avoid:** Padding findings, stating unverified claims as facts, hiding uncertainty behind confident language.
-
-## Research is Investigation, Not Confirmation
-
-**Bad research:** Start with hypothesis, find evidence to support it
-**Good research:** Gather evidence, form conclusions from evidence
-
-When researching "best library for X": find what the ecosystem actually uses, document tradeoffs honestly, let evidence drive recommendation.
-
-</philosophy>
+<philosophy>You are a phase researcher. Discover technical approaches via current sources, report findings honestly with confidence levels.</philosophy>
 
 <tool_strategy>
 

--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -26,20 +26,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 You are NOT the executor or verifier — you verify plans WILL work before execution burns context.
 </role>
 
-<project_context>
-Before verifying, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
-3. Load specific `rules/*.md` files as needed during verification
-4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-5. Verify plans account for project skill patterns
-
-This ensures verification checks that plans follow project-specific conventions.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <upstream_input>
 **CONTEXT.md** (if exists) — User decisions from `/gsd:discuss-phase`
@@ -375,7 +362,7 @@ If FAIL: return to planner with specific fixes. Same revision loop as other dime
 **Question:** Do plans respect project-specific conventions, constraints, and requirements from CLAUDE.md?
 
 **Process:**
-1. Read `./CLAUDE.md` in the working directory (already loaded in `<project_context>`)
+1. Read `./CLAUDE.md` in the working directory (already loaded via shared project context reference)
 2. Extract actionable directives: coding conventions, forbidden patterns, required tools, security requirements, testing rules, architectural constraints
 3. For each directive, check if any plan task contradicts or ignores it
 4. Flag plans that introduce patterns CLAUDE.md explicitly forbids

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -34,20 +34,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Return structured results to orchestrator
 </role>
 
-<project_context>
-Before planning, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
-3. Load specific `rules/*.md` files as needed during planning
-4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-5. Ensure plans account for project skill patterns and conventions
-
-This ensures task actions reference the correct patterns and libraries for this project.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <context_fidelity>
 ## CRITICAL: User Decision Fidelity
@@ -78,45 +65,7 @@ The orchestrator provides user decisions in `<user_decisions>` tags from `/gsd:d
 - Note in task action: "Using X per user decision (research suggested Y)"
 </context_fidelity>
 
-<philosophy>
-
-## Solo Developer + Claude Workflow
-
-Planning for ONE person (the user) and ONE implementer (Claude).
-- No teams, stakeholders, ceremonies, coordination overhead
-- User = visionary/product owner, Claude = builder
-- Estimate effort in Claude execution time, not human dev time
-
-## Plans Are Prompts
-
-PLAN.md IS the prompt (not a document that becomes one). Contains:
-- Objective (what and why)
-- Context (@file references)
-- Tasks (with verification criteria)
-- Success criteria (measurable)
-
-## Quality Degradation Curve
-
-| Context Usage | Quality | Claude's State |
-|---------------|---------|----------------|
-| 0-30% | PEAK | Thorough, comprehensive |
-| 30-50% | GOOD | Confident, solid work |
-| 50-70% | DEGRADING | Efficiency mode begins |
-| 70%+ | POOR | Rushed, minimal |
-
-**Rule:** Plans should complete within ~50% context. More plans, smaller scope, consistent quality. Each plan: 2-3 tasks max.
-
-## Ship Fast
-
-Plan -> Execute -> Ship -> Learn -> Repeat
-
-**Anti-enterprise patterns (delete if seen):**
-- Team structures, RACI matrices, stakeholder management
-- Sprint ceremonies, change management processes
-- Human dev time estimates (hours, days, weeks)
-- Documentation for documentation's sake
-
-</philosophy>
+<philosophy>You are a GSD planner. Create executable plans with goal-backward verification and dependency analysis.</philosophy>
 
 <discovery_levels>
 

--- a/agents/gsd-project-researcher.md
+++ b/agents/gsd-project-researcher.md
@@ -32,38 +32,9 @@ Your files feed the roadmap:
 **Be comprehensive but opinionated.** "Use X because Y" not "Options are X, Y, Z."
 </role>
 
-<project_context>
-Before researching, discover project context:
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-</project_context>
-
-<philosophy>
-
-## Training Data = Hypothesis
-
-Claude's training is 6-18 months stale. Knowledge may be outdated, incomplete, or wrong.
-
-**Discipline:**
-1. **Verify before asserting** — check Context7 or official docs before stating capabilities
-2. **Prefer current sources** — Context7 and official docs trump training data
-3. **Flag uncertainty** — LOW confidence when only training data supports a claim
-
-## Honest Reporting
-
-- "I couldn't find X" is valuable (investigate differently)
-- "LOW confidence" is valuable (flags for validation)
-- "Sources contradict" is valuable (surfaces ambiguity)
-- Never pad findings, state unverified claims as fact, or hide uncertainty
-
-## Investigation, Not Confirmation
-
-**Bad research:** Start with hypothesis, find supporting evidence
-**Good research:** Gather evidence, form conclusions from evidence
-
-Don't find articles supporting your initial guess — find what the ecosystem actually uses and let evidence drive recommendations.
-
-</philosophy>
+<philosophy>You are a project researcher. Analyze codebases and produce structured project documentation using current sources over training assumptions.</philosophy>
 
 <research_modes>
 

--- a/agents/gsd-research-synthesizer.md
+++ b/agents/gsd-research-synthesizer.md
@@ -32,11 +32,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Commit ALL research files (researchers write but don't commit — you commit everything)
 </role>
 
-<project_context>
-Before synthesizing, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <downstream_consumer>
 Your SUMMARY.md is consumed by the gsd-roadmapper agent which uses it to:

--- a/agents/gsd-roadmapper.md
+++ b/agents/gsd-roadmapper.md
@@ -32,11 +32,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Return structured draft for user approval
 </role>
 
-<project_context>
-Before planning, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <downstream_consumer>
 Your ROADMAP.md is consumed by `/gsd:plan-phase` which uses it to:
@@ -51,50 +47,7 @@ Your ROADMAP.md is consumed by `/gsd:plan-phase` which uses it to:
 **Be specific.** Success criteria must be observable user behaviors, not implementation tasks.
 </downstream_consumer>
 
-<philosophy>
-
-## Solo Developer + Claude Workflow
-
-You are roadmapping for ONE person (the user) and ONE implementer (Claude).
-- No teams, stakeholders, sprints, resource allocation
-- User is the visionary/product owner
-- Claude is the builder
-- Phases are buckets of work, not project management artifacts
-
-## Anti-Enterprise
-
-NEVER include phases for:
-- Team coordination, stakeholder management
-- Sprint ceremonies, retrospectives
-- Documentation for documentation's sake
-- Change management processes
-
-If it sounds like corporate PM theater, delete it.
-
-## Requirements Drive Structure
-
-**Derive phases from requirements. Don't impose structure.**
-
-Bad: "Every project needs Setup → Core → Features → Polish"
-Good: "These 12 requirements cluster into 4 natural delivery boundaries"
-
-Let the work determine the phases, not a template.
-
-## Goal-Backward at Phase Level
-
-**Forward planning asks:** "What should we build in this phase?"
-**Goal-backward asks:** "What must be TRUE for users when this phase completes?"
-
-Forward produces task lists. Goal-backward produces success criteria that tasks must satisfy.
-
-## Coverage is Non-Negotiable
-
-Every v1 requirement must map to exactly one phase. No orphans. No duplicates.
-
-If a requirement doesn't fit any phase → create a phase or defer to v2.
-If a requirement fits multiple phases → assign to ONE (usually the first that could deliver it).
-
-</philosophy>
+<philosophy>You are a GSD roadmapper. Decompose projects into phased execution plans driven by requirements, not templates.</philosophy>
 
 <goal_backward_phases>
 

--- a/agents/gsd-ui-auditor.md
+++ b/agents/gsd-ui-auditor.md
@@ -27,16 +27,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Write UI-REVIEW.md with actionable findings
 </role>
 
-<project_context>
-Before auditing, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill
-3. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <upstream_input>
 **UI-SPEC.md** (if exists) — Design contract from `/gsd:ui-phase`

--- a/agents/gsd-ui-checker.md
+++ b/agents/gsd-ui-checker.md
@@ -24,19 +24,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 You are read-only — never modify UI-SPEC.md. Report findings, let the researcher fix.
 </role>
 
-<project_context>
-Before verifying, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
-3. Load specific `rules/*.md` files as needed during verification
-4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-
-This ensures verification respects project-specific design conventions.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <upstream_input>
 **UI-SPEC.md** — Design contract from gsd-ui-researcher (primary input)

--- a/agents/gsd-ui-researcher.md
+++ b/agents/gsd-ui-researcher.md
@@ -27,20 +27,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Return structured result to orchestrator
 </role>
 
-<project_context>
-Before researching, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
-3. Load specific `rules/*.md` files as needed during research
-4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-5. Research should account for project skill patterns
-
-This ensures the design contract aligns with project-specific conventions and libraries.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <upstream_input>
 **CONTEXT.md** (if exists) — User decisions from `/gsd:discuss-phase`

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -22,20 +22,7 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 **Critical mindset:** Do NOT trust SUMMARY.md claims. SUMMARYs document what Claude SAID it did. You verify what ACTUALLY exists in the code. These often differ.
 </role>
 
-<project_context>
-Before verifying, discover project context:
-
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
-
-**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
-1. List available skills (subdirectories)
-2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
-3. Load specific `rules/*.md` files as needed during verification
-4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
-5. Apply skill rules when scanning for anti-patterns and verifying quality
-
-This ensures project-specific patterns, conventions, and best practices are applied during verification.
-</project_context>
+@~/.claude/gsd-ng/references/agent-shared-context.md
 
 <core_principle>
 **Task completion ≠ Goal achievement**
@@ -353,6 +340,76 @@ Categorize: 🛑 Blocker (prevents goal) | ⚠️ Warning (incomplete) | ℹ️ 
 **Expected:** {What should happen}
 **Why human:** {Why can't verify programmatically}
 ```
+
+## Step 8b: Check Related Todos (Warning Only)
+
+**Purpose:** Inform the verification report about related todos that may need attention. This is informational — it does NOT affect the overall pass/fail status and does not block verification.
+
+Check if this phase has a source todo linked via ROADMAP.md:
+
+```bash
+PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --raw 2>/dev/null || echo "{}")
+SOURCE_TODO=$(echo "$PHASE_DATA" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try { const r=JSON.parse(d); console.log(r.source_todos || ''); } catch { console.log(''); }
+  });
+")
+```
+
+If `$SOURCE_TODO` is non-empty, read its `related:` field:
+
+```bash
+RELATED_RAW=""
+# Check pending/ first, then completed/
+for DIR in ".planning/todos/pending" ".planning/todos/completed"; do
+  if [[ -f "$DIR/$SOURCE_TODO" ]]; then
+    RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+      "$DIR/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+    break
+  fi
+done
+```
+
+Normalize to array and check each related todo:
+
+```bash
+# Parse RELATED_RAW (JSON string or array) into list
+RELATED_LIST=$(echo "$RELATED_RAW" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      console.log(arr.join('\n'));
+    } catch { console.log(''); }
+  });
+")
+# For each related filename, check if it exists in pending/ (still open work)
+UNADDRESSED_TODOS=""
+while IFS= read -r related_file; do
+  [[ -z "$related_file" ]] && continue
+  if [[ -f ".planning/todos/pending/$related_file" ]]; then
+    TITLE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+      ".planning/todos/pending/$related_file" --field title --raw 2>/dev/null || echo "(no title)")
+    UNADDRESSED_TODOS="${UNADDRESSED_TODOS}| $related_file | $TITLE | pending |\n"
+  fi
+done <<< "$RELATED_LIST"
+```
+
+If `$UNADDRESSED_TODOS` is non-empty, add a **Related Todo Warnings** section to the VERIFICATION.md output. Place this section AFTER the main verification results, clearly marked as warnings. This section does NOT change `status:` from passed to gaps_found and does NOT add items to the `gaps:` frontmatter section.
+
+```markdown
+### Related Todo Warnings
+
+The following todos are linked (via `related:` field) to this phase's source todo but remain in pending/:
+
+| Todo | Title | Status |
+|------|-------|--------|
+{UNADDRESSED_TODOS rows here}
+
+These are informational warnings — related todos represent separate work items and do not block verification.
+```
+
+If no source todo exists, `$SOURCE_TODO` is empty, or no related todos are in pending/, omit this section entirely.
 
 ## Step 9: Determine Overall Status
 

--- a/gsd-ng/bin/lib/verify.cjs
+++ b/gsd-ng/bin/lib/verify.cjs
@@ -920,6 +920,55 @@ function cmdValidateHealth(cwd, options, raw) {
     }
   }
 
+  // --- Check 21: Broken related links (related: references non-existent todos) ---
+  for (const file of pendingTodosForPhaseCheck) {
+    try {
+      const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+      const fm = extractFrontmatter(content);
+      if (!fm || !fm.related) continue;
+      const relatedList = Array.isArray(fm.related) ? fm.related : (fm.related ? [fm.related] : []);
+      for (const ref of relatedList) {
+        const existsInPending = fs.existsSync(path.join(pendingTodosDir, ref));
+        const existsInCompleted = fs.existsSync(path.join(completedTodosDir, ref));
+        if (!existsInPending && !existsInCompleted) {
+          addIssue('warning', 'W021',
+            `Todo "${file}" has related: "${ref}" which does not exist in pending/ or completed/`,
+            'Remove the stale related: reference or recreate the missing todo',
+            true);
+          if (!repairs.includes('clearRelatedLink')) repairs.push('clearRelatedLink');
+        }
+      }
+    } catch (_e) { /* skip */ }
+  }
+
+  // --- Check 22: Asymmetric related links (A references B but B does not reference A back) ---
+  for (const file of pendingTodosForPhaseCheck) {
+    try {
+      const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+      const fm = extractFrontmatter(content);
+      if (!fm || !fm.related) continue;
+      const relatedList = Array.isArray(fm.related) ? fm.related : (fm.related ? [fm.related] : []);
+      for (const ref of relatedList) {
+        const refPath = path.join(pendingTodosDir, ref);
+        if (!fs.existsSync(refPath)) continue; // W021 covers missing refs — skip here
+        try {
+          const refContent = fs.readFileSync(refPath, 'utf-8');
+          const refFm = extractFrontmatter(refContent);
+          const refRelatedList = refFm && refFm.related
+            ? (Array.isArray(refFm.related) ? refFm.related : [refFm.related])
+            : [];
+          if (!refRelatedList.includes(file)) {
+            addIssue('warning', 'W022',
+              `Asymmetric related link: "${file}" references "${ref}" but "${ref}" does not reference back`,
+              'Run /gsd:health --repair to add the missing backlink, or add it manually',
+              true);
+            if (!repairs.includes('addBacklink')) repairs.push('addBacklink');
+          }
+        } catch (_e) { /* skip unreadable ref */ }
+      }
+    } catch (_e) { /* skip */ }
+  }
+
   // --- Check 20: Security events log — high-confidence detections ---
   const secLogDir = process.env.GSD_SECURITY_LOG_DIR || path.join(cwd, '.claude', 'logs');
   const secLogPath = path.join(secLogDir, 'security-events.log');

--- a/gsd-ng/references/agent-shared-context.md
+++ b/gsd-ng/references/agent-shared-context.md
@@ -1,0 +1,14 @@
+<project_context>
+Before executing, discover project context:
+
+**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
+
+**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
+1. List available skills (subdirectories)
+2. Read `SKILL.md` for each skill (lightweight index ~130 lines)
+3. Load specific `rules/*.md` files as needed during implementation
+4. Do NOT load full `AGENTS.md` files (100KB+ context cost)
+5. Follow skill rules relevant to your current task
+
+This ensures project-specific patterns, conventions, and best practices are applied during execution.
+</project_context>

--- a/gsd-ng/references/ask-user-question.md
+++ b/gsd-ng/references/ask-user-question.md
@@ -1,0 +1,28 @@
+<tool_usage>
+CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
+
+The AskUserQuestion tool accepts a `questions` array. Each question must have:
+- `question` (string) — the question text
+- `header` (string, max 12 chars) — short label shown above the question
+- `multiSelect` (boolean) — true for "select all that apply", false for single choice
+- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
+
+Example call structure:
+```json
+{
+  "questions": [
+    {
+      "question": "The question text?",
+      "header": "Choose",
+      "multiSelect": false,
+      "options": [
+        { "label": "Option A", "description": "What option A means" },
+        { "label": "Option B", "description": "What option B means" }
+      ]
+    }
+  ]
+}
+```
+
+If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
+</tool_usage>

--- a/gsd-ng/references/checkpoints-core.md
+++ b/gsd-ng/references/checkpoints-core.md
@@ -1,0 +1,120 @@
+# Checkpoints Reference — Core
+
+> Core type definitions. See also:
+> - `@~/.claude/gsd-ng/references/checkpoints-standard.md` — writing guidelines
+> - `@~/.claude/gsd-ng/references/checkpoints-deep.md` — full examples
+<overview>
+Plans execute autonomously. Checkpoints formalize interaction points where human verification or decisions are needed.
+
+**Core principle:** Claude automates everything with CLI/API. Checkpoints are for verification and decisions, not manual work.
+
+**Golden rules:**
+1. **If Claude can run it, Claude runs it** - Never ask user to execute CLI commands, start servers, or run builds
+2. **Claude sets up the verification environment** - Start dev servers, seed databases, configure env vars
+3. **User only does what requires human judgment** - Visual checks, UX evaluation, "does this feel right?"
+4. **Secrets come from user, automation comes from Claude** - Ask for API keys, then Claude uses them via CLI
+5. **Auto-mode bypasses verification/decision checkpoints** — When `workflow._auto_chain_active` or `workflow.auto_advance` is true in config: human-verify auto-approves, decision auto-selects first option, human-action still stops (auth gates cannot be automated)
+</overview>
+
+<checkpoint_types>
+
+<type name="human-verify">
+## checkpoint:human-verify (Most Common - 90%)
+
+**When:** Claude completed automated work, human confirms it works correctly.
+
+**Use for:**
+- Visual UI checks (layout, styling, responsiveness)
+- Interactive flows (click through wizard, test user flows)
+- Functional verification (feature works as expected)
+- Audio/video playback quality
+- Animation smoothness
+- Accessibility testing
+
+**Structure:**
+</task>
+
+**Example: UI Component (shows key pattern: Claude starts server BEFORE checkpoint)**
+</task>
+</task>
+</task>
+
+**Example: Xcode Build**
+</task>
+</task>
+</type>
+
+<type name="decision">
+## checkpoint:decision (9%)
+
+**When:** Human must make choice that affects implementation direction.
+
+**Use for:**
+- Technology selection (which auth provider, which database)
+- Architecture decisions (monorepo vs separate repos)
+- Design choices (color scheme, layout approach)
+- Feature prioritization (which variant to build)
+- Data model decisions (schema structure)
+
+**Structure:**
+</task>
+
+**Example: Auth Provider Selection**
+</task>
+
+**Example: Database Selection**
+</task>
+</type>
+
+<type name="human-action">
+## checkpoint:human-action (1% - Rare)
+
+**When:** Action has NO CLI/API and requires human-only interaction, OR Claude hit an authentication gate during automation.
+
+**Use ONLY for:**
+- **Authentication gates** - Claude tried CLI/API but needs credentials (this is NOT a failure)
+- Email verification links (clicking email)
+- SMS 2FA codes (phone verification)
+- Manual account approvals (platform requires human review)
+- Credit card 3D Secure flows (web-based payment authorization)
+- OAuth app approvals (web-based approval)
+
+**Do NOT use for pre-planned manual work:**
+- Deploying (use CLI - auth gate if needed)
+- Creating webhooks/databases (use API/CLI - auth gate if needed)
+- Running builds/tests (use Bash tool)
+- Creating files (use Write tool)
+
+**Structure:**
+</task>
+
+**Example: Email Verification**
+</task>
+</task>
+
+**Example: Authentication Gate (Dynamic Checkpoint)**
+</task>
+</task>
+</task>
+
+**Key distinction:** Auth gates are created dynamically when Claude encounters auth errors. NOT pre-planned — Claude automates first, asks for credentials only when blocked.
+</type>
+</checkpoint_types>
+
+<summary>
+
+Checkpoints formalize human-in-the-loop points for verification and decisions, not manual work.
+
+**The golden rule:** If Claude CAN automate it, Claude MUST automate it.
+
+**Checkpoint priority:**
+1. **checkpoint:human-verify** (90%) - Claude automated everything, human confirms visual/functional correctness
+2. **checkpoint:decision** (9%) - Human makes architectural/technology choices
+3. **checkpoint:human-action** (1%) - Truly unavoidable manual steps with no API/CLI
+
+**When NOT to use checkpoints:**
+- Things Claude can verify programmatically (tests, builds)
+- File operations (Claude can read files)
+- Code correctness (tests and static analysis)
+- Anything automatable via CLI/API
+</summary>

--- a/gsd-ng/references/checkpoints-deep.md
+++ b/gsd-ng/references/checkpoints-deep.md
@@ -1,32 +1,8 @@
-<overview>
-Plans execute autonomously. Checkpoints formalize interaction points where human verification or decisions are needed.
+# Checkpoints Reference — Deep
 
-**Core principle:** Claude automates everything with CLI/API. Checkpoints are for verification and decisions, not manual work.
-
-**Golden rules:**
-1. **If Claude can run it, Claude runs it** - Never ask user to execute CLI commands, start servers, or run builds
-2. **Claude sets up the verification environment** - Start dev servers, seed databases, configure env vars
-3. **User only does what requires human judgment** - Visual checks, UX evaluation, "does this feel right?"
-4. **Secrets come from user, automation comes from Claude** - Ask for API keys, then Claude uses them via CLI
-5. **Auto-mode bypasses verification/decision checkpoints** — When `workflow._auto_chain_active` or `workflow.auto_advance` is true in config: human-verify auto-approves, decision auto-selects first option, human-action still stops (auth gates cannot be automated)
-</overview>
-
-<checkpoint_types>
-
-<type name="human-verify">
-## checkpoint:human-verify (Most Common - 90%)
-
-**When:** Claude completed automated work, human confirms it works correctly.
-
-**Use for:**
-- Visual UI checks (layout, styling, responsiveness)
-- Interactive flows (click through wizard, test user flows)
-- Functional verification (feature works as expected)
-- Audio/video playback quality
-- Animation smoothness
-- Accessibility testing
-
-**Structure:**
+> Full examples and code templates. See also:
+> - `@~/.claude/gsd-ng/references/checkpoints-core.md` — type definitions
+> - `@~/.claude/gsd-ng/references/checkpoints-standard.md` — writing guidelines
 ```xml
 <task type="checkpoint:human-verify" gate="blocking">
   <what-built>[What Claude automated and deployed/built]</what-built>
@@ -34,10 +10,7 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
     [Exact steps to test - URLs, commands, expected behavior]
   </how-to-verify>
   <resume-signal>[How to continue - "approved", "yes", or describe issues]</resume-signal>
-</task>
 ```
-
-**Example: UI Component (shows key pattern: Claude starts server BEFORE checkpoint)**
 ```xml
 <task type="auto">
   <name>Build responsive dashboard layout</name>
@@ -45,14 +18,12 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
   <action>Create dashboard with sidebar, header, and content area. Use Tailwind responsive classes for mobile.</action>
   <verify>npm run build succeeds, no TypeScript errors</verify>
   <done>Dashboard component builds without errors</done>
-</task>
 
 <task type="auto">
   <name>Start dev server for verification</name>
   <action>Run `npm run dev` in background, wait for "ready" message, capture port</action>
   <verify>curl http://localhost:3000 returns 200</verify>
   <done>Dev server running at http://localhost:3000</done>
-</task>
 
 <task type="checkpoint:human-verify" gate="blocking">
   <what-built>Responsive dashboard layout - dev server running at http://localhost:3000</what-built>
@@ -64,10 +35,7 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
     4. No layout shift or horizontal scroll at any size
   </how-to-verify>
   <resume-signal>Type "approved" or describe layout issues</resume-signal>
-</task>
 ```
-
-**Example: Xcode Build**
 ```xml
 <task type="auto">
   <name>Build macOS app with Xcode</name>
@@ -75,7 +43,6 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
   <action>Run `xcodebuild -project App.xcodeproj -scheme App build`. Check for compilation errors in output.</action>
   <verify>Build output contains "BUILD SUCCEEDED", no errors</verify>
   <done>App builds successfully</done>
-</task>
 
 <task type="checkpoint:human-verify" gate="blocking">
   <what-built>Built macOS app at DerivedData/Build/Products/Debug/App.app</what-built>
@@ -87,23 +54,7 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
     - No visual glitches or layout issues
   </how-to-verify>
   <resume-signal>Type "approved" or describe issues</resume-signal>
-</task>
 ```
-</type>
-
-<type name="decision">
-## checkpoint:decision (9%)
-
-**When:** Human must make choice that affects implementation direction.
-
-**Use for:**
-- Technology selection (which auth provider, which database)
-- Architecture decisions (monorepo vs separate repos)
-- Design choices (color scheme, layout approach)
-- Feature prioritization (which variant to build)
-- Data model decisions (schema structure)
-
-**Structure:**
 ```xml
 <task type="checkpoint:decision" gate="blocking">
   <decision>[What's being decided]</decision>
@@ -121,10 +72,7 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
     </option>
   </options>
   <resume-signal>[How to indicate choice]</resume-signal>
-</task>
 ```
-
-**Example: Auth Provider Selection**
 ```xml
 <task type="checkpoint:decision" gate="blocking">
   <decision>Select authentication provider</decision>
@@ -149,10 +97,7 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
     </option>
   </options>
   <resume-signal>Select: supabase, clerk, or nextauth</resume-signal>
-</task>
 ```
-
-**Example: Database Selection**
 ```xml
 <task type="checkpoint:decision" gate="blocking">
   <decision>Select database for user data</decision>
@@ -178,30 +123,7 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
     </option>
   </options>
   <resume-signal>Select: supabase, planetscale, or convex</resume-signal>
-</task>
 ```
-</type>
-
-<type name="human-action">
-## checkpoint:human-action (1% - Rare)
-
-**When:** Action has NO CLI/API and requires human-only interaction, OR Claude hit an authentication gate during automation.
-
-**Use ONLY for:**
-- **Authentication gates** - Claude tried CLI/API but needs credentials (this is NOT a failure)
-- Email verification links (clicking email)
-- SMS 2FA codes (phone verification)
-- Manual account approvals (platform requires human review)
-- Credit card 3D Secure flows (web-based payment authorization)
-- OAuth app approvals (web-based approval)
-
-**Do NOT use for pre-planned manual work:**
-- Deploying (use CLI - auth gate if needed)
-- Creating webhooks/databases (use API/CLI - auth gate if needed)
-- Running builds/tests (use Bash tool)
-- Creating files (use Write tool)
-
-**Structure:**
 ```xml
 <task type="checkpoint:human-action" gate="blocking">
   <action>[What human must do - Claude already did everything automatable]</action>
@@ -211,17 +133,13 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
   </instructions>
   <verification>[What Claude can check afterward]</verification>
   <resume-signal>[How to continue]</resume-signal>
-</task>
 ```
-
-**Example: Email Verification**
 ```xml
 <task type="auto">
   <name>Create SendGrid account via API</name>
   <action>Use SendGrid API to create subuser account with provided email. Request verification email.</action>
   <verify>API returns 201, account created</verify>
   <done>Account created, verification email sent</done>
-</task>
 
 <task type="checkpoint:human-action" gate="blocking">
   <action>Complete email verification for SendGrid account</action>
@@ -231,17 +149,13 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
   </instructions>
   <verification>SendGrid API key works: curl test succeeds</verification>
   <resume-signal>Type "done" when email verified</resume-signal>
-</task>
 ```
-
-**Example: Authentication Gate (Dynamic Checkpoint)**
 ```xml
 <task type="auto">
   <name>Deploy to Vercel</name>
   <files>.vercel/, vercel.json</files>
   <action>Run `vercel --yes` to deploy</action>
   <verify>vercel ls shows deployment, curl returns 200</verify>
-</task>
 
 <!-- If vercel returns "Error: Not authenticated", Claude creates checkpoint on the fly -->
 
@@ -254,7 +168,6 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
   </instructions>
   <verification>vercel whoami returns your account email</verification>
   <resume-signal>Type "done" when authenticated</resume-signal>
-</task>
 
 <!-- After authentication, Claude retries the deployment -->
 
@@ -262,24 +175,7 @@ Plans execute autonomously. Checkpoints formalize interaction points where human
   <name>Retry Vercel deployment</name>
   <action>Run `vercel --yes` (now authenticated)</action>
   <verify>vercel ls shows deployment, curl returns 200</verify>
-</task>
 ```
-
-**Key distinction:** Auth gates are created dynamically when Claude encounters auth errors. NOT pre-planned — Claude automates first, asks for credentials only when blocked.
-</type>
-</checkpoint_types>
-
-<execution_protocol>
-
-When Claude encounters `type="checkpoint:*"`:
-
-1. **Stop immediately** - do not proceed to next task
-2. **Display checkpoint clearly** using the format below
-3. **Wait for user response** - do not hallucinate completion
-4. **Verify if possible** - check files, run tests, whatever is specified
-5. **Resume execution** - continue to next task only after confirmation
-
-**For checkpoint:human-verify:**
 ```
 ╔═══════════════════════════════════════════════════════╗
 ║  CHECKPOINT: Verification Required                    ║
@@ -300,8 +196,6 @@ How to verify:
 → YOUR ACTION: Type "approved" or describe issues
 ────────────────────────────────────────────────────────
 ```
-
-**For checkpoint:decision:**
 ```
 ╔═══════════════════════════════════════════════════════╗
 ║  CHECKPOINT: Decision Required                        ║
@@ -331,8 +225,6 @@ Options:
 → YOUR ACTION: Select supabase, clerk, or nextauth
 ────────────────────────────────────────────────────────
 ```
-
-**For checkpoint:human-action:**
 ```
 ╔═══════════════════════════════════════════════════════╗
 ║  CHECKPOINT: Action Required                          ║
@@ -355,70 +247,11 @@ I'll verify: vercel whoami returns your account
 → YOUR ACTION: Type "done" when authenticated
 ────────────────────────────────────────────────────────
 ```
-</execution_protocol>
-
-<authentication_gates>
-
-**Auth gate = Claude tried CLI/API, got auth error.** Not a failure — a gate requiring human input to unblock.
-
-**Pattern:** Claude tries automation → auth error → creates checkpoint:human-action → user authenticates → Claude retries → continues
-
-**Gate protocol:**
-1. Recognize it's not a failure - missing auth is expected
-2. Stop current task - don't retry repeatedly
-3. Create checkpoint:human-action dynamically
-4. Provide exact authentication steps
-5. Verify authentication works
-6. Retry the original task
-7. Continue normally
-
-**Key distinction:**
-- Pre-planned checkpoint: "I need you to do X" (wrong - Claude should automate)
-- Auth gate: "I tried to automate X but need credentials" (correct - unblocks automation)
-
-</authentication_gates>
-
-<automation_reference>
-
-**The rule:** If it has CLI/API, Claude does it. Never ask human to perform automatable work.
-
-## Service CLI Reference
-
-| Service | CLI/API | Key Commands | Auth Gate |
-|---------|---------|--------------|-----------|
-| Vercel | `vercel` | `--yes`, `env add`, `--prod`, `ls` | `vercel login` |
-| Railway | `railway` | `init`, `up`, `variables set` | `railway login` |
-| Fly | `fly` | `launch`, `deploy`, `secrets set` | `fly auth login` |
-| Stripe | `stripe` + API | `listen`, `trigger`, API calls | API key in .env |
-| Supabase | `supabase` | `init`, `link`, `db push`, `gen types` | `supabase login` |
-| Upstash | `upstash` | `redis create`, `redis get` | `upstash auth login` |
-| PlanetScale | `pscale` | `database create`, `branch create` | `pscale auth login` |
-| GitHub | `gh` | `repo create`, `pr create`, `secret set` | `gh auth login` |
-| Node | `npm`/`pnpm` | `install`, `run build`, `test`, `run dev` | N/A |
-| Xcode | `xcodebuild` | `-project`, `-scheme`, `build`, `test` | N/A |
-| Convex | `npx convex` | `dev`, `deploy`, `env set`, `env get` | `npx convex login` |
-
-## Environment Variable Automation
-
-**Env files:** Use Write/Edit tools. Never ask human to create .env manually.
-
-**Dashboard env vars via CLI:**
-
-| Platform | CLI Command | Example |
-|----------|-------------|---------|
-| Convex | `npx convex env set` | `npx convex env set OPENAI_API_KEY sk-...` |
-| Vercel | `vercel env add` | `vercel env add STRIPE_KEY production` |
-| Railway | `railway variables set` | `railway variables set API_KEY=value` |
-| Fly | `fly secrets set` | `fly secrets set DATABASE_URL=...` |
-| Supabase | `supabase secrets set` | `supabase secrets set MY_SECRET=value` |
-
-**Secret collection pattern:**
 ```xml
 <!-- WRONG: Asking user to add env vars in dashboard -->
 <task type="checkpoint:human-action">
   <action>Add OPENAI_API_KEY to Convex dashboard</action>
   <instructions>Go to dashboard.convex.dev → Settings → Environment Variables → Add</instructions>
-</task>
 
 <!-- RIGHT: Claude asks for value, then adds via CLI -->
 <task type="checkpoint:human-action">
@@ -430,26 +263,12 @@ I'll verify: vercel whoami returns your account
   </instructions>
   <verification>I'll add it via `npx convex env set` and verify</verification>
   <resume-signal>Paste your API key</resume-signal>
-</task>
 
 <task type="auto">
   <name>Configure OpenAI key in Convex</name>
   <action>Run `npx convex env set OPENAI_API_KEY {user-provided-key}`</action>
   <verify>`npx convex env get OPENAI_API_KEY` returns the key (masked)</verify>
-</task>
 ```
-
-## Dev Server Automation
-
-| Framework | Start Command | Ready Signal | Default URL |
-|-----------|---------------|--------------|-------------|
-| Next.js | `npm run dev` | "Ready in" or "started server" | http://localhost:3000 |
-| Vite | `npm run dev` | "ready in" | http://localhost:5173 |
-| Convex | `npx convex dev` | "Convex functions ready" | N/A (backend only) |
-| Express | `npm start` | "listening on port" | http://localhost:3000 |
-| Django | `python manage.py runserver` | "Starting development server" | http://localhost:8000 |
-
-**Server lifecycle:**
 ```bash
 # Run in background, capture PID
 npm run dev &
@@ -458,104 +277,22 @@ DEV_SERVER_PID=$!
 # Wait for ready (max 30s)
 timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; done'
 ```
-
-**Port conflicts:** Kill stale process (`lsof -ti:3000 | xargs kill`) or use alternate port (`--port 3001`).
-
-**Server stays running** through checkpoints. Only kill when plan complete, switching to production, or port needed for different service.
-
-## CLI Installation Handling
-
-| CLI | Auto-install? | Command |
-|-----|---------------|---------|
-| npm/pnpm/yarn | No - ask user | User chooses package manager |
-| vercel | Yes | `npm i -g vercel` |
-| gh (GitHub) | Yes | `brew install gh` (macOS) or `apt install gh` (Linux) |
-| stripe | Yes | `npm i -g stripe` |
-| supabase | Yes | `npm i -g supabase` |
-| convex | No - use npx | `npx convex` (no install needed) |
-| fly | Yes | `brew install flyctl` or curl installer |
-| railway | Yes | `npm i -g @railway/cli` |
-
-**Protocol:** Try command → "command not found" → auto-installable? → yes: install silently, retry → no: checkpoint asking user to install.
-
-## Pre-Checkpoint Automation Failures
-
-| Failure | Response |
-|---------|----------|
-| Server won't start | Check error, fix issue, retry (don't proceed to checkpoint) |
-| Port in use | Kill stale process or use alternate port |
-| Missing dependency | Run `npm install`, retry |
-| Build error | Fix the error first (bug, not checkpoint issue) |
-| Auth error | Create auth gate checkpoint |
-| Network timeout | Retry with backoff, then checkpoint if persistent |
-
-**Never present a checkpoint with broken verification environment.** If `curl localhost:3000` fails, don't ask user to "visit localhost:3000".
-
 ```xml
 <!-- WRONG: Checkpoint with broken environment -->
 <task type="checkpoint:human-verify">
   <what-built>Dashboard (server failed to start)</what-built>
   <how-to-verify>Visit http://localhost:3000...</how-to-verify>
-</task>
 
 <!-- RIGHT: Fix first, then checkpoint -->
 <task type="auto">
   <name>Fix server startup issue</name>
   <action>Investigate error, fix root cause, restart server</action>
   <verify>curl http://localhost:3000 returns 200</verify>
-</task>
 
 <task type="checkpoint:human-verify">
   <what-built>Dashboard - server running at http://localhost:3000</what-built>
   <how-to-verify>Visit http://localhost:3000/dashboard...</how-to-verify>
-</task>
 ```
-
-## Automatable Quick Reference
-
-| Action | Automatable? | Claude does it? |
-|--------|--------------|-----------------|
-| Deploy to Vercel | Yes (`vercel`) | YES |
-| Create Stripe webhook | Yes (API) | YES |
-| Write .env file | Yes (Write tool) | YES |
-| Create Upstash DB | Yes (`upstash`) | YES |
-| Run tests | Yes (`npm test`) | YES |
-| Start dev server | Yes (`npm run dev`) | YES |
-| Add env vars to Convex | Yes (`npx convex env set`) | YES |
-| Add env vars to Vercel | Yes (`vercel env add`) | YES |
-| Seed database | Yes (CLI/API) | YES |
-| Click email verification link | No | NO |
-| Enter credit card with 3DS | No | NO |
-| Complete OAuth in browser | No | NO |
-| Visually verify UI looks correct | No | NO |
-| Test interactive user flows | No | NO |
-
-</automation_reference>
-
-<writing_guidelines>
-
-**DO:**
-- Automate everything with CLI/API before checkpoint
-- Be specific: "Visit https://myapp.vercel.app" not "check deployment"
-- Number verification steps
-- State expected outcomes: "You should see X"
-- Provide context: why this checkpoint exists
-
-**DON'T:**
-- Ask human to do work Claude can automate ❌
-- Assume knowledge: "Configure the usual settings" ❌
-- Skip steps: "Set up database" (too vague) ❌
-- Mix multiple verifications in one checkpoint ❌
-
-**Placement:**
-- **After automation completes** - not before Claude does the work
-- **After UI buildout** - before declaring phase complete
-- **Before dependent work** - decisions before implementation
-- **At integration points** - after configuring external services
-
-**Bad placement:** Before automation ❌ | Too frequent ❌ | Too late (dependent tasks already needed the result) ❌
-</writing_guidelines>
-
 <examples>
 
 ### Example 1: Database Setup (No Checkpoint Needed)
@@ -630,7 +367,7 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 
 <anti_patterns>
 
-### ❌ BAD: Asking user to start dev server
+### Bad: Asking user to start dev server
 
 ```xml
 <task type="checkpoint:human-verify" gate="blocking">
@@ -645,7 +382,7 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 
 **Why bad:** Claude can run `npm run dev`. User should only visit URLs, not execute commands.
 
-### ✅ GOOD: Claude starts server, user visits
+### Good: Claude starts server, user visits
 
 ```xml
 <task type="auto">
@@ -664,7 +401,7 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 </task>
 ```
 
-### ❌ BAD: Asking human to deploy / ✅ GOOD: Claude automates
+### Bad: Asking human to deploy / Good: Claude automates
 
 ```xml
 <!-- BAD: Asking user to deploy via dashboard -->
@@ -687,7 +424,7 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 </task>
 ```
 
-### ❌ BAD: Too many checkpoints / ✅ GOOD: Single checkpoint
+### Bad: Too many checkpoints / Good: Single checkpoint
 
 ```xml
 <!-- BAD: Checkpoint after every task -->
@@ -710,7 +447,7 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 </task>
 ```
 
-### ❌ BAD: Vague verification / ✅ GOOD: Specific steps
+### Bad: Vague verification / Good: Specific steps
 
 ```xml
 <!-- BAD -->
@@ -733,7 +470,7 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 </task>
 ```
 
-### ❌ BAD: Asking user to run CLI commands
+### Bad: Asking user to run CLI commands
 
 ```xml
 <task type="checkpoint:human-action">
@@ -744,7 +481,7 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 
 **Why bad:** Claude can run these commands. User should never execute CLI commands.
 
-### ❌ BAD: Asking user to copy values between services
+### Bad: Asking user to copy values between services
 
 ```xml
 <task type="checkpoint:human-action">
@@ -756,21 +493,3 @@ timeout 30 bash -c 'until curl -s localhost:3000 > /dev/null 2>&1; do sleep 1; d
 **Why bad:** Stripe has an API. Claude should create the webhook via API and write to .env directly.
 
 </anti_patterns>
-
-<summary>
-
-Checkpoints formalize human-in-the-loop points for verification and decisions, not manual work.
-
-**The golden rule:** If Claude CAN automate it, Claude MUST automate it.
-
-**Checkpoint priority:**
-1. **checkpoint:human-verify** (90%) - Claude automated everything, human confirms visual/functional correctness
-2. **checkpoint:decision** (9%) - Human makes architectural/technology choices
-3. **checkpoint:human-action** (1%) - Truly unavoidable manual steps with no API/CLI
-
-**When NOT to use checkpoints:**
-- Things Claude can verify programmatically (tests, builds)
-- File operations (Claude can read files)
-- Code correctness (tests and static analysis)
-- Anything automatable via CLI/API
-</summary>

--- a/gsd-ng/references/checkpoints-standard.md
+++ b/gsd-ng/references/checkpoints-standard.md
@@ -1,0 +1,174 @@
+# Checkpoints Reference — Standard
+
+> Writing guidelines and patterns. See also:
+> - `@~/.claude/gsd-ng/references/checkpoints-core.md` — type definitions
+> - `@~/.claude/gsd-ng/references/checkpoints-deep.md` — full examples
+<execution_protocol>
+
+When Claude encounters `type="checkpoint:*"`:
+
+1. **Stop immediately** - do not proceed to next task
+2. **Display checkpoint clearly** using the format below
+3. **Wait for user response** - do not hallucinate completion
+4. **Verify if possible** - check files, run tests, whatever is specified
+5. **Resume execution** - continue to next task only after confirmation
+
+**For checkpoint:human-verify:**
+
+**For checkpoint:decision:**
+
+**For checkpoint:human-action:**
+</execution_protocol>
+
+<authentication_gates>
+
+**Auth gate = Claude tried CLI/API, got auth error.** Not a failure — a gate requiring human input to unblock.
+
+**Pattern:** Claude tries automation → auth error → creates checkpoint:human-action → user authenticates → Claude retries → continues
+
+**Gate protocol:**
+1. Recognize it's not a failure - missing auth is expected
+2. Stop current task - don't retry repeatedly
+3. Create checkpoint:human-action dynamically
+4. Provide exact authentication steps
+5. Verify authentication works
+6. Retry the original task
+7. Continue normally
+
+**Key distinction:**
+- Pre-planned checkpoint: "I need you to do X" (wrong - Claude should automate)
+- Auth gate: "I tried to automate X but need credentials" (correct - unblocks automation)
+
+</authentication_gates>
+
+<automation_reference>
+
+**The rule:** If it has CLI/API, Claude does it. Never ask human to perform automatable work.
+
+## Service CLI Reference
+
+| Service | CLI/API | Key Commands | Auth Gate |
+|---------|---------|--------------|-----------|
+| Vercel | `vercel` | `--yes`, `env add`, `--prod`, `ls` | `vercel login` |
+| Railway | `railway` | `init`, `up`, `variables set` | `railway login` |
+| Fly | `fly` | `launch`, `deploy`, `secrets set` | `fly auth login` |
+| Stripe | `stripe` + API | `listen`, `trigger`, API calls | API key in .env |
+| Supabase | `supabase` | `init`, `link`, `db push`, `gen types` | `supabase login` |
+| Upstash | `upstash` | `redis create`, `redis get` | `upstash auth login` |
+| PlanetScale | `pscale` | `database create`, `branch create` | `pscale auth login` |
+| GitHub | `gh` | `repo create`, `pr create`, `secret set` | `gh auth login` |
+| Node | `npm`/`pnpm` | `install`, `run build`, `test`, `run dev` | N/A |
+| Xcode | `xcodebuild` | `-project`, `-scheme`, `build`, `test` | N/A |
+| Convex | `npx convex` | `dev`, `deploy`, `env set`, `env get` | `npx convex login` |
+
+## Environment Variable Automation
+
+**Env files:** Use Write/Edit tools. Never ask human to create .env manually.
+
+**Dashboard env vars via CLI:**
+
+| Platform | CLI Command | Example |
+|----------|-------------|---------|
+| Convex | `npx convex env set` | `npx convex env set OPENAI_API_KEY sk-...` |
+| Vercel | `vercel env add` | `vercel env add STRIPE_KEY production` |
+| Railway | `railway variables set` | `railway variables set API_KEY=value` |
+| Fly | `fly secrets set` | `fly secrets set DATABASE_URL=...` |
+| Supabase | `supabase secrets set` | `supabase secrets set MY_SECRET=value` |
+
+**Secret collection pattern:**
+</task>
+</task>
+</task>
+
+## Dev Server Automation
+
+| Framework | Start Command | Ready Signal | Default URL |
+|-----------|---------------|--------------|-------------|
+| Next.js | `npm run dev` | "Ready in" or "started server" | http://localhost:3000 |
+| Vite | `npm run dev` | "ready in" | http://localhost:5173 |
+| Convex | `npx convex dev` | "Convex functions ready" | N/A (backend only) |
+| Express | `npm start` | "listening on port" | http://localhost:3000 |
+| Django | `python manage.py runserver` | "Starting development server" | http://localhost:8000 |
+
+**Server lifecycle:**
+
+**Port conflicts:** Kill stale process (`lsof -ti:3000 | xargs kill`) or use alternate port (`--port 3001`).
+
+**Server stays running** through checkpoints. Only kill when plan complete, switching to production, or port needed for different service.
+
+## CLI Installation Handling
+
+| CLI | Auto-install? | Command |
+|-----|---------------|---------|
+| npm/pnpm/yarn | No - ask user | User chooses package manager |
+| vercel | Yes | `npm i -g vercel` |
+| gh (GitHub) | Yes | `brew install gh` (macOS) or `apt install gh` (Linux) |
+| stripe | Yes | `npm i -g stripe` |
+| supabase | Yes | `npm i -g supabase` |
+| convex | No - use npx | `npx convex` (no install needed) |
+| fly | Yes | `brew install flyctl` or curl installer |
+| railway | Yes | `npm i -g @railway/cli` |
+
+**Protocol:** Try command → "command not found" → auto-installable? → yes: install silently, retry → no: checkpoint asking user to install.
+
+## Pre-Checkpoint Automation Failures
+
+| Failure | Response |
+|---------|----------|
+| Server won't start | Check error, fix issue, retry (don't proceed to checkpoint) |
+| Port in use | Kill stale process or use alternate port |
+| Missing dependency | Run `npm install`, retry |
+| Build error | Fix the error first (bug, not checkpoint issue) |
+| Auth error | Create auth gate checkpoint |
+| Network timeout | Retry with backoff, then checkpoint if persistent |
+
+**Never present a checkpoint with broken verification environment.** If `curl localhost:3000` fails, don't ask user to "visit localhost:3000".
+
+</task>
+</task>
+</task>
+
+## Automatable Quick Reference
+
+| Action | Automatable? | Claude does it? |
+|--------|--------------|-----------------|
+| Deploy to Vercel | Yes (`vercel`) | YES |
+| Create Stripe webhook | Yes (API) | YES |
+| Write .env file | Yes (Write tool) | YES |
+| Create Upstash DB | Yes (`upstash`) | YES |
+| Run tests | Yes (`npm test`) | YES |
+| Start dev server | Yes (`npm run dev`) | YES |
+| Add env vars to Convex | Yes (`npx convex env set`) | YES |
+| Add env vars to Vercel | Yes (`vercel env add`) | YES |
+| Seed database | Yes (CLI/API) | YES |
+| Click email verification link | No | NO |
+| Enter credit card with 3DS | No | NO |
+| Complete OAuth in browser | No | NO |
+| Visually verify UI looks correct | No | NO |
+| Test interactive user flows | No | NO |
+
+</automation_reference>
+
+<writing_guidelines>
+
+**DO:**
+- Automate everything with CLI/API before checkpoint
+- Be specific: "Visit https://myapp.vercel.app" not "check deployment"
+- Number verification steps
+- State expected outcomes: "You should see X"
+- Provide context: why this checkpoint exists
+
+**DON'T:**
+- Ask human to do work Claude can automate ❌
+- Assume knowledge: "Configure the usual settings" ❌
+- Skip steps: "Set up database" (too vague) ❌
+- Mix multiple verifications in one checkpoint ❌
+
+**Placement:**
+- **After automation completes** - not before Claude does the work
+- **After UI buildout** - before declaring phase complete
+- **Before dependent work** - decisions before implementation
+- **At integration points** - after configuring external services
+
+**Bad placement:** Before automation ❌ | Too frequent ❌ | Too late (dependent tasks already needed the result) ❌
+</writing_guidelines>

--- a/gsd-ng/references/verification-patterns-core.md
+++ b/gsd-ng/references/verification-patterns-core.md
@@ -1,0 +1,40 @@
+# Verification Patterns — Core
+
+> Pattern names and one-line descriptions. See also:
+> - `@~/.claude/gsd-ng/references/verification-patterns-standard.md` — full descriptions
+> - `@~/.claude/gsd-ng/references/verification-patterns-deep.md` — code examples
+## Universal Stub Patterns
+## React/Next.js Components
+## API Routes (Next.js App Router / Express / etc.)
+## Database Schema (Prisma / Drizzle / SQL)
+## Custom Hooks and Utilities
+## Environment Variables and Configuration
+## Wiring Verification Patterns
+### Pattern: Component → API
+### Pattern: API → Database
+### Pattern: Form → Handler
+### Pattern: State → Render
+## Quick Verification Checklist
+### Component Checklist
+- [ ] File exists at expected path
+- [ ] Exports a function/const component
+- [ ] Returns JSX (not null/empty)
+### API Route Checklist
+- [ ] File exists at expected path
+- [ ] Exports HTTP method handlers
+- [ ] Handlers have more than 5 lines
+### Schema Checklist
+- [ ] Model/table defined
+- [ ] Has all expected fields
+- [ ] Fields have appropriate types
+### Hook/Utility Checklist
+- [ ] File exists at expected path
+- [ ] Exports function
+- [ ] Has meaningful implementation (not empty returns)
+### Wiring Checklist
+- [ ] Component → API: fetch/axios call exists and uses response
+- [ ] API → Database: query exists and result returned
+- [ ] Form → Handler: onSubmit calls API/mutation
+## Automated Verification Approach
+## When to Require Human Verification
+## Pre-Checkpoint Automation

--- a/gsd-ng/references/verification-patterns-deep.md
+++ b/gsd-ng/references/verification-patterns-deep.md
@@ -1,70 +1,36 @@
-# Verification Patterns
+# Verification Patterns — Deep
 
-How to verify different types of artifacts are real implementations, not stubs or placeholders.
-
-<core_principle>
-**Existence ≠ Implementation**
-
-A file existing does not mean the feature works. Verification must check:
-1. **Exists** - File is present at expected path
-2. **Substantive** - Content is real implementation, not placeholder
-3. **Wired** - Connected to the rest of the system
-4. **Functional** - Actually works when invoked
-
-Levels 1-3 can be checked programmatically. Level 4 often requires human verification.
-</core_principle>
-
-<stub_detection>
-
-## Universal Stub Patterns
-
-These patterns indicate placeholder code regardless of file type:
-
-**Comment-based stubs:**
+> Full code examples for all verification patterns. See also:
+> - `@~/.claude/gsd-ng/references/verification-patterns-core.md` — quick reference
+> - `@~/.claude/gsd-ng/references/verification-patterns-standard.md` — full descriptions
 ```bash
 # Grep patterns for stub comments
 grep -E "(TODO|FIXME|XXX|HACK|PLACEHOLDER)" "$file"
 grep -E "implement|add later|coming soon|will be" "$file" -i
 grep -E "// \.\.\.|/\* \.\.\. \*/|# \.\.\." "$file"
 ```
-
-**Placeholder text in output:**
 ```bash
 # UI placeholder patterns
 grep -E "placeholder|lorem ipsum|coming soon|under construction" "$file" -i
 grep -E "sample|example|test data|dummy" "$file" -i
 grep -E "\[.*\]|<.*>|\{.*\}" "$file"  # Template brackets left in
 ```
-
-**Empty or trivial implementations:**
 ```bash
 # Functions that do nothing
 grep -E "return null|return undefined|return \{\}|return \[\]" "$file"
 grep -E "pass$|\.\.\.|\bnothing\b" "$file"
 grep -E "console\.(log|warn|error).*only" "$file"  # Log-only functions
 ```
-
-**Hardcoded values where dynamic expected:**
 ```bash
 # Hardcoded IDs, counts, or content
 grep -E "id.*=.*['\"].*['\"]" "$file"  # Hardcoded string IDs
 grep -E "count.*=.*\d+|length.*=.*\d+" "$file"  # Hardcoded counts
 grep -E "\\\$\d+\.\d{2}|\d+ items" "$file"  # Hardcoded display values
 ```
-
-</stub_detection>
-
-<react_components>
-
-## React/Next.js Components
-
-**Existence check:**
 ```bash
 # File exists and exports component
 [ -f "$component_path" ] && grep -E "export (default |)function|export const.*=.*\(" "$component_path"
 ```
-
-**Substantive check:**
 ```bash
 # Returns actual JSX, not placeholder
 grep -E "return.*<" "$component_path" | grep -v "return.*null" | grep -v "placeholder" -i
@@ -75,8 +41,6 @@ grep -E "<[A-Z][a-zA-Z]+|className=|onClick=|onChange=" "$component_path"
 # Uses props or state (not static)
 grep -E "props\.|useState|useEffect|useContext|\{.*\}" "$component_path"
 ```
-
-**Stub patterns specific to React:**
 ```javascript
 // RED FLAGS - These are stubs:
 return <div>Component</div>
@@ -91,8 +55,6 @@ onClick={() => {}}
 onChange={() => console.log('clicked')}
 onSubmit={(e) => e.preventDefault()}  // Only prevents default, does nothing
 ```
-
-**Wiring check:**
 ```bash
 # Component imports what it needs
 grep -E "^import.*from" "$component_path"
@@ -104,20 +66,6 @@ grep -E "\{ .* \}.*props|\bprops\.[a-zA-Z]+" "$component_path"
 # API calls exist (for data-fetching components)
 grep -E "fetch\(|axios\.|useSWR|useQuery|getServerSideProps|getStaticProps" "$component_path"
 ```
-
-**Functional verification (human required):**
-- Does the component render visible content?
-- Do interactive elements respond to clicks?
-- Does data load and display?
-- Do error states show appropriately?
-
-</react_components>
-
-<api_routes>
-
-## API Routes (Next.js App Router / Express / etc.)
-
-**Existence check:**
 ```bash
 # Route file exists
 [ -f "$route_path" ]
@@ -128,8 +76,6 @@ grep -E "export (async )?(function|const) (GET|POST|PUT|PATCH|DELETE)" "$route_p
 # Or Express-style handlers
 grep -E "\.(get|post|put|patch|delete)\(" "$route_path"
 ```
-
-**Substantive check:**
 ```bash
 # Has actual logic, not just return statement
 wc -l "$route_path"  # More than 10-15 lines suggests real implementation
@@ -143,8 +89,6 @@ grep -E "try|catch|throw|error|Error" "$route_path"
 # Returns meaningful response
 grep -E "Response\.json|res\.json|res\.send|return.*\{" "$route_path" | grep -v "message.*not implemented" -i
 ```
-
-**Stub patterns specific to API routes:**
 ```typescript
 // RED FLAGS - These are stubs:
 export async function POST() {
@@ -165,8 +109,6 @@ export async function POST(req) {
   return Response.json({ ok: true })
 }
 ```
-
-**Wiring check:**
 ```bash
 # Imports database/service clients
 grep -E "^import.*prisma|^import.*db|^import.*client" "$route_path"
@@ -177,20 +119,6 @@ grep -E "req\.json\(\)|req\.body|request\.json\(\)" "$route_path"
 # Validates input (not just trusting request)
 grep -E "schema\.parse|validate|zod|yup|joi" "$route_path"
 ```
-
-**Functional verification (human or automated):**
-- Does GET return real data from database?
-- Does POST actually create a record?
-- Does error response have correct status code?
-- Are auth checks actually enforced?
-
-</api_routes>
-
-<database_schema>
-
-## Database Schema (Prisma / Drizzle / SQL)
-
-**Existence check:**
 ```bash
 # Schema file exists
 [ -f "prisma/schema.prisma" ] || [ -f "drizzle/schema.ts" ] || [ -f "src/db/schema.sql" ]
@@ -198,8 +126,6 @@ grep -E "schema\.parse|validate|zod|yup|joi" "$route_path"
 # Model/table is defined
 grep -E "^model $model_name|CREATE TABLE $table_name|export const $table_name" "$schema_path"
 ```
-
-**Substantive check:**
 ```bash
 # Has expected fields (not just id)
 grep -A 20 "model $model_name" "$schema_path" | grep -E "^\s+\w+\s+\w+"
@@ -210,8 +136,6 @@ grep -E "@relation|REFERENCES|FOREIGN KEY" "$schema_path"
 # Has appropriate field types (not all String)
 grep -A 20 "model $model_name" "$schema_path" | grep -E "Int|DateTime|Boolean|Float|Decimal|Json"
 ```
-
-**Stub patterns specific to schemas:**
 ```prisma
 // RED FLAGS - These are stubs:
 model User {
@@ -230,8 +154,6 @@ model Order {
   // No: userId, items, total, status, createdAt
 }
 ```
-
-**Wiring check:**
 ```bash
 # Migrations exist and are applied
 ls prisma/migrations/ 2>/dev/null | wc -l  # Should be > 0
@@ -240,26 +162,14 @@ npx prisma migrate status 2>/dev/null | grep -v "pending"
 # Client is generated
 [ -d "node_modules/.prisma/client" ]
 ```
-
-**Functional verification:**
 ```bash
 # Can query the table (automated)
 npx prisma db execute --stdin <<< "SELECT COUNT(*) FROM $table_name"
 ```
-
-</database_schema>
-
-<hooks_utilities>
-
-## Custom Hooks and Utilities
-
-**Existence check:**
 ```bash
 # File exists and exports function
 [ -f "$hook_path" ] && grep -E "export (default )?(function|const)" "$hook_path"
 ```
-
-**Substantive check:**
 ```bash
 # Hook uses React hooks (for custom hooks)
 grep -E "useState|useEffect|useCallback|useMemo|useRef|useContext" "$hook_path"
@@ -270,8 +180,6 @@ grep -E "return \{|return \[" "$hook_path"
 # More than trivial length
 [ $(wc -l < "$hook_path") -gt 10 ]
 ```
-
-**Stub patterns specific to hooks:**
 ```typescript
 // RED FLAGS - These are stubs:
 export function useAuth() {
@@ -288,8 +196,6 @@ export function useUser() {
   return { name: "Test User", email: "test@example.com" }
 }
 ```
-
-**Wiring check:**
 ```bash
 # Hook is actually imported somewhere
 grep -r "import.*$hook_name" src/ --include="*.tsx" --include="*.ts" | grep -v "$hook_path"
@@ -297,14 +203,6 @@ grep -r "import.*$hook_name" src/ --include="*.tsx" --include="*.ts" | grep -v "
 # Hook is actually called
 grep -r "$hook_name()" src/ --include="*.tsx" --include="*.ts" | grep -v "$hook_path"
 ```
-
-</hooks_utilities>
-
-<environment_config>
-
-## Environment Variables and Configuration
-
-**Existence check:**
 ```bash
 # .env file exists
 [ -f ".env" ] || [ -f ".env.local" ]
@@ -312,8 +210,6 @@ grep -r "$hook_name()" src/ --include="*.tsx" --include="*.ts" | grep -v "$hook_
 # Required variable is defined
 grep -E "^$VAR_NAME=" .env .env.local 2>/dev/null
 ```
-
-**Substantive check:**
 ```bash
 # Variable has actual value (not placeholder)
 grep -E "^$VAR_NAME=.+" .env .env.local 2>/dev/null | grep -v "your-.*-here|xxx|placeholder|TODO" -i
@@ -323,8 +219,6 @@ grep -E "^$VAR_NAME=.+" .env .env.local 2>/dev/null | grep -v "your-.*-here|xxx|
 # - Keys should be long enough
 # - Booleans should be true/false
 ```
-
-**Stub patterns specific to env:**
 ```bash
 # RED FLAGS - These are stubs:
 DATABASE_URL=your-database-url-here
@@ -332,8 +226,6 @@ STRIPE_SECRET_KEY=sk_test_xxx
 API_KEY=placeholder
 NEXT_PUBLIC_API_URL=http://localhost:3000  # Still pointing to localhost in prod
 ```
-
-**Wiring check:**
 ```bash
 # Variable is actually used in code
 grep -r "process\.env\.$VAR_NAME|env\.$VAR_NAME" src/ --include="*.ts" --include="*.tsx"
@@ -341,19 +233,6 @@ grep -r "process\.env\.$VAR_NAME|env\.$VAR_NAME" src/ --include="*.ts" --include
 # Variable is in validation schema (if using zod/etc for env)
 grep -E "$VAR_NAME" src/env.ts src/env.mjs 2>/dev/null
 ```
-
-</environment_config>
-
-<wiring_verification>
-
-## Wiring Verification Patterns
-
-Wiring verification checks that components actually communicate. This is where most stubs hide.
-
-### Pattern: Component → API
-
-**Check:** Does the component actually call the API?
-
 ```bash
 # Find the fetch/axios call
 grep -E "fetch\(['\"].*$api_path|axios\.(get|post).*$api_path" "$component_path"
@@ -364,8 +243,6 @@ grep -E "fetch\(|axios\." "$component_path" | grep -v "^.*//.*fetch"
 # Check the response is used
 grep -E "await.*fetch|\.then\(|setData|setState" "$component_path"
 ```
-
-**Red flags:**
 ```typescript
 // Fetch exists but response ignored:
 fetch('/api/messages')  // No await, no .then, no assignment
@@ -376,11 +253,6 @@ fetch('/api/messages')  // No await, no .then, no assignment
 // Fetch to wrong endpoint:
 fetch('/api/message')  // Typo - should be /api/messages
 ```
-
-### Pattern: API → Database
-
-**Check:** Does the API route actually query the database?
-
 ```bash
 # Find the database call
 grep -E "prisma\.$model|db\.query|Model\.find" "$route_path"
@@ -391,8 +263,6 @@ grep -E "await.*prisma|await.*db\." "$route_path"
 # Check result is returned
 grep -E "return.*json.*data|res\.json.*result" "$route_path"
 ```
-
-**Red flags:**
 ```typescript
 // Query exists but result not returned:
 await prisma.message.findMany()
@@ -402,11 +272,6 @@ return Response.json({ ok: true })  // Returns static, not query result
 const messages = prisma.message.findMany()  // Missing await
 return Response.json(messages)  // Returns Promise, not data
 ```
-
-### Pattern: Form → Handler
-
-**Check:** Does the form submission actually do something?
-
 ```bash
 # Find onSubmit handler
 grep -E "onSubmit=\{|handleSubmit" "$component_path"
@@ -417,8 +282,6 @@ grep -A 10 "onSubmit.*=" "$component_path" | grep -E "fetch|axios|mutate|dispatc
 # Verify not just preventDefault
 grep -A 5 "onSubmit" "$component_path" | grep -v "only.*preventDefault" -i
 ```
-
-**Red flags:**
 ```typescript
 // Handler only prevents default:
 onSubmit={(e) => e.preventDefault()}
@@ -431,11 +294,6 @@ const handleSubmit = (data) => {
 // Handler is empty:
 onSubmit={() => {}}
 ```
-
-### Pattern: State → Render
-
-**Check:** Does the component render state, not hardcoded content?
-
 ```bash
 # Find state usage in JSX
 grep -E "\{.*messages.*\}|\{.*data.*\}|\{.*items.*\}" "$component_path"
@@ -446,14 +304,11 @@ grep -E "\.map\(|\.filter\(|\.reduce\(" "$component_path"
 # Verify dynamic content
 grep -E "\{[a-zA-Z_]+\." "$component_path"  # Variable interpolation
 ```
-
-**Red flags:**
 ```tsx
 // Hardcoded instead of state:
 return <div>
   <p>Message 1</p>
   <p>Message 2</p>
-</div>
 
 // State exists but not rendered:
 const [messages, setMessages] = useState([])
@@ -463,64 +318,6 @@ return <div>No messages</div>  // Always shows "no messages"
 const [messages, setMessages] = useState([])
 return <div>{otherData.map(...)}</div>  // Uses different data
 ```
-
-</wiring_verification>
-
-<verification_checklist>
-
-## Quick Verification Checklist
-
-For each artifact type, run through this checklist:
-
-### Component Checklist
-- [ ] File exists at expected path
-- [ ] Exports a function/const component
-- [ ] Returns JSX (not null/empty)
-- [ ] No placeholder text in render
-- [ ] Uses props or state (not static)
-- [ ] Event handlers have real implementations
-- [ ] Imports resolve correctly
-- [ ] Used somewhere in the app
-
-### API Route Checklist
-- [ ] File exists at expected path
-- [ ] Exports HTTP method handlers
-- [ ] Handlers have more than 5 lines
-- [ ] Queries database or service
-- [ ] Returns meaningful response (not empty/placeholder)
-- [ ] Has error handling
-- [ ] Validates input
-- [ ] Called from frontend
-
-### Schema Checklist
-- [ ] Model/table defined
-- [ ] Has all expected fields
-- [ ] Fields have appropriate types
-- [ ] Relationships defined if needed
-- [ ] Migrations exist and applied
-- [ ] Client generated
-
-### Hook/Utility Checklist
-- [ ] File exists at expected path
-- [ ] Exports function
-- [ ] Has meaningful implementation (not empty returns)
-- [ ] Used somewhere in the app
-- [ ] Return values consumed
-
-### Wiring Checklist
-- [ ] Component → API: fetch/axios call exists and uses response
-- [ ] API → Database: query exists and result returned
-- [ ] Form → Handler: onSubmit calls API/mutation
-- [ ] State → Render: state variables appear in JSX
-
-</verification_checklist>
-
-<automated_verification_script>
-
-## Automated Verification Approach
-
-For the verification subagent, use this pattern:
-
 ```bash
 # 1. Check existence
 check_exists() {
@@ -551,33 +348,6 @@ check_substantive() {
   [ "$lines" -ge "$min_lines" ] && [ "$has_pattern" -gt 0 ] && echo "SUBSTANTIVE: $file" || echo "THIN: $file ($lines lines, $has_pattern matches)"
 }
 ```
-
-Run these checks against each must-have artifact. Aggregate results into VERIFICATION.md.
-
-</automated_verification_script>
-
-<human_verification_triggers>
-
-## When to Require Human Verification
-
-Some things can't be verified programmatically. Flag these for human testing:
-
-**Always human:**
-- Visual appearance (does it look right?)
-- User flow completion (can you actually do the thing?)
-- Real-time behavior (WebSocket, SSE)
-- External service integration (Stripe, email sending)
-- Error message clarity (is the message helpful?)
-- Performance feel (does it feel fast?)
-
-**Human if uncertain:**
-- Complex wiring that grep can't trace
-- Dynamic behavior depending on state
-- Edge cases and error states
-- Mobile responsiveness
-- Accessibility
-
-**Format for human verification request:**
 ```markdown
 ## Human Verification Required
 
@@ -591,22 +361,3 @@ Some things can't be verified programmatically. Flag these for human testing:
 **Expected:** Error message appears, message not lost
 **Check:** Can retry after reconnect?
 ```
-
-</human_verification_triggers>
-
-<checkpoint_automation_reference>
-
-## Pre-Checkpoint Automation
-
-For automation-first checkpoint patterns, server lifecycle management, CLI installation handling, and error recovery protocols, see:
-
-**@~/.claude/gsd-ng/references/checkpoints.md** → `<automation_reference>` section
-
-Key principles:
-- Claude sets up verification environment BEFORE presenting checkpoints
-- Users never run CLI commands (visit URLs only)
-- Server lifecycle: start before checkpoint, handle port conflicts, keep running for duration
-- CLI installation: auto-install where safe, checkpoint for user choice otherwise
-- Error handling: fix broken environment before checkpoint, never present checkpoint with failed setup
-
-</checkpoint_automation_reference>

--- a/gsd-ng/references/verification-patterns-standard.md
+++ b/gsd-ng/references/verification-patterns-standard.md
@@ -1,0 +1,259 @@
+# Verification Patterns — Standard
+
+> Pattern descriptions with when-to-use guidance (no code blocks). See also:
+> - `@~/.claude/gsd-ng/references/verification-patterns-core.md` — quick reference
+> - `@~/.claude/gsd-ng/references/verification-patterns-deep.md` — code examples
+# Verification Patterns
+
+How to verify different types of artifacts are real implementations, not stubs or placeholders.
+
+<core_principle>
+**Existence ≠ Implementation**
+
+A file existing does not mean the feature works. Verification must check:
+1. **Exists** - File is present at expected path
+2. **Substantive** - Content is real implementation, not placeholder
+3. **Wired** - Connected to the rest of the system
+4. **Functional** - Actually works when invoked
+
+Levels 1-3 can be checked programmatically. Level 4 often requires human verification.
+</core_principle>
+
+<stub_detection>
+
+## Universal Stub Patterns
+
+These patterns indicate placeholder code regardless of file type:
+
+**Comment-based stubs:**
+
+**Placeholder text in output:**
+
+**Empty or trivial implementations:**
+
+**Hardcoded values where dynamic expected:**
+
+</stub_detection>
+
+<react_components>
+
+## React/Next.js Components
+
+**Existence check:**
+
+**Substantive check:**
+
+**Stub patterns specific to React:**
+
+**Wiring check:**
+
+**Functional verification (human required):**
+- Does the component render visible content?
+- Do interactive elements respond to clicks?
+- Does data load and display?
+- Do error states show appropriately?
+
+</react_components>
+
+<api_routes>
+
+## API Routes (Next.js App Router / Express / etc.)
+
+**Existence check:**
+
+**Substantive check:**
+
+**Stub patterns specific to API routes:**
+
+**Wiring check:**
+
+**Functional verification (human or automated):**
+- Does GET return real data from database?
+- Does POST actually create a record?
+- Does error response have correct status code?
+- Are auth checks actually enforced?
+
+</api_routes>
+
+<database_schema>
+
+## Database Schema (Prisma / Drizzle / SQL)
+
+**Existence check:**
+
+**Substantive check:**
+
+**Stub patterns specific to schemas:**
+
+**Wiring check:**
+
+**Functional verification:**
+
+</database_schema>
+
+<hooks_utilities>
+
+## Custom Hooks and Utilities
+
+**Existence check:**
+
+**Substantive check:**
+
+**Stub patterns specific to hooks:**
+
+**Wiring check:**
+
+</hooks_utilities>
+
+<environment_config>
+
+## Environment Variables and Configuration
+
+**Existence check:**
+
+**Substantive check:**
+
+**Stub patterns specific to env:**
+
+**Wiring check:**
+
+</environment_config>
+
+<wiring_verification>
+
+## Wiring Verification Patterns
+
+Wiring verification checks that components actually communicate. This is where most stubs hide.
+
+### Pattern: Component → API
+
+**Check:** Does the component actually call the API?
+
+
+**Red flags:**
+
+### Pattern: API → Database
+
+**Check:** Does the API route actually query the database?
+
+
+**Red flags:**
+
+### Pattern: Form → Handler
+
+**Check:** Does the form submission actually do something?
+
+
+**Red flags:**
+
+### Pattern: State → Render
+
+**Check:** Does the component render state, not hardcoded content?
+
+
+**Red flags:**
+</div>
+
+</wiring_verification>
+
+<verification_checklist>
+
+## Quick Verification Checklist
+
+For each artifact type, run through this checklist:
+
+### Component Checklist
+- [ ] File exists at expected path
+- [ ] Exports a function/const component
+- [ ] Returns JSX (not null/empty)
+- [ ] No placeholder text in render
+- [ ] Uses props or state (not static)
+- [ ] Event handlers have real implementations
+- [ ] Imports resolve correctly
+- [ ] Used somewhere in the app
+
+### API Route Checklist
+- [ ] File exists at expected path
+- [ ] Exports HTTP method handlers
+- [ ] Handlers have more than 5 lines
+- [ ] Queries database or service
+- [ ] Returns meaningful response (not empty/placeholder)
+- [ ] Has error handling
+- [ ] Validates input
+- [ ] Called from frontend
+
+### Schema Checklist
+- [ ] Model/table defined
+- [ ] Has all expected fields
+- [ ] Fields have appropriate types
+- [ ] Relationships defined if needed
+- [ ] Migrations exist and applied
+- [ ] Client generated
+
+### Hook/Utility Checklist
+- [ ] File exists at expected path
+- [ ] Exports function
+- [ ] Has meaningful implementation (not empty returns)
+- [ ] Used somewhere in the app
+- [ ] Return values consumed
+
+### Wiring Checklist
+- [ ] Component → API: fetch/axios call exists and uses response
+- [ ] API → Database: query exists and result returned
+- [ ] Form → Handler: onSubmit calls API/mutation
+- [ ] State → Render: state variables appear in JSX
+
+</verification_checklist>
+
+<automated_verification_script>
+
+## Automated Verification Approach
+
+For the verification subagent, use this pattern:
+
+
+Run these checks against each must-have artifact. Aggregate results into VERIFICATION.md.
+
+</automated_verification_script>
+
+<human_verification_triggers>
+
+## When to Require Human Verification
+
+Some things can't be verified programmatically. Flag these for human testing:
+
+**Always human:**
+- Visual appearance (does it look right?)
+- User flow completion (can you actually do the thing?)
+- Real-time behavior (WebSocket, SSE)
+- External service integration (Stripe, email sending)
+- Error message clarity (is the message helpful?)
+- Performance feel (does it feel fast?)
+
+**Human if uncertain:**
+- Complex wiring that grep can't trace
+- Dynamic behavior depending on state
+- Edge cases and error states
+- Mobile responsiveness
+- Accessibility
+
+**Format for human verification request:**
+
+</human_verification_triggers>
+
+<checkpoint_automation_reference>
+
+## Pre-Checkpoint Automation
+
+For automation-first checkpoint patterns, server lifecycle management, CLI installation handling, and error recovery protocols, see:
+
+**@~/.claude/gsd-ng/references/checkpoints-standard.md** → `<automation_reference>` section
+
+Key principles:
+- Claude sets up verification environment BEFORE presenting checkpoints
+- Users never run CLI commands (visit URLs only)
+- Server lifecycle: start before checkpoint, handle port conflicts, keep running for duration
+- CLI installation: auto-install where safe, checkpoint for user choice otherwise
+- Error handling: fix broken environment before checkpoint, never present checkpoint with failed setup
+
+</checkpoint_automation_reference>

--- a/gsd-ng/templates/phase-prompt.md
+++ b/gsd-ng/templates/phase-prompt.md
@@ -41,7 +41,7 @@ Output: [What artifacts will be created]
 @~/.claude/gsd-ng/workflows/execute-plan.md
 @~/.claude/gsd-ng/templates/summary.md
 [If plan contains checkpoint tasks (type="checkpoint:*"), add:]
-@~/.claude/gsd-ng/references/checkpoints.md
+@~/.claude/gsd-ng/references/checkpoints-core.md
 </execution_context>
 
 <context>
@@ -85,7 +85,7 @@ Output: [What artifacts will be created]
   <done>[Acceptance criteria]</done>
 </task>
 
-<!-- For checkpoint task examples and patterns, see @~/.claude/gsd-ng/references/checkpoints.md -->
+<!-- For checkpoint task examples and patterns, see @~/.claude/gsd-ng/references/checkpoints-deep.md -->
 
 <task type="checkpoint:decision" gate="blocking">
   <decision>[What needs deciding]</decision>
@@ -384,7 +384,7 @@ Output: Working dashboard component.
 <execution_context>
 @~/.claude/gsd-ng/workflows/execute-plan.md
 @~/.claude/gsd-ng/templates/summary.md
-@~/.claude/gsd-ng/references/checkpoints.md
+@~/.claude/gsd-ng/references/checkpoints-core.md
 </execution_context>
 
 <context>
@@ -403,7 +403,7 @@ Output: Working dashboard component.
   <done>Dashboard renders without errors</done>
 </task>
 
-<!-- Checkpoint pattern: Claude starts server, user visits URL. See checkpoints.md for full patterns. -->
+<!-- Checkpoint pattern: Claude starts server, user visits URL. See checkpoints-deep.md for full patterns. -->
 <task type="auto">
   <name>Start dev server</name>
   <action>Run `npm run dev` in background, wait for ready</action>

--- a/gsd-ng/workflows/add-tests.md
+++ b/gsd-ng/workflows/add-tests.md
@@ -4,34 +4,7 @@ Generate unit and E2E tests for a completed phase based on its SUMMARY.md, CONTE
 Users currently hand-craft `/gsd:quick` prompts for test generation after each phase. This workflow standardizes the process with proper classification, quality gates, and gap reporting.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/add-todo.md
+++ b/gsd-ng/workflows/add-todo.md
@@ -2,34 +2,7 @@
 Capture an idea, task, or issue that surfaces during a GSD session as a structured todo for later work. Enables "thought → capture → continue" flow without losing context.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.
@@ -100,12 +73,27 @@ If potential duplicate found:
 2. Compare scope
 
 If overlapping, use AskUserQuestion:
-- header: "Duplicate?"
-- question: "Similar todo exists: [title]. What would you like to do?"
-- options:
-  - "Skip" — keep existing todo
-  - "Replace" — update existing with new context
-  - "Add anyway" — create as separate todo
+```
+AskUserQuestion(
+  header: "Duplicate?",
+  question: "Similar todo exists: [title]. What would you like to do?",
+  multiSelect: false,
+  options: [
+    { label: "Skip", description: "Keep existing todo" },
+    { label: "Replace", description: "Update existing with new context" },
+    { label: "Add anyway", description: "Create as separate todo" },
+    { label: "Link as related", description: "Create new todo and link both as related" }
+  ]
+)
+```
+
+Handle responses:
+- **"Skip"**: Do not create new todo. Exit workflow.
+- **"Replace"**: Update the existing todo file with new context. Exit workflow.
+- **"Add anyway"**: Continue to `create_file` step as normal.
+- **"Link as related"**: Set `LINK_AS_RELATED=true` and `EXISTING_TODO_FOR_LINK="[existing-todo-filename]"` (basename only, e.g. `2026-03-29-auth-refresh.md`). Continue to `create_file` step.
+
+Note: If "Link as related" was selected, `$LINK_AS_RELATED` is set to `true` and `$EXISTING_TODO_FOR_LINK` holds the existing todo filename. The auto-backlink runs in the `git_commit` step after `create_file`.
 </step>
 
 <step name="create_file">
@@ -153,10 +141,44 @@ If `.planning/STATE.md` exists:
 </step>
 
 <step name="git_commit">
-Commit the todo and any updated state:
+**If `$LINK_AS_RELATED` is true**, run the auto-backlink BEFORE committing:
 
 ```bash
-node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title]" --files .planning/todos/pending/[filename] .planning/STATE.md
+# NEW_TODO_FILE is the filename just created (e.g., "2026-03-29-my-new-todo.md")
+# EXISTING_TODO_FOR_LINK is the similar todo found during duplicate check (basename only)
+
+# Set related: on the new todo (fresh file, no existing related: field)
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$NEW_TODO_FILE" --field related --value "[\"$EXISTING_TODO_FOR_LINK\"]"
+
+# Append to related: on the existing todo (may already have related: entries)
+EXISTING_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --raw 2>/dev/null || echo "")
+UPDATED_RELATED=$(echo "$EXISTING_RELATED" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      if (!arr.includes('$NEW_TODO_FILE')) arr.push('$NEW_TODO_FILE');
+      console.log(JSON.stringify(arr));
+    } catch { console.log(JSON.stringify(['$NEW_TODO_FILE'])); }
+  });
+")
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --value "$UPDATED_RELATED"
+```
+
+Log: `Linked: $NEW_TODO_FILE <-> $EXISTING_TODO_FOR_LINK`
+
+Commit the todo, any updated state, and (if linking) the existing todo:
+
+```bash
+if [[ "$LINK_AS_RELATED" == "true" ]]; then
+  node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title] (linked to $EXISTING_TODO_FOR_LINK)" \
+    --files ".planning/todos/pending/$NEW_TODO_FILE" ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" .planning/STATE.md
+else
+  node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title]" --files .planning/todos/pending/[filename] .planning/STATE.md
+fi
 ```
 
 Tool respects `commit_docs` config and gitignore automatically.

--- a/gsd-ng/workflows/check-todos.md
+++ b/gsd-ng/workflows/check-todos.md
@@ -2,36 +2,7 @@
 List all pending todos, allow selection, load full context for the selected todo, and route to appropriate action.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-
-**UI rendering constraint:** Keep output before each AskUserQuestion call to 2-3 lines maximum. The Claude Code dialog can occlude preceding text when it is long. Truncate long todo content to a brief summary rather than reproducing it in full before a dialog.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/complete-milestone.md
+++ b/gsd-ng/workflows/complete-milestone.md
@@ -4,34 +4,7 @@ Mark a shipped version (v1.0, v1.1, v2.0) as complete. Bumps project version and
 
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 

--- a/gsd-ng/workflows/discovery-phase.md
+++ b/gsd-ng/workflows/discovery-phase.md
@@ -7,34 +7,7 @@ Called from plan-phase.md's mandatory_discovery step with a depth parameter.
 NOTE: For comprehensive ecosystem research ("how do experts build this"), use /gsd:research-phase instead, which produces RESEARCH.md.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <depth_levels>
 **This workflow supports three depth levels:**

--- a/gsd-ng/workflows/discuss-phase.md
+++ b/gsd-ng/workflows/discuss-phase.md
@@ -105,36 +105,7 @@ Phase: "API documentation"
 - Scope (roadmap defines this)
 </gray_area_identification>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "Which areas do you want to discuss?",
-      "header": "Discuss",
-      "multiSelect": true,
-      "options": [
-        { "label": "Layout style", "description": "Cards vs list vs timeline" },
-        { "label": "Loading behavior", "description": "Infinite scroll or pagination" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-
-**UI rendering constraint:** Keep output before each AskUserQuestion call to 2-3 lines maximum. The Claude Code dialog can occlude preceding text when it is long. Embed context summaries in the `question` string rather than outputting them as preceding prose.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <answer_validation>
 **IMPORTANT: Answer validation** — After every AskUserQuestion call, check if the response is empty or whitespace-only. If so:
@@ -278,6 +249,84 @@ For each linked todo in auto mode:
 ```bash
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set ".planning/todos/pending/$FILE" --field phase --value "${PHASE}"
 ```
+
+**Surface related: link suggestions (interactive mode only)**
+
+After the phase: linking is done, check if this phase has a source todo and surface potential `related:` links.
+
+In **--auto mode**: skip this section entirely. Related: linking during discussion requires user confirmation — it is not a closure workflow.
+
+In **interactive mode**:
+
+1. Find the source todo for this phase by checking ROADMAP.md:
+```bash
+SOURCE_TODO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --raw 2>/dev/null | node -e "
+  process.stdin.on('data', d => {
+    try { const r = JSON.parse(d); console.log(r.source_todos || ''); } catch { console.log(''); }
+  });
+")
+```
+
+2. If `$SOURCE_TODO` is non-empty, read its existing `related:` field:
+```bash
+EXISTING_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+```
+
+3. From the phase: linking candidates above (1-3 todos that were evaluated), filter for any that:
+   - Were NOT selected for phase: linking
+   - Are NOT already in the source todo's `related:` field
+
+4. If 1-3 such candidates exist:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "These pending todos may be related to the source todo for Phase ${PHASE}. Link them via related: field?",
+  multiSelect: true,
+  options: [
+    { label: "[todo-filename-1]", description: "[todo title 1]" },
+    ...
+    { label: "None of these", description: "Skip related linking" }
+  ]
+)
+```
+
+5. For each selected todo (not "None of these"), set `related:` bidirectionally using the safe read-append-write pattern:
+```bash
+# Append selected todo filename to source todo's related: field
+SOURCE_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+UPDATED_SOURCE=$(echo "$SOURCE_RELATED_RAW" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      if (!arr.includes('$SELECTED_FILE')) arr.push('$SELECTED_FILE');
+      console.log(JSON.stringify(arr));
+    } catch { console.log(JSON.stringify(['$SELECTED_FILE'])); }
+  });
+")
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$SOURCE_TODO" --field related --value "$UPDATED_SOURCE"
+
+# Append source todo filename to selected todo's related: field (backlink)
+SELECTED_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$SELECTED_FILE" --field related --raw 2>/dev/null || echo "")
+UPDATED_SELECTED=$(echo "$SELECTED_RELATED_RAW" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      if (!arr.includes('$SOURCE_TODO')) arr.push('$SOURCE_TODO');
+      console.log(JSON.stringify(arr));
+    } catch { console.log(JSON.stringify(['$SOURCE_TODO'])); }
+  });
+")
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$SELECTED_FILE" --field related --value "$UPDATED_SELECTED"
+```
+
+Log: `Linked related: $SOURCE_TODO <-> $SELECTED_FILE`
 
 Continue to load_prior_context.
 </step>

--- a/gsd-ng/workflows/do.md
+++ b/gsd-ng/workflows/do.md
@@ -2,34 +2,7 @@
 Analyze freeform text from the user and route to the most appropriate GSD command. This is a dispatcher — it never does the work itself. Match user intent to the best command, confirm the routing, and hand off.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -181,7 +181,7 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
        <execution_context>
        @~/.claude/gsd-ng/workflows/execute-plan.md
        @~/.claude/gsd-ng/templates/summary.md
-       @~/.claude/gsd-ng/references/checkpoints.md
+       @~/.claude/gsd-ng/references/checkpoints-core.md
        @~/.claude/gsd-ng/references/tdd.md
        </execution_context>
 
@@ -833,6 +833,105 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close phase-linked t
 ```
 
 Note: `todo complete` triggers inline issue-sync automatically (from Plan 01) — no additional sync code needed here.
+
+**Related Todos scan (after phase-linked scan):**
+
+Fire when `$VERIFY_STATUS` is `passed` AND `$ORIGIN_TODO_FILE` is set. The origin todo may now be in completed/ (just closed above), so check both locations.
+
+**Step 1 — Read outbound links from origin todo:**
+```bash
+RELATED_OUTBOUND=""
+if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS" == "passed" ]]; then
+  # Origin todo may have been moved to completed/ in the closure step above
+  ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
+  if [[ ! -f "$ORIGIN_PATH" ]]; then
+    ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
+  fi
+  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
+  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
+    # Normalize: parse JSON (string or array) into newline-separated filenames
+    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
+      });
+    ")
+  fi
+fi
+```
+
+**Step 2 — Scan all pending todos for inbound links to origin:**
+```bash
+RELATED_INBOUND=""
+PENDING_DIR=".planning/todos/pending"
+if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS" == "passed" ]]; then
+  for TODO_FILE in "$PENDING_DIR"/*.md; do
+    [[ -f "$TODO_FILE" ]] || continue
+    TODO_BASENAME=$(basename "$TODO_FILE")
+    # Skip the origin todo itself
+    [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
+    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
+    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
+      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
+        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
+      fi
+    fi
+  done
+fi
+```
+
+**Step 3 — Deduplicate and filter (only pending/ files):**
+```bash
+RELATED_ALL=""
+if [[ -n "$RELATED_OUTBOUND" ]] || [[ -n "$RELATED_INBOUND" ]]; then
+  # Combine outbound + inbound, deduplicate, filter to files still in pending/
+  RELATED_ALL=$(printf "%s\n%s" "$RELATED_OUTBOUND" "$RELATED_INBOUND" | sort -u | while read -r REL_FILE; do
+    [[ -z "$REL_FILE" ]] && continue
+    [[ "$REL_FILE" == "$ORIGIN_TODO_FILE" ]] && continue
+    if [[ -f ".planning/todos/pending/$REL_FILE" ]]; then
+      echo "$REL_FILE"
+    fi
+  done)
+fi
+```
+
+**Step 4 — Present for closure (auto or interactive):**
+
+If `$RELATED_ALL` is non-empty:
+
+**Auto mode:**
+```bash
+if [[ "$AUTO_CFG" == "true" ]]; then
+  while IFS= read -r REL_TODO; do
+    [[ -z "$REL_TODO" ]] && continue
+    REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after phase completion" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
+    echo "[auto] Closed related todo: $REL_TITLE"
+  done <<< "$RELATED_ALL"
+fi
+```
+
+**Interactive mode** — build options list and use AskUserQuestion:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "Closing '$ORIGIN_TODO_TITLE' — these todos are linked via related:. Close them too?",
+  multiSelect: true,
+  options: [
+    { label: "[rel-filename-1]", description: "[rel-title-1]" },
+    ...
+    { label: "Keep all open", description: "Leave all in pending" }
+  ]
+)
+```
+
+For each selected todo (not "Keep all open"):
+```bash
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$SELECTED_REL"
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after phase completion" --files ".planning/todos/completed/$SELECTED_REL" ".planning/todos/pending/$SELECTED_REL"
+```
+
+Note: `todo complete` triggers inline issue-sync automatically — no additional sync code needed.
 </step>
 
 </process>

--- a/gsd-ng/workflows/execute-plan.md
+++ b/gsd-ng/workflows/execute-plan.md
@@ -2,34 +2,7 @@
 Execute a phase prompt (PLAN.md) and create the outcome summary (SUMMARY.md).
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read STATE.md before any operation to load project context.
@@ -334,7 +307,7 @@ Display: `CHECKPOINT: [Type]` box → Progress {X}/{Y} → Task name → type-sp
 
 After response: verify if specified. Pass → continue. Fail → inform, wait. WAIT for user — do NOT hallucinate completion.
 
-See ~/.claude/gsd-ng/references/checkpoints.md for details.
+See ~/.claude/gsd-ng/references/checkpoints-core.md for details.
 </step>
 
 <step name="checkpoint_return_for_orchestrator">

--- a/gsd-ng/workflows/import-issue.md
+++ b/gsd-ng/workflows/import-issue.md
@@ -2,34 +2,7 @@
 Import external issues from GitHub/GitLab/Forgejo/Gitea as GSD todos. Supports both single issue import and bulk import filtered by label or milestone.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/map-codebase.md
+++ b/gsd-ng/workflows/map-codebase.md
@@ -6,34 +6,7 @@ Each agent has fresh context, explores a specific focus area, and **writes docum
 Output: .planning/codebase/ folder with 7 structured documents about the codebase state.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <philosophy>
 **Why dedicated mapper agents:**

--- a/gsd-ng/workflows/new-milestone.md
+++ b/gsd-ng/workflows/new-milestone.md
@@ -4,34 +4,7 @@ Start a new milestone cycle for an existing project. Loads project context, gath
 
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 

--- a/gsd-ng/workflows/new-project.md
+++ b/gsd-ng/workflows/new-project.md
@@ -2,34 +2,7 @@
 Initialize a new project through unified flow: questioning, research (optional), requirements, roadmap. This is the most leveraged moment in any project — deep questioning here means better plans, better execution, better outcomes. One workflow takes you from idea to ready-for-planning.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/plan-milestone-gaps.md
+++ b/gsd-ng/workflows/plan-milestone-gaps.md
@@ -2,34 +2,7 @@
 Create all phases necessary to close gaps identified by `/gsd:audit-milestone`. Reads MILESTONE-AUDIT.md, groups gaps into logical phases, creates phase entries in ROADMAP.md, and offers to plan each phase. One command creates all fix phases — no manual `/gsd:add-phase` per gap.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/plan-phase.md
+++ b/gsd-ng/workflows/plan-phase.md
@@ -2,34 +2,7 @@
 Create executable phase prompts (PLAN.md files) for a roadmap phase with integrated research and verification. Default flow: Research (if needed) -> Plan -> Verify -> Done. Orchestrates gsd-phase-researcher, gsd-planner, and gsd-plan-checker agents with a revision loop (max 3 iterations).
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/quick.md
+++ b/gsd-ng/workflows/quick.md
@@ -12,34 +12,7 @@ With `--all` flag: convenience shorthand that enables all optional stages (discu
 Flags are composable: `--discuss --research --verify` gives discussion + research + plan-checking + verification.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.
@@ -835,6 +808,104 @@ Display: `Closed todo: $ORIGIN_TODO_TITLE`
 
 If user selects "No, keep open":
 Display: `Todo kept open: $ORIGIN_TODO_TITLE`
+
+Set `ORIGIN_CLOSED=true` after origin todo is closed (either auto or interactive "Yes"). If origin was not closed (user said "No, keep open" or auto kept open), do NOT run the related-todo scan.
+
+**Related Todos scan (only when origin todo was closed):**
+
+Fire when `$ORIGIN_TODO_FILE` is set AND `$ORIGIN_CLOSED` is `true`.
+
+**Step 1 — Read outbound links from origin todo (now in completed/):**
+```bash
+RELATED_OUTBOUND=""
+if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  # Origin was just closed — check completed/ first, then pending/ as fallback
+  ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
+  if [[ ! -f "$ORIGIN_PATH" ]]; then
+    ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
+  fi
+  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
+  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
+    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
+      });
+    ")
+  fi
+fi
+```
+
+**Step 2 — Scan all pending todos for inbound links to origin:**
+```bash
+RELATED_INBOUND=""
+PENDING_DIR=".planning/todos/pending"
+if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  for TODO_FILE in "$PENDING_DIR"/*.md; do
+    [[ -f "$TODO_FILE" ]] || continue
+    TODO_BASENAME=$(basename "$TODO_FILE")
+    [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
+    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
+    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
+      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
+        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
+      fi
+    fi
+  done
+fi
+```
+
+**Step 3 — Deduplicate and filter (only pending/ files):**
+```bash
+RELATED_ALL=""
+if [[ -n "$RELATED_OUTBOUND" ]] || [[ -n "$RELATED_INBOUND" ]]; then
+  RELATED_ALL=$(printf "%s\n%s" "$RELATED_OUTBOUND" "$RELATED_INBOUND" | sort -u | while read -r REL_FILE; do
+    [[ -z "$REL_FILE" ]] && continue
+    [[ "$REL_FILE" == "$ORIGIN_TODO_FILE" ]] && continue
+    if [[ -f ".planning/todos/pending/$REL_FILE" ]]; then
+      echo "$REL_FILE"
+    fi
+  done)
+fi
+```
+
+**Step 4 — Present for closure (auto or interactive):**
+
+If `$RELATED_ALL` is non-empty:
+
+**Auto mode:**
+```bash
+if [[ "$AUTO_CFG" == "true" ]]; then
+  while IFS= read -r REL_TODO; do
+    [[ -z "$REL_TODO" ]] && continue
+    REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after quick task" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
+    echo "[auto] Closed related todo: $REL_TITLE"
+  done <<< "$RELATED_ALL"
+fi
+```
+
+**Interactive mode** — build options list and use AskUserQuestion:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "Closing '$ORIGIN_TODO_TITLE' — these todos are linked via related:. Close them too?",
+  multiSelect: true,
+  options: [
+    { label: "[rel-filename-1]", description: "[rel-title-1]" },
+    ...
+    { label: "Keep all open", description: "Leave all in pending" }
+  ]
+)
+```
+
+For each selected todo (not "Keep all open"):
+```bash
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$SELECTED_REL"
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after quick task" --files ".planning/todos/completed/$SELECTED_REL" ".planning/todos/pending/$SELECTED_REL"
+```
+
+Note: `todo complete` triggers inline issue-sync automatically — no additional sync code needed.
 
 </process>
 

--- a/gsd-ng/workflows/settings.md
+++ b/gsd-ng/workflows/settings.md
@@ -2,34 +2,7 @@
 Interactive configuration of GSD workflow agents (research, plan_check, verifier) and model profile selection via multi-question prompt. Updates .planning/config.json with user preferences. Optionally saves settings as global defaults (~/.gsd/defaults.json) for future projects.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/squash.md
+++ b/gsd-ng/workflows/squash.md
@@ -4,34 +4,7 @@ Supports three strategies: single (all commits to one), per-plan (group by plan)
 and logical (user-guided grouping). Always creates backup tags before rewriting history.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 @~/.claude/gsd-ng/references/planning-config.md

--- a/gsd-ng/workflows/sync-issues.md
+++ b/gsd-ng/workflows/sync-issues.md
@@ -2,34 +2,7 @@
 Manually sync GSD planning state with external issue trackers. Runs both outbound (GSD -> tracker) and inbound (tracker -> GSD) reconciliation. Outbound closes/comments issues for completed work. Inbound detects mismatches (externally closed issues still pending in GSD).
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 Read all files referenced by the invoking prompt's execution_context before starting.

--- a/gsd-ng/workflows/transition.md
+++ b/gsd-ng/workflows/transition.md
@@ -10,34 +10,7 @@
 
 </required_reading>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <purpose>
 

--- a/gsd-ng/workflows/ui-phase.md
+++ b/gsd-ng/workflows/ui-phase.md
@@ -4,34 +4,7 @@ Generate a UI design contract (UI-SPEC.md) for frontend phases. Orchestrates gsd
 UI-SPEC.md locks spacing, typography, color, copywriting, and design system decisions before the planner creates tasks. This prevents design debt caused by ad-hoc styling decisions during execution.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 @~/.claude/gsd-ng/references/ui-brand.md

--- a/gsd-ng/workflows/ui-review.md
+++ b/gsd-ng/workflows/ui-review.md
@@ -2,34 +2,7 @@
 Retroactive 6-pillar visual audit of implemented frontend code. Standalone command that works on any project — GSD-managed or not. Produces scored UI-REVIEW.md with actionable findings.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 @~/.claude/gsd-ng/references/ui-brand.md

--- a/gsd-ng/workflows/validate-phase.md
+++ b/gsd-ng/workflows/validate-phase.md
@@ -2,34 +2,7 @@
 Audit Nyquist validation gaps for a completed phase. Generate missing tests. Update VALIDATION.md.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <required_reading>
 @~/.claude/gsd-ng/references/ui-brand.md

--- a/gsd-ng/workflows/verify-phase.md
+++ b/gsd-ng/workflows/verify-phase.md
@@ -18,7 +18,7 @@ Then verify each level against the actual codebase.
 </core_principle>
 
 <required_reading>
-@~/.claude/gsd-ng/references/verification-patterns.md
+@~/.claude/gsd-ng/references/verification-patterns-core.md
 @~/.claude/gsd-ng/templates/verification-report.md
 </required_reading>
 

--- a/gsd-ng/workflows/verify-work.md
+++ b/gsd-ng/workflows/verify-work.md
@@ -4,34 +4,7 @@ Validate built features through conversational testing with persistent state. Cr
 User tests, Claude records. One test at a time. Plain text responses.
 </purpose>
 
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
-
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
-- `question` (string) — the question text
-- `header` (string, max 12 chars) — short label shown above the question
-- `multiSelect` (boolean) — true for "select all that apply", false for single choice
-- `options` (array of `{label, description}`) — 2-4 choices; "Other" is added automatically, do NOT add it yourself
-
-Example call structure:
-```json
-{
-  "questions": [
-    {
-      "question": "The question text?",
-      "header": "Choose",
-      "multiSelect": false,
-      "options": [
-        { "label": "Option A", "description": "What option A means" },
-        { "label": "Option B", "description": "What option B means" }
-      ]
-    }
-  ]
-}
-```
-
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
-</tool_usage>
+@~/.claude/gsd-ng/references/ask-user-question.md
 
 <philosophy>
 **Show expected, ask if reality matches.**

--- a/tests/verify-health.test.cjs
+++ b/tests/verify-health.test.cjs
@@ -1200,3 +1200,163 @@ describe('validate health — orphan detection checks (W015-W018)', () => {
     assert.strictEqual(w018.repairable, true, 'W018 should be repairable');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate health — related link checks (W021-W022)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate health — related link checks (W021-W022)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalStateMd(tmpDir, '# Session State\n\nPhase 1 in progress.\n');
+    writeValidConfigJson(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Project\n\nInstructions.\n');
+    // Write a minimal ROADMAP with one phase so W017/W018 don't interfere
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phases\n\n- [ ] **Phase 1: Test Phase**\n'
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-test'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // ─── Helper: write a pending todo with frontmatter ────────────────────────
+
+  function writePendingTodo(tmpDir, filename, frontmatter) {
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    fs.mkdirSync(pendingDir, { recursive: true });
+    const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`).join('\n');
+    fs.writeFileSync(
+      path.join(pendingDir, filename),
+      `---\n${fmLines}\n---\n\nTodo content.\n`
+    );
+  }
+
+  // ─── Helper: write a completed todo with frontmatter ─────────────────────
+
+  function writeCompletedTodo(tmpDir, filename, frontmatter) {
+    const completedDir = path.join(tmpDir, '.planning', 'todos', 'completed');
+    fs.mkdirSync(completedDir, { recursive: true });
+    const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`).join('\n');
+    fs.writeFileSync(
+      path.join(completedDir, filename),
+      `---\n${fmLines}\n---\n\nTodo content.\n`
+    );
+  }
+
+  // ─── W021: broken related links ───────────────────────────────────────────
+
+  test('W021 fires when pending todo related: references non-existent file', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const w021 = parsed.warnings.find(w => w.code === 'W021');
+    assert.ok(w021, `Expected W021 in warnings: ${JSON.stringify(parsed.warnings)}`);
+    assert.ok(w021.message.includes('ghost.md'), `W021 message should mention "ghost.md": ${w021.message}`);
+    assert.ok(w021.message.includes('does not exist'), `W021 message should include "does not exist": ${w021.message}`);
+    assert.strictEqual(w021.repairable, true, 'W021 should be repairable');
+  });
+
+  test('W021 does NOT fire when related: references file that exists in completed/', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[other.md]' });
+    writeCompletedTodo(tmpDir, 'other.md', { completed: '2026-03-29' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W021'),
+      `Should not have W021 when ref exists in completed/: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+
+  test('W021 does NOT fire when related: references file that exists in pending/', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { related: '[todo-a.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W021'),
+      `Should not have W021 when ref exists in pending/: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+
+  test('W021 is repairable', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const w021 = parsed.warnings.find(w => w.code === 'W021');
+    assert.ok(w021, `Expected W021: ${JSON.stringify(parsed.warnings)}`);
+    assert.strictEqual(w021.repairable, true, 'W021 should be repairable');
+  });
+
+  // ─── W022: asymmetric related links ───────────────────────────────────────
+
+  test('W022 fires when related: link is asymmetric (A references B but B does not reference A back)', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { title: 'Todo B' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const w022 = parsed.warnings.find(w => w.code === 'W022');
+    assert.ok(w022, `Expected W022 in warnings: ${JSON.stringify(parsed.warnings)}`);
+    assert.ok(
+      w022.message.toLowerCase().includes('asymmetric'),
+      `W022 message should include "asymmetric": ${w022.message}`
+    );
+    assert.ok(w022.message.includes('todo-a.md'), `W022 message should mention "todo-a.md": ${w022.message}`);
+    assert.ok(w022.message.includes('todo-b.md'), `W022 message should mention "todo-b.md": ${w022.message}`);
+    assert.strictEqual(w022.repairable, true, 'W022 should be repairable');
+  });
+
+  test('W022 does NOT fire when related: references are symmetric', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { related: '[todo-a.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W022'),
+      `Should not have W022 for symmetric related refs: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+
+  test('W022 skips refs not in pending/ (no double-warn with W021 for missing files)', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md]' });
+    // ghost.md does not exist in pending/ or completed/
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    // W021 should fire (broken link), W022 should NOT fire (ghost not in pending/)
+    assert.ok(
+      parsed.warnings.some(w => w.code === 'W021'),
+      `Expected W021 for missing ref: ${JSON.stringify(parsed.warnings)}`
+    );
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W022'),
+      `Should not have W022 when ref not in pending/: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Teach workflows, verifier, and CLI to read `related:` frontmatter field on todos. Enable batch closure of linked todos, verifier cross-checking, and duplicate-check suggestions. Also ships the approved content optimization variants from Phase 39 sub-phases.

## Changes

### Phase 43: related-frontmatter-tag
- **43-01**: W021 (broken related links) and W022 (asymmetric related links) health checks added to verify.cjs with 7 TDD test cases, matching the W017/W018 structural pattern
- **43-02**: Bidirectional related-todo scan added to all three orchestrator closure points (execute-phase, quick, gsd-debugger) using outbound+inbound resolution, auto-mode auto-close, and interactive AskUserQuestion multi-select
- **43-03**: "Link as related" 4th option in add-todo with safe bidirectional auto-backlink, related: suggestions in discuss-phase, non-blocking verifier Step 8b warning, and 9 REL43-XX requirements registered

### Phase 39.2-39.4: content optimization shipping
- **39.2**: 3-tier reference splitting for checkpoints and verification-patterns (core/standard/deep)
- **39.3**: Extract shared context (project_context, tool_usage) to deduplicated agent references
- **39.4**: Condense philosophy sections in 6 agent files to single-line identity sentences

## Test Plan

- [ ] Automated tests pass (`npm test` — includes 7 new W021/W022 health check tests)
- [ ] Manual verification of related: frontmatter linking in add-todo workflow
- [ ] Verify bidirectional related-todo scan triggers at phase close

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng) from phase 43 execution*