### PR TITLE
feat: related frontmatter tag support (Phase 43)

### DIFF
--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -1123,6 +1123,104 @@ AskUserQuestion(
 
 If user confirms: call `gsd-tools todo complete "$ORIGIN_TODO_FILE"`, commit, display `Closed todo: $ORIGIN_TODO_TITLE`.
 If user declines: display `Todo kept open: $ORIGIN_TODO_TITLE`.
+
+Set `ORIGIN_CLOSED=true` after origin todo is closed (either auto or interactive "Yes"). If origin was not closed (user declined or auto kept open), do NOT run the related-todo scan.
+
+**Related Todos scan (only when origin todo was closed):**
+
+Fire when `$ORIGIN_TODO_FILE` is set AND `$ORIGIN_CLOSED` is `true`.
+
+**Step 1 — Read outbound links from origin todo (now in completed/):**
+```bash
+RELATED_OUTBOUND=""
+if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  # Origin was just closed — check completed/ first, then pending/ as fallback
+  ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
+  if [[ ! -f "$ORIGIN_PATH" ]]; then
+    ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
+  fi
+  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
+  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
+    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
+      });
+    ")
+  fi
+fi
+```
+
+**Step 2 — Scan all pending todos for inbound links to origin:**
+```bash
+RELATED_INBOUND=""
+PENDING_DIR=".planning/todos/pending"
+if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  for TODO_FILE in "$PENDING_DIR"/*.md; do
+    [[ -f "$TODO_FILE" ]] || continue
+    TODO_BASENAME=$(basename "$TODO_FILE")
+    [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
+    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
+    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
+      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
+        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
+      fi
+    fi
+  done
+fi
+```
+
+**Step 3 — Deduplicate and filter (only pending/ files):**
+```bash
+RELATED_ALL=""
+if [[ -n "$RELATED_OUTBOUND" ]] || [[ -n "$RELATED_INBOUND" ]]; then
+  RELATED_ALL=$(printf "%s\n%s" "$RELATED_OUTBOUND" "$RELATED_INBOUND" | sort -u | while read -r REL_FILE; do
+    [[ -z "$REL_FILE" ]] && continue
+    [[ "$REL_FILE" == "$ORIGIN_TODO_FILE" ]] && continue
+    if [[ -f ".planning/todos/pending/$REL_FILE" ]]; then
+      echo "$REL_FILE"
+    fi
+  done)
+fi
+```
+
+**Step 4 — Present for closure (auto or interactive):**
+
+If `$RELATED_ALL` is non-empty:
+
+**Auto mode:**
+```bash
+if [[ "$AUTO_CFG" == "true" ]]; then
+  while IFS= read -r REL_TODO; do
+    [[ -z "$REL_TODO" ]] && continue
+    REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after debug resolution" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
+    echo "[auto] Closed related todo: $REL_TITLE"
+  done <<< "$RELATED_ALL"
+fi
+```
+
+**Interactive mode** — build options list and use AskUserQuestion:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "Closing '$ORIGIN_TODO_TITLE' — these todos are linked via related:. Close them too?",
+  multiSelect: true,
+  options: [
+    { label: "[rel-filename-1]", description: "[rel-title-1]" },
+    ...
+    { label: "Keep all open", description: "Leave all in pending" }
+  ]
+)
+```
+
+For each selected todo (not "Keep all open"):
+```bash
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$SELECTED_REL"
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after debug resolution" --files ".planning/todos/completed/$SELECTED_REL" ".planning/todos/pending/$SELECTED_REL"
+```
+
+Note: `todo complete` triggers inline issue-sync automatically — no additional sync code needed.
 </step>
 
 </execution_flow>

--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -1139,14 +1139,8 @@ if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
   if [[ ! -f "$ORIGIN_PATH" ]]; then
     ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
   fi
-  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
-  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
-    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
-      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
-      });
-    ")
-  fi
+  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --raw 2>/dev/null || echo "")
+  if [[ "$RELATED_OUTBOUND" == "null" ]]; then RELATED_OUTBOUND=""; fi
 fi
 ```
 
@@ -1159,11 +1153,8 @@ if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED
     [[ -f "$TODO_FILE" ]] || continue
     TODO_BASENAME=$(basename "$TODO_FILE")
     [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
-    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
-    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
-      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
-        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
-      fi
+    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline --raw 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
+      RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
     fi
   done
 fi

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -364,25 +364,16 @@ RELATED_RAW=""
 for DIR in ".planning/todos/pending" ".planning/todos/completed"; do
   if [[ -f "$DIR/$SOURCE_TODO" ]]; then
     RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
-      "$DIR/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+      "$DIR/$SOURCE_TODO" --field related --format newline --raw 2>/dev/null || echo "")
     break
   fi
 done
+RELATED_LIST="$RELATED_RAW"
 ```
 
-Normalize to array and check each related todo:
+Check each related todo:
 
 ```bash
-# Parse RELATED_RAW (JSON string or array) into list
-RELATED_LIST=$(echo "$RELATED_RAW" | node -e "
-  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-    try {
-      const v = JSON.parse(d);
-      const arr = Array.isArray(v) ? v : (v ? [v] : []);
-      console.log(arr.join('\n'));
-    } catch { console.log(''); }
-  });
-")
 # For each related filename, check if it exists in pending/ (still open work)
 UNADDRESSED_TODOS=""
 while IFS= read -r related_file; do

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -341,6 +341,76 @@ Categorize: 🛑 Blocker (prevents goal) | ⚠️ Warning (incomplete) | ℹ️ 
 **Why human:** {Why can't verify programmatically}
 ```
 
+## Step 8b: Check Related Todos (Warning Only)
+
+**Purpose:** Inform the verification report about related todos that may need attention. This is informational — it does NOT affect the overall pass/fail status and does not block verification.
+
+Check if this phase has a source todo linked via ROADMAP.md:
+
+```bash
+PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --raw 2>/dev/null || echo "{}")
+SOURCE_TODO=$(echo "$PHASE_DATA" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try { const r=JSON.parse(d); console.log(r.source_todos || ''); } catch { console.log(''); }
+  });
+")
+```
+
+If `$SOURCE_TODO` is non-empty, read its `related:` field:
+
+```bash
+RELATED_RAW=""
+# Check pending/ first, then completed/
+for DIR in ".planning/todos/pending" ".planning/todos/completed"; do
+  if [[ -f "$DIR/$SOURCE_TODO" ]]; then
+    RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+      "$DIR/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+    break
+  fi
+done
+```
+
+Normalize to array and check each related todo:
+
+```bash
+# Parse RELATED_RAW (JSON string or array) into list
+RELATED_LIST=$(echo "$RELATED_RAW" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      console.log(arr.join('\n'));
+    } catch { console.log(''); }
+  });
+")
+# For each related filename, check if it exists in pending/ (still open work)
+UNADDRESSED_TODOS=""
+while IFS= read -r related_file; do
+  [[ -z "$related_file" ]] && continue
+  if [[ -f ".planning/todos/pending/$related_file" ]]; then
+    TITLE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+      ".planning/todos/pending/$related_file" --field title --raw 2>/dev/null || echo "(no title)")
+    UNADDRESSED_TODOS="${UNADDRESSED_TODOS}| $related_file | $TITLE | pending |\n"
+  fi
+done <<< "$RELATED_LIST"
+```
+
+If `$UNADDRESSED_TODOS` is non-empty, add a **Related Todo Warnings** section to the VERIFICATION.md output. Place this section AFTER the main verification results, clearly marked as warnings. This section does NOT change `status:` from passed to gaps_found and does NOT add items to the `gaps:` frontmatter section.
+
+```markdown
+### Related Todo Warnings
+
+The following todos are linked (via `related:` field) to this phase's source todo but remain in pending/:
+
+| Todo | Title | Status |
+|------|-------|--------|
+{UNADDRESSED_TODOS rows here}
+
+These are informational warnings — related todos represent separate work items and do not block verification.
+```
+
+If no source todo exists, `$SOURCE_TODO` is empty, or no related todos are in pending/, omit this section entirely.
+
 ## Step 9: Determine Overall Status
 
 **Status: passed** — All truths VERIFIED, all artifacts pass levels 1-3, all key links WIRED, no blocker anti-patterns.

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -631,7 +631,8 @@ async function main() {
       const file = args[2];
       if (subcommand === 'get') {
         const fieldIdx = args.indexOf('--field');
-        frontmatter.cmdFrontmatterGet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, raw);
+        const formatIdx = args.indexOf('--format');
+        frontmatter.cmdFrontmatterGet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, raw, formatIdx !== -1 ? args[formatIdx + 1] : null);
       } else if (subcommand === 'set') {
         const fieldIdx = args.indexOf('--field');
         const valueIdx = args.indexOf('--value');

--- a/gsd-ng/bin/lib/frontmatter.cjs
+++ b/gsd-ng/bin/lib/frontmatter.cjs
@@ -231,7 +231,7 @@ const FRONTMATTER_SCHEMAS = {
   verification: { required: ['phase', 'verified', 'status', 'score'] },
 };
 
-function cmdFrontmatterGet(cwd, filePath, field, raw) {
+function cmdFrontmatterGet(cwd, filePath, field, raw, format) {
   if (!filePath) { error('file path required'); }
   const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
@@ -240,7 +240,10 @@ function cmdFrontmatterGet(cwd, filePath, field, raw) {
   if (field) {
     const value = fm[field];
     if (value === undefined) { output({ error: 'Field not found', field }, raw); return; }
-    output({ [field]: value }, raw, Array.isArray(value) ? value.join(', ') : String(value));
+    const rawString = (format === 'newline' && Array.isArray(value))
+      ? value.join('\n')
+      : (Array.isArray(value) ? value.join(', ') : String(value));
+    output({ [field]: value }, raw, rawString);
   } else {
     output(fm, raw);
   }

--- a/gsd-ng/bin/lib/verify.cjs
+++ b/gsd-ng/bin/lib/verify.cjs
@@ -920,6 +920,55 @@ function cmdValidateHealth(cwd, options, raw) {
     }
   }
 
+  // --- Check 21: Broken related links (related: references non-existent todos) ---
+  for (const file of pendingTodosForPhaseCheck) {
+    try {
+      const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+      const fm = extractFrontmatter(content);
+      if (!fm || !fm.related) continue;
+      const relatedList = Array.isArray(fm.related) ? fm.related : (fm.related ? [fm.related] : []);
+      for (const ref of relatedList) {
+        const existsInPending = fs.existsSync(path.join(pendingTodosDir, ref));
+        const existsInCompleted = fs.existsSync(path.join(completedTodosDir, ref));
+        if (!existsInPending && !existsInCompleted) {
+          addIssue('warning', 'W021',
+            `Todo "${file}" has related: "${ref}" which does not exist in pending/ or completed/`,
+            'Remove the stale related: reference or recreate the missing todo',
+            true);
+          if (!repairs.includes('clearRelatedLink')) repairs.push('clearRelatedLink');
+        }
+      }
+    } catch (_e) { /* skip */ }
+  }
+
+  // --- Check 22: Asymmetric related links (A references B but B does not reference A back) ---
+  for (const file of pendingTodosForPhaseCheck) {
+    try {
+      const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+      const fm = extractFrontmatter(content);
+      if (!fm || !fm.related) continue;
+      const relatedList = Array.isArray(fm.related) ? fm.related : (fm.related ? [fm.related] : []);
+      for (const ref of relatedList) {
+        const refPath = path.join(pendingTodosDir, ref);
+        if (!fs.existsSync(refPath)) continue; // W021 covers missing refs — skip here
+        try {
+          const refContent = fs.readFileSync(refPath, 'utf-8');
+          const refFm = extractFrontmatter(refContent);
+          const refRelatedList = refFm && refFm.related
+            ? (Array.isArray(refFm.related) ? refFm.related : [refFm.related])
+            : [];
+          if (!refRelatedList.includes(file)) {
+            addIssue('warning', 'W022',
+              `Asymmetric related link: "${file}" references "${ref}" but "${ref}" does not reference back`,
+              'Run /gsd:health --repair to add the missing backlink, or add it manually',
+              true);
+            if (!repairs.includes('addBacklink')) repairs.push('addBacklink');
+          }
+        } catch (_e) { /* skip unreadable ref */ }
+      }
+    } catch (_e) { /* skip */ }
+  }
+
   // --- Check 20: Security events log — high-confidence detections ---
   const secLogDir = process.env.GSD_SECURITY_LOG_DIR || path.join(cwd, '.claude', 'logs');
   const secLogPath = path.join(secLogDir, 'security-events.log');

--- a/gsd-ng/bin/lib/verify.cjs
+++ b/gsd-ng/bin/lib/verify.cjs
@@ -6,7 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { safeReadFile, normalizePhaseName, execGit, findPhaseInternal, getMilestoneInfo, extractCurrentMilestone, output, error, planningPaths } = require('./core.cjs');
-const { extractFrontmatter, parseMustHavesBlock } = require('./frontmatter.cjs');
+const { extractFrontmatter, spliceFrontmatter, parseMustHavesBlock } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 const { detectWorkspaceType, generateMemoriesSection, generateMemoryMd } = require('./workspace.cjs');
 
@@ -1116,6 +1116,54 @@ function cmdValidateHealth(cwd, options, raw) {
             // Close pending todos linked to completed phases
             // Advisory — log but don't auto-close (health checks never auto-fix per CONTEXT.md)
             repairActions.push({ action: repair, success: false, note: 'Manual closure required — use /gsd:check-todos' });
+            break;
+          }
+          case 'clearRelatedLink': {
+            // Re-scan W021 warnings to find all (file, stale_ref) pairs
+            const w021Warnings = warnings.filter(w => w.code === 'W021');
+            for (const w of w021Warnings) {
+              const match = /Todo "([^"]+)" has related: "([^"]+)"/.exec(w.message);
+              if (!match) continue;
+              const [, todoFile, staleRef] = match;
+              const todoPath = path.join(pendingTodosDir, todoFile);
+              try {
+                const content = fs.readFileSync(todoPath, 'utf-8');
+                const fm = extractFrontmatter(content);
+                if (!fm || !fm.related) continue;
+                const relatedList = Array.isArray(fm.related) ? fm.related : [fm.related];
+                fm.related = relatedList.filter(r => r !== staleRef);
+                if (fm.related.length === 0) delete fm.related;
+                const newContent = spliceFrontmatter(content, fm);
+                fs.writeFileSync(todoPath, newContent, 'utf-8');
+              } catch (_e) { /* skip unreadable files */ }
+            }
+            repairActions.push({ action: repair, success: true });
+            break;
+          }
+          case 'addBacklink': {
+            // Re-scan W022 warnings to find all (source, target) pairs
+            const w022Warnings = warnings.filter(w => w.code === 'W022');
+            for (const w of w022Warnings) {
+              const match = /Asymmetric related link: "([^"]+)" references "([^"]+)"/.exec(w.message);
+              if (!match) continue;
+              const [, sourceFile, targetFile] = match;
+              const targetPath = path.join(pendingTodosDir, targetFile);
+              try {
+                const content = fs.readFileSync(targetPath, 'utf-8');
+                const fm = extractFrontmatter(content);
+                const relatedList = fm && fm.related
+                  ? (Array.isArray(fm.related) ? fm.related : [fm.related])
+                  : [];
+                if (!relatedList.includes(sourceFile)) {
+                  relatedList.push(sourceFile);
+                }
+                if (!fm) continue;
+                fm.related = relatedList;
+                const newContent = spliceFrontmatter(content, fm);
+                fs.writeFileSync(targetPath, newContent, 'utf-8');
+              } catch (_e) { /* skip unreadable files */ }
+            }
+            repairActions.push({ action: repair, success: true });
             break;
           }
         }

--- a/gsd-ng/workflows/add-todo.md
+++ b/gsd-ng/workflows/add-todo.md
@@ -73,12 +73,27 @@ If potential duplicate found:
 2. Compare scope
 
 If overlapping, use AskUserQuestion:
-- header: "Duplicate?"
-- question: "Similar todo exists: [title]. What would you like to do?"
-- options:
-  - "Skip" — keep existing todo
-  - "Replace" — update existing with new context
-  - "Add anyway" — create as separate todo
+```
+AskUserQuestion(
+  header: "Duplicate?",
+  question: "Similar todo exists: [title]. What would you like to do?",
+  multiSelect: false,
+  options: [
+    { label: "Skip", description: "Keep existing todo" },
+    { label: "Replace", description: "Update existing with new context" },
+    { label: "Add anyway", description: "Create as separate todo" },
+    { label: "Link as related", description: "Create new todo and link both as related" }
+  ]
+)
+```
+
+Handle responses:
+- **"Skip"**: Do not create new todo. Exit workflow.
+- **"Replace"**: Update the existing todo file with new context. Exit workflow.
+- **"Add anyway"**: Continue to `create_file` step as normal.
+- **"Link as related"**: Set `LINK_AS_RELATED=true` and `EXISTING_TODO_FOR_LINK="[existing-todo-filename]"` (basename only, e.g. `2026-03-29-auth-refresh.md`). Continue to `create_file` step.
+
+Note: If "Link as related" was selected, `$LINK_AS_RELATED` is set to `true` and `$EXISTING_TODO_FOR_LINK` holds the existing todo filename. The auto-backlink runs in the `git_commit` step after `create_file`.
 </step>
 
 <step name="create_file">
@@ -126,10 +141,44 @@ If `.planning/STATE.md` exists:
 </step>
 
 <step name="git_commit">
-Commit the todo and any updated state:
+**If `$LINK_AS_RELATED` is true**, run the auto-backlink BEFORE committing:
 
 ```bash
-node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title]" --files .planning/todos/pending/[filename] .planning/STATE.md
+# NEW_TODO_FILE is the filename just created (e.g., "2026-03-29-my-new-todo.md")
+# EXISTING_TODO_FOR_LINK is the similar todo found during duplicate check (basename only)
+
+# Set related: on the new todo (fresh file, no existing related: field)
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$NEW_TODO_FILE" --field related --value "[\"$EXISTING_TODO_FOR_LINK\"]"
+
+# Append to related: on the existing todo (may already have related: entries)
+EXISTING_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --raw 2>/dev/null || echo "")
+UPDATED_RELATED=$(echo "$EXISTING_RELATED" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      if (!arr.includes('$NEW_TODO_FILE')) arr.push('$NEW_TODO_FILE');
+      console.log(JSON.stringify(arr));
+    } catch { console.log(JSON.stringify(['$NEW_TODO_FILE'])); }
+  });
+")
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --value "$UPDATED_RELATED"
+```
+
+Log: `Linked: $NEW_TODO_FILE <-> $EXISTING_TODO_FOR_LINK`
+
+Commit the todo, any updated state, and (if linking) the existing todo:
+
+```bash
+if [[ "$LINK_AS_RELATED" == "true" ]]; then
+  node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title] (linked to $EXISTING_TODO_FOR_LINK)" \
+    --files ".planning/todos/pending/$NEW_TODO_FILE" ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" .planning/STATE.md
+else
+  node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title]" --files .planning/todos/pending/[filename] .planning/STATE.md
+fi
 ```
 
 Tool respects `commit_docs` config and gitignore automatically.

--- a/gsd-ng/workflows/add-todo.md
+++ b/gsd-ng/workflows/add-todo.md
@@ -155,15 +155,16 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
 EXISTING_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
   ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --raw 2>/dev/null || echo "")
 UPDATED_RELATED=$(echo "$EXISTING_RELATED" | node -e "
+  const newFile = process.argv[1];
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
     try {
       const v = JSON.parse(d);
       const arr = Array.isArray(v) ? v : (v ? [v] : []);
-      if (!arr.includes('$NEW_TODO_FILE')) arr.push('$NEW_TODO_FILE');
+      if (!arr.includes(newFile)) arr.push(newFile);
       console.log(JSON.stringify(arr));
-    } catch { console.log(JSON.stringify(['$NEW_TODO_FILE'])); }
+    } catch { console.log(JSON.stringify([newFile])); }
   });
-")
+" "$NEW_TODO_FILE")
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
   ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --value "$UPDATED_RELATED"
 ```

--- a/gsd-ng/workflows/discuss-phase.md
+++ b/gsd-ng/workflows/discuss-phase.md
@@ -250,6 +250,84 @@ For each linked todo in auto mode:
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set ".planning/todos/pending/$FILE" --field phase --value "${PHASE}"
 ```
 
+**Surface related: link suggestions (interactive mode only)**
+
+After the phase: linking is done, check if this phase has a source todo and surface potential `related:` links.
+
+In **--auto mode**: skip this section entirely. Related: linking during discussion requires user confirmation — it is not a closure workflow.
+
+In **interactive mode**:
+
+1. Find the source todo for this phase by checking ROADMAP.md:
+```bash
+SOURCE_TODO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --raw 2>/dev/null | node -e "
+  process.stdin.on('data', d => {
+    try { const r = JSON.parse(d); console.log(r.source_todos || ''); } catch { console.log(''); }
+  });
+")
+```
+
+2. If `$SOURCE_TODO` is non-empty, read its existing `related:` field:
+```bash
+EXISTING_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+```
+
+3. From the phase: linking candidates above (1-3 todos that were evaluated), filter for any that:
+   - Were NOT selected for phase: linking
+   - Are NOT already in the source todo's `related:` field
+
+4. If 1-3 such candidates exist:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "These pending todos may be related to the source todo for Phase ${PHASE}. Link them via related: field?",
+  multiSelect: true,
+  options: [
+    { label: "[todo-filename-1]", description: "[todo title 1]" },
+    ...
+    { label: "None of these", description: "Skip related linking" }
+  ]
+)
+```
+
+5. For each selected todo (not "None of these"), set `related:` bidirectionally using the safe read-append-write pattern:
+```bash
+# Append selected todo filename to source todo's related: field
+SOURCE_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+UPDATED_SOURCE=$(echo "$SOURCE_RELATED_RAW" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      if (!arr.includes('$SELECTED_FILE')) arr.push('$SELECTED_FILE');
+      console.log(JSON.stringify(arr));
+    } catch { console.log(JSON.stringify(['$SELECTED_FILE'])); }
+  });
+")
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$SOURCE_TODO" --field related --value "$UPDATED_SOURCE"
+
+# Append source todo filename to selected todo's related: field (backlink)
+SELECTED_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
+  ".planning/todos/pending/$SELECTED_FILE" --field related --raw 2>/dev/null || echo "")
+UPDATED_SELECTED=$(echo "$SELECTED_RELATED_RAW" | node -e "
+  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+    try {
+      const v = JSON.parse(d);
+      const arr = Array.isArray(v) ? v : (v ? [v] : []);
+      if (!arr.includes('$SOURCE_TODO')) arr.push('$SOURCE_TODO');
+      console.log(JSON.stringify(arr));
+    } catch { console.log(JSON.stringify(['$SOURCE_TODO'])); }
+  });
+")
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
+  ".planning/todos/pending/$SELECTED_FILE" --field related --value "$UPDATED_SELECTED"
+```
+
+Log: `Linked related: $SOURCE_TODO <-> $SELECTED_FILE`
+
 Continue to load_prior_context.
 </step>
 

--- a/gsd-ng/workflows/discuss-phase.md
+++ b/gsd-ng/workflows/discuss-phase.md
@@ -297,15 +297,16 @@ AskUserQuestion(
 SOURCE_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
   ".planning/todos/pending/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
 UPDATED_SOURCE=$(echo "$SOURCE_RELATED_RAW" | node -e "
+  const newFile = process.argv[1];
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
     try {
       const v = JSON.parse(d);
       const arr = Array.isArray(v) ? v : (v ? [v] : []);
-      if (!arr.includes('$SELECTED_FILE')) arr.push('$SELECTED_FILE');
+      if (!arr.includes(newFile)) arr.push(newFile);
       console.log(JSON.stringify(arr));
-    } catch { console.log(JSON.stringify(['$SELECTED_FILE'])); }
+    } catch { console.log(JSON.stringify([newFile])); }
   });
-")
+" "$SELECTED_FILE")
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
   ".planning/todos/pending/$SOURCE_TODO" --field related --value "$UPDATED_SOURCE"
 
@@ -313,15 +314,16 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
 SELECTED_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
   ".planning/todos/pending/$SELECTED_FILE" --field related --raw 2>/dev/null || echo "")
 UPDATED_SELECTED=$(echo "$SELECTED_RELATED_RAW" | node -e "
+  const newFile = process.argv[1];
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
     try {
       const v = JSON.parse(d);
       const arr = Array.isArray(v) ? v : (v ? [v] : []);
-      if (!arr.includes('$SOURCE_TODO')) arr.push('$SOURCE_TODO');
+      if (!arr.includes(newFile)) arr.push(newFile);
       console.log(JSON.stringify(arr));
-    } catch { console.log(JSON.stringify(['$SOURCE_TODO'])); }
+    } catch { console.log(JSON.stringify([newFile])); }
   });
-")
+" "$SOURCE_TODO")
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
   ".planning/todos/pending/$SELECTED_FILE" --field related --value "$UPDATED_SELECTED"
 ```

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -833,6 +833,105 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close phase-linked t
 ```
 
 Note: `todo complete` triggers inline issue-sync automatically (from Plan 01) — no additional sync code needed here.
+
+**Related Todos scan (after phase-linked scan):**
+
+Fire when `$VERIFY_STATUS` is `passed` AND `$ORIGIN_TODO_FILE` is set. The origin todo may now be in completed/ (just closed above), so check both locations.
+
+**Step 1 — Read outbound links from origin todo:**
+```bash
+RELATED_OUTBOUND=""
+if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS" == "passed" ]]; then
+  # Origin todo may have been moved to completed/ in the closure step above
+  ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
+  if [[ ! -f "$ORIGIN_PATH" ]]; then
+    ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
+  fi
+  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
+  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
+    # Normalize: parse JSON (string or array) into newline-separated filenames
+    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
+      });
+    ")
+  fi
+fi
+```
+
+**Step 2 — Scan all pending todos for inbound links to origin:**
+```bash
+RELATED_INBOUND=""
+PENDING_DIR=".planning/todos/pending"
+if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS" == "passed" ]]; then
+  for TODO_FILE in "$PENDING_DIR"/*.md; do
+    [[ -f "$TODO_FILE" ]] || continue
+    TODO_BASENAME=$(basename "$TODO_FILE")
+    # Skip the origin todo itself
+    [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
+    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
+    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
+      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
+        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
+      fi
+    fi
+  done
+fi
+```
+
+**Step 3 — Deduplicate and filter (only pending/ files):**
+```bash
+RELATED_ALL=""
+if [[ -n "$RELATED_OUTBOUND" ]] || [[ -n "$RELATED_INBOUND" ]]; then
+  # Combine outbound + inbound, deduplicate, filter to files still in pending/
+  RELATED_ALL=$(printf "%s\n%s" "$RELATED_OUTBOUND" "$RELATED_INBOUND" | sort -u | while read -r REL_FILE; do
+    [[ -z "$REL_FILE" ]] && continue
+    [[ "$REL_FILE" == "$ORIGIN_TODO_FILE" ]] && continue
+    if [[ -f ".planning/todos/pending/$REL_FILE" ]]; then
+      echo "$REL_FILE"
+    fi
+  done)
+fi
+```
+
+**Step 4 — Present for closure (auto or interactive):**
+
+If `$RELATED_ALL` is non-empty:
+
+**Auto mode:**
+```bash
+if [[ "$AUTO_CFG" == "true" ]]; then
+  while IFS= read -r REL_TODO; do
+    [[ -z "$REL_TODO" ]] && continue
+    REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after phase completion" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
+    echo "[auto] Closed related todo: $REL_TITLE"
+  done <<< "$RELATED_ALL"
+fi
+```
+
+**Interactive mode** — build options list and use AskUserQuestion:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "Closing '$ORIGIN_TODO_TITLE' — these todos are linked via related:. Close them too?",
+  multiSelect: true,
+  options: [
+    { label: "[rel-filename-1]", description: "[rel-title-1]" },
+    ...
+    { label: "Keep all open", description: "Leave all in pending" }
+  ]
+)
+```
+
+For each selected todo (not "Keep all open"):
+```bash
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$SELECTED_REL"
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after phase completion" --files ".planning/todos/completed/$SELECTED_REL" ".planning/todos/pending/$SELECTED_REL"
+```
+
+Note: `todo complete` triggers inline issue-sync automatically — no additional sync code needed.
 </step>
 
 </process>

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -847,15 +847,8 @@ if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS" == "passed" ]]; then
   if [[ ! -f "$ORIGIN_PATH" ]]; then
     ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
   fi
-  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
-  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
-    # Normalize: parse JSON (string or array) into newline-separated filenames
-    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
-      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
-      });
-    ")
-  fi
+  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --raw 2>/dev/null || echo "")
+  if [[ "$RELATED_OUTBOUND" == "null" ]]; then RELATED_OUTBOUND=""; fi
 fi
 ```
 
@@ -869,11 +862,8 @@ if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS
     TODO_BASENAME=$(basename "$TODO_FILE")
     # Skip the origin todo itself
     [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
-    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
-    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
-      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
-        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
-      fi
+    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline --raw 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
+      RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
     fi
   done
 fi

--- a/gsd-ng/workflows/quick.md
+++ b/gsd-ng/workflows/quick.md
@@ -824,14 +824,8 @@ if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
   if [[ ! -f "$ORIGIN_PATH" ]]; then
     ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
   fi
-  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
-  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
-    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
-      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
-      });
-    ")
-  fi
+  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --raw 2>/dev/null || echo "")
+  if [[ "$RELATED_OUTBOUND" == "null" ]]; then RELATED_OUTBOUND=""; fi
 fi
 ```
 
@@ -844,11 +838,8 @@ if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED
     [[ -f "$TODO_FILE" ]] || continue
     TODO_BASENAME=$(basename "$TODO_FILE")
     [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
-    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
-    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
-      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
-        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
-      fi
+    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline --raw 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
+      RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
     fi
   done
 fi

--- a/gsd-ng/workflows/quick.md
+++ b/gsd-ng/workflows/quick.md
@@ -809,6 +809,104 @@ Display: `Closed todo: $ORIGIN_TODO_TITLE`
 If user selects "No, keep open":
 Display: `Todo kept open: $ORIGIN_TODO_TITLE`
 
+Set `ORIGIN_CLOSED=true` after origin todo is closed (either auto or interactive "Yes"). If origin was not closed (user said "No, keep open" or auto kept open), do NOT run the related-todo scan.
+
+**Related Todos scan (only when origin todo was closed):**
+
+Fire when `$ORIGIN_TODO_FILE` is set AND `$ORIGIN_CLOSED` is `true`.
+
+**Step 1 — Read outbound links from origin todo (now in completed/):**
+```bash
+RELATED_OUTBOUND=""
+if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  # Origin was just closed — check completed/ first, then pending/ as fallback
+  ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
+  if [[ ! -f "$ORIGIN_PATH" ]]; then
+    ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
+  fi
+  RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --raw 2>/dev/null || echo "")
+  if [[ -n "$RELATED_RAW" ]] && [[ "$RELATED_RAW" != "null" ]]; then
+    RELATED_OUTBOUND=$(echo "$RELATED_RAW" | node -e "
+      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
+        try { const v=JSON.parse(d); const arr=Array.isArray(v)?v:(v?[v]:[]); console.log(arr.join('\n')); } catch { console.log(''); }
+      });
+    ")
+  fi
+fi
+```
+
+**Step 2 — Scan all pending todos for inbound links to origin:**
+```bash
+RELATED_INBOUND=""
+PENDING_DIR=".planning/todos/pending"
+if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
+  for TODO_FILE in "$PENDING_DIR"/*.md; do
+    [[ -f "$TODO_FILE" ]] || continue
+    TODO_BASENAME=$(basename "$TODO_FILE")
+    [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
+    TODO_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --raw 2>/dev/null || echo "")
+    if [[ -n "$TODO_RELATED" ]] && [[ "$TODO_RELATED" != "null" ]]; then
+      if echo "$TODO_RELATED" | grep -q "$ORIGIN_TODO_FILE"; then
+        RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
+      fi
+    fi
+  done
+fi
+```
+
+**Step 3 — Deduplicate and filter (only pending/ files):**
+```bash
+RELATED_ALL=""
+if [[ -n "$RELATED_OUTBOUND" ]] || [[ -n "$RELATED_INBOUND" ]]; then
+  RELATED_ALL=$(printf "%s\n%s" "$RELATED_OUTBOUND" "$RELATED_INBOUND" | sort -u | while read -r REL_FILE; do
+    [[ -z "$REL_FILE" ]] && continue
+    [[ "$REL_FILE" == "$ORIGIN_TODO_FILE" ]] && continue
+    if [[ -f ".planning/todos/pending/$REL_FILE" ]]; then
+      echo "$REL_FILE"
+    fi
+  done)
+fi
+```
+
+**Step 4 — Present for closure (auto or interactive):**
+
+If `$RELATED_ALL` is non-empty:
+
+**Auto mode:**
+```bash
+if [[ "$AUTO_CFG" == "true" ]]; then
+  while IFS= read -r REL_TODO; do
+    [[ -z "$REL_TODO" ]] && continue
+    REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
+    node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after quick task" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
+    echo "[auto] Closed related todo: $REL_TITLE"
+  done <<< "$RELATED_ALL"
+fi
+```
+
+**Interactive mode** — build options list and use AskUserQuestion:
+```
+AskUserQuestion(
+  header: "Related Todos",
+  question: "Closing '$ORIGIN_TODO_TITLE' — these todos are linked via related:. Close them too?",
+  multiSelect: true,
+  options: [
+    { label: "[rel-filename-1]", description: "[rel-title-1]" },
+    ...
+    { label: "Keep all open", description: "Leave all in pending" }
+  ]
+)
+```
+
+For each selected todo (not "Keep all open"):
+```bash
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$SELECTED_REL"
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after quick task" --files ".planning/todos/completed/$SELECTED_REL" ".planning/todos/pending/$SELECTED_REL"
+```
+
+Note: `todo complete` triggers inline issue-sync automatically — no additional sync code needed.
+
 </process>
 
 <success_criteria>

--- a/tests/frontmatter-cli.test.cjs
+++ b/tests/frontmatter-cli.test.cjs
@@ -270,6 +270,39 @@ body`;
   });
 });
 
+// ─── frontmatter get --format newline ───────────────────────────────────────
+
+describe('frontmatter get --format newline', () => {
+  test('outputs array values one per line with --format newline --raw', () => {
+    const file = writeTempFile('---\ntags:\n  - alpha\n  - beta\n  - gamma\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field tags --format newline --raw`);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output, 'alpha\nbeta\ngamma');
+  });
+
+  test('passes scalar through unchanged with --format newline --raw', () => {
+    const file = writeTempFile('---\ntitle: My Title\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field title --format newline --raw`);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output, 'My Title');
+  });
+
+  test('comma-separated output without --format flag is backward compatible', () => {
+    const file = writeTempFile('---\ntags:\n  - alpha\n  - beta\n  - gamma\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field tags --raw`);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output, 'alpha, beta, gamma');
+  });
+
+  test('returns JSON object with --format newline but no --raw', () => {
+    const file = writeTempFile('---\ntags:\n  - alpha\n  - beta\n  - gamma\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field tags --format newline`);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.deepStrictEqual(parsed, { tags: ['alpha', 'beta', 'gamma'] });
+  });
+});
+
 // ─── frontmatter set validates field name (SEC-02) ──────────────────────────
 
 describe('frontmatter set validates field name (SEC-02)', () => {

--- a/tests/verify-health.test.cjs
+++ b/tests/verify-health.test.cjs
@@ -1369,8 +1369,8 @@ describe('validate health — related link checks (W021-W022)', () => {
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const parsed = JSON.parse(result.output);
-    const clearAction = parsed.repairActions && parsed.repairActions.find(a => a.action === 'clearRelatedLink');
-    assert.ok(clearAction, `Expected clearRelatedLink repairAction: ${JSON.stringify(parsed.repairActions)}`);
+    const clearAction = parsed.repairs_performed && parsed.repairs_performed.find(a => a.action === 'clearRelatedLink');
+    assert.ok(clearAction, `Expected clearRelatedLink in repairs_performed: ${JSON.stringify(parsed.repairs_performed)}`);
     assert.strictEqual(clearAction.success, true, 'clearRelatedLink should succeed');
 
     const { extractFrontmatter: efm } = require('../gsd-ng/bin/lib/frontmatter.cjs');
@@ -1410,8 +1410,8 @@ describe('validate health — related link checks (W021-W022)', () => {
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const parsed = JSON.parse(result.output);
-    const backlinkAction = parsed.repairActions && parsed.repairActions.find(a => a.action === 'addBacklink');
-    assert.ok(backlinkAction, `Expected addBacklink repairAction: ${JSON.stringify(parsed.repairActions)}`);
+    const backlinkAction = parsed.repairs_performed && parsed.repairs_performed.find(a => a.action === 'addBacklink');
+    assert.ok(backlinkAction, `Expected addBacklink in repairs_performed: ${JSON.stringify(parsed.repairs_performed)}`);
     assert.strictEqual(backlinkAction.success, true, 'addBacklink should succeed');
 
     const { extractFrontmatter: efm } = require('../gsd-ng/bin/lib/frontmatter.cjs');

--- a/tests/verify-health.test.cjs
+++ b/tests/verify-health.test.cjs
@@ -1200,3 +1200,163 @@ describe('validate health — orphan detection checks (W015-W018)', () => {
     assert.strictEqual(w018.repairable, true, 'W018 should be repairable');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// validate health — related link checks (W021-W022)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('validate health — related link checks (W021-W022)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    writeMinimalProjectMd(tmpDir);
+    writeMinimalStateMd(tmpDir, '# Session State\n\nPhase 1 in progress.\n');
+    writeValidConfigJson(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), '# Project\n\nInstructions.\n');
+    // Write a minimal ROADMAP with one phase so W017/W018 don't interfere
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phases\n\n- [ ] **Phase 1: Test Phase**\n'
+    );
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-test'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // ─── Helper: write a pending todo with frontmatter ────────────────────────
+
+  function writePendingTodo(tmpDir, filename, frontmatter) {
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    fs.mkdirSync(pendingDir, { recursive: true });
+    const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`).join('\n');
+    fs.writeFileSync(
+      path.join(pendingDir, filename),
+      `---\n${fmLines}\n---\n\nTodo content.\n`
+    );
+  }
+
+  // ─── Helper: write a completed todo with frontmatter ─────────────────────
+
+  function writeCompletedTodo(tmpDir, filename, frontmatter) {
+    const completedDir = path.join(tmpDir, '.planning', 'todos', 'completed');
+    fs.mkdirSync(completedDir, { recursive: true });
+    const fmLines = Object.entries(frontmatter).map(([k, v]) => `${k}: ${v}`).join('\n');
+    fs.writeFileSync(
+      path.join(completedDir, filename),
+      `---\n${fmLines}\n---\n\nTodo content.\n`
+    );
+  }
+
+  // ─── W021: broken related links ───────────────────────────────────────────
+
+  test('W021 fires when pending todo related: references non-existent file', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const w021 = parsed.warnings.find(w => w.code === 'W021');
+    assert.ok(w021, `Expected W021 in warnings: ${JSON.stringify(parsed.warnings)}`);
+    assert.ok(w021.message.includes('ghost.md'), `W021 message should mention "ghost.md": ${w021.message}`);
+    assert.ok(w021.message.includes('does not exist'), `W021 message should include "does not exist": ${w021.message}`);
+    assert.strictEqual(w021.repairable, true, 'W021 should be repairable');
+  });
+
+  test('W021 does NOT fire when related: references file that exists in completed/', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[other.md]' });
+    writeCompletedTodo(tmpDir, 'other.md', { completed: '2026-03-29' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W021'),
+      `Should not have W021 when ref exists in completed/: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+
+  test('W021 does NOT fire when related: references file that exists in pending/', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { related: '[todo-a.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W021'),
+      `Should not have W021 when ref exists in pending/: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+
+  test('W021 is repairable', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const w021 = parsed.warnings.find(w => w.code === 'W021');
+    assert.ok(w021, `Expected W021: ${JSON.stringify(parsed.warnings)}`);
+    assert.strictEqual(w021.repairable, true, 'W021 should be repairable');
+  });
+
+  // ─── W022: asymmetric related links ───────────────────────────────────────
+
+  test('W022 fires when related: link is asymmetric (A references B but B does not reference A back)', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { title: 'Todo B' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const w022 = parsed.warnings.find(w => w.code === 'W022');
+    assert.ok(w022, `Expected W022 in warnings: ${JSON.stringify(parsed.warnings)}`);
+    assert.ok(
+      w022.message.toLowerCase().includes('asymmetric'),
+      `W022 message should include "asymmetric": ${w022.message}`
+    );
+    assert.ok(w022.message.includes('todo-a.md'), `W022 message should mention "todo-a.md": ${w022.message}`);
+    assert.ok(w022.message.includes('todo-b.md'), `W022 message should mention "todo-b.md": ${w022.message}`);
+    assert.strictEqual(w022.repairable, true, 'W022 should be repairable');
+  });
+
+  test('W022 does NOT fire when related: references are symmetric', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { related: '[todo-a.md]' });
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W022'),
+      `Should not have W022 for symmetric related refs: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+
+  test('W022 skips refs not in pending/ (no double-warn with W021 for missing files)', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md]' });
+    // ghost.md does not exist in pending/ or completed/
+
+    const result = runGsdTools('validate health', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    // W021 should fire (broken link), W022 should NOT fire (ghost not in pending/)
+    assert.ok(
+      parsed.warnings.some(w => w.code === 'W021'),
+      `Expected W021 for missing ref: ${JSON.stringify(parsed.warnings)}`
+    );
+    assert.ok(
+      !parsed.warnings.some(w => w.code === 'W022'),
+      `Should not have W022 when ref not in pending/: ${JSON.stringify(parsed.warnings)}`
+    );
+  });
+});

--- a/tests/verify-health.test.cjs
+++ b/tests/verify-health.test.cjs
@@ -1359,4 +1359,106 @@ describe('validate health — related link checks (W021-W022)', () => {
       `Should not have W022 when ref not in pending/: ${JSON.stringify(parsed.warnings)}`
     );
   });
+
+  // ─── W021 repair: clearRelatedLink ────────────────────────────────────────
+
+  test('W021 repair removes stale related: entry from pending todo file', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md]' });
+
+    const result = runGsdTools('validate health --repair', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const clearAction = parsed.repairActions && parsed.repairActions.find(a => a.action === 'clearRelatedLink');
+    assert.ok(clearAction, `Expected clearRelatedLink repairAction: ${JSON.stringify(parsed.repairActions)}`);
+    assert.strictEqual(clearAction.success, true, 'clearRelatedLink should succeed');
+
+    const { extractFrontmatter: efm } = require('../gsd-ng/bin/lib/frontmatter.cjs');
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'todo-a.md'), 'utf-8');
+    const fm = efm(content);
+    const relatedList = fm.related
+      ? (Array.isArray(fm.related) ? fm.related : [fm.related])
+      : [];
+    assert.ok(!relatedList.includes('ghost.md'), `ghost.md should be removed from related: ${JSON.stringify(relatedList)}`);
+  });
+
+  test('W021 repair removes only the stale entry, preserving valid related refs', () => {
+    // todo-a.md references ghost.md (stale) and todo-b.md (valid)
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md, todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { related: '[todo-a.md]' });
+
+    const result = runGsdTools('validate health --repair', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const { extractFrontmatter: efm } = require('../gsd-ng/bin/lib/frontmatter.cjs');
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'todo-a.md'), 'utf-8');
+    const fm = efm(content);
+    const relatedList = fm.related
+      ? (Array.isArray(fm.related) ? fm.related : [fm.related])
+      : [];
+    assert.ok(!relatedList.includes('ghost.md'), `ghost.md should be removed: ${JSON.stringify(relatedList)}`);
+    assert.ok(relatedList.includes('todo-b.md'), `todo-b.md should be preserved: ${JSON.stringify(relatedList)}`);
+  });
+
+  // ─── W022 repair: addBacklink ─────────────────────────────────────────────
+
+  test('W022 repair adds missing backlink to target todo file', () => {
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { title: 'Todo B' });
+
+    const result = runGsdTools('validate health --repair', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    const backlinkAction = parsed.repairActions && parsed.repairActions.find(a => a.action === 'addBacklink');
+    assert.ok(backlinkAction, `Expected addBacklink repairAction: ${JSON.stringify(parsed.repairActions)}`);
+    assert.strictEqual(backlinkAction.success, true, 'addBacklink should succeed');
+
+    const { extractFrontmatter: efm } = require('../gsd-ng/bin/lib/frontmatter.cjs');
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'todo-b.md'), 'utf-8');
+    const fm = efm(content);
+    const relatedList = fm.related
+      ? (Array.isArray(fm.related) ? fm.related : [fm.related])
+      : [];
+    assert.ok(relatedList.includes('todo-a.md'), `todo-b.md should now reference todo-a.md: ${JSON.stringify(relatedList)}`);
+  });
+
+  test('W022 repair preserves existing related refs when adding backlink', () => {
+    // todo-a references todo-b (asymmetric), todo-b already references todo-c
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { related: '[todo-c.md]' });
+    writePendingTodo(tmpDir, 'todo-c.md', { related: '[todo-b.md]' });
+
+    const result = runGsdTools('validate health --repair', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const { extractFrontmatter: efm } = require('../gsd-ng/bin/lib/frontmatter.cjs');
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'todo-b.md'), 'utf-8');
+    const fm = efm(content);
+    const relatedList = fm.related
+      ? (Array.isArray(fm.related) ? fm.related : [fm.related])
+      : [];
+    assert.ok(relatedList.includes('todo-c.md'), `Existing ref todo-c.md should be preserved: ${JSON.stringify(relatedList)}`);
+    assert.ok(relatedList.includes('todo-a.md'), `Backlink todo-a.md should be added: ${JSON.stringify(relatedList)}`);
+  });
+
+  test('W021 and W022 repairs are idempotent — re-running health shows no warnings', () => {
+    // Setup: todo-a has stale ref, todo-a references todo-b (asymmetric)
+    writePendingTodo(tmpDir, 'todo-a.md', { related: '[ghost.md, todo-b.md]' });
+    writePendingTodo(tmpDir, 'todo-b.md', { title: 'Todo B' });
+
+    // First run with repair
+    const repairResult = runGsdTools('validate health --repair', tmpDir);
+    assert.ok(repairResult.success, `Repair command failed: ${repairResult.error}`);
+
+    // Second run without repair — should show no W021 or W022
+    const checkResult = runGsdTools('validate health', tmpDir);
+    assert.ok(checkResult.success, `Health check failed: ${checkResult.error}`);
+
+    const parsed = JSON.parse(checkResult.output);
+    const w021s = parsed.warnings.filter(w => w.code === 'W021');
+    const w022s = parsed.warnings.filter(w => w.code === 'W022');
+    assert.strictEqual(w021s.length, 0, `Should have no W021 warnings after repair: ${JSON.stringify(w021s)}`);
+    assert.strictEqual(w022s.length, 0, `Should have no W022 warnings after repair: ${JSON.stringify(w022s)}`);
+  });
 });


### PR DESCRIPTION
## Summary

Teach workflows, verifier, and CLI to read `related:` frontmatter field on todos. Enable batch closure of linked todos, verifier cross-checking, and duplicate-check suggestions.

Reopens #9 (auto-closed when base branch `feature/39-content-optimization-shipping` was deleted after PR #8 merge).

## Changes

- **43-01**: W021 (broken related links) and W022 (asymmetric related links) health checks added to verify.cjs with 7 TDD test cases, matching the W017/W018 structural pattern
- **43-02**: Bidirectional related-todo scan added to all three orchestrator closure points (execute-phase, quick, gsd-debugger) using outbound+inbound resolution, auto-mode auto-close, and interactive AskUserQuestion multi-select
- **43-03**: "Link as related" 4th option in add-todo with safe bidirectional auto-backlink, related: suggestions in discuss-phase, non-blocking verifier Step 8b warning, and 9 REL43-XX requirements registered

## Test Plan

- [ ] Automated tests pass (`npm test` — includes 7 new W021/W022 health check tests)
- [ ] Manual verification of related: frontmatter linking in add-todo workflow
- [ ] Verify bidirectional related-todo scan triggers at phase close

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng) from phase 43 execution*