### PR TITLE
Phase 45: E2E smoke test, dynamic UID fix, --current filter tests

### DIFF
--- a/benchmarks/benchmark-runner.cjs
+++ b/benchmarks/benchmark-runner.cjs
@@ -162,7 +162,7 @@ function validateTasks(tasks, config) {
  * @returns {string} Path to writable temp dir
  */
 function resolveTmpDir() {
-  const candidates = [process.env.TMPDIR, os.tmpdir(), '/tmp/claude-1000', '/tmp'].filter(Boolean);
+  const candidates = [process.env.TMPDIR, os.tmpdir(), `/tmp/claude-${process.getuid()}`, '/tmp'].filter(Boolean);
   for (const dir of candidates) {
     try {
       if (fs.existsSync(dir)) return dir;

--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -57,7 +57,7 @@ process.stdin.on('end', () => {
       }
     }
 
-    const tmpDir = [process.env.TMPDIR, os.tmpdir(), '/tmp/claude-1000', '/tmp']
+    const tmpDir = [process.env.TMPDIR, os.tmpdir(), `/tmp/claude-${process.getuid()}`, '/tmp']
       .filter(Boolean)
       .find(d => { try { return fs.existsSync(d); } catch { return false; } })
       || os.tmpdir();

--- a/hooks/gsd-sandbox-detect.js
+++ b/hooks/gsd-sandbox-detect.js
@@ -29,7 +29,7 @@ process.stdin.on('end', () => {
     const sessionId = data.session_id || 'unknown';
 
     // ── Once-per-session gate ─────────────────────────────────────────────
-    const sandboxTmpDir = [process.env.TMPDIR, os.tmpdir(), '/tmp/claude-1000', '/tmp']
+    const sandboxTmpDir = [process.env.TMPDIR, os.tmpdir(), `/tmp/claude-${process.getuid()}`, '/tmp']
       .filter(Boolean)
       .find(d => { try { return fs.existsSync(d); } catch { return false; } })
       || os.tmpdir();

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "prepublishOnly": "npm run build:hooks",
     "pretest": "npm run build:hooks",
     "test": "node scripts/run-tests.cjs",
+    "test:e2e": "node --test tests/e2e/smoke.test.cjs",
     "test:coverage": "npm run build:hooks && c8 --check-coverage --lines 70 --reporter text --include 'gsd-ng/bin/lib/*.cjs' --exclude 'tests/**' --all node scripts/run-tests.cjs"
   }
 }

--- a/tests/benchmark-harness.test.cjs
+++ b/tests/benchmark-harness.test.cjs
@@ -38,7 +38,7 @@ const { evaluateOutput } = require('../benchmarks/evaluators/structural.cjs');
 
 // Resolve writable temp dir (sandbox-safe, same pattern as helpers.cjs)
 function resolveTmpDir() {
-  const candidates = [process.env.TMPDIR, os.tmpdir(), '/tmp/claude-1000', '/tmp'].filter(Boolean);
+  const candidates = [process.env.TMPDIR, os.tmpdir(), `/tmp/claude-${process.getuid()}`, '/tmp'].filter(Boolean);
   for (const dir of candidates) {
     try { if (fs.existsSync(dir)) return dir; } catch {}
   }

--- a/tests/e2e/smoke.test.cjs
+++ b/tests/e2e/smoke.test.cjs
@@ -1,0 +1,249 @@
+'use strict';
+/**
+ * E2E Smoke Test: install to execute lifecycle
+ *
+ * Validates the full install -> scaffold -> init plan-phase -> init execute-phase
+ * lifecycle using the INSTALLED copy of gsd-tools.cjs (not the source copy).
+ *
+ * This catches integration bugs like positional argument issues that unit tests miss.
+ */
+const { describe, test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { resolveTmpDir, createTempGitProject, cleanup } = require('../helpers.cjs');
+
+const INSTALLER = path.resolve(__dirname, '..', '..', 'bin', 'install.js');
+
+/** Run a command against the installed gsd-tools.cjs copy (not source). */
+function runInstalled(args, cwd, installedToolsPath) {
+  const result = spawnSync(process.execPath, [installedToolsPath, ...args], {
+    cwd,
+    encoding: 'utf-8',
+    env: process.env,
+    timeout: 30000,
+  });
+  return {
+    success: result.status === 0,
+    output: (result.stdout || '').trim(),
+    error: (result.stderr || '').trim(),
+  };
+}
+
+describe('E2E smoke test: install to execute', () => {
+  let projectDir;
+  let INSTALLED_TOOLS;
+
+  before(() => {
+    projectDir = createTempGitProject();
+  });
+
+  after(() => {
+    if (projectDir) cleanup(projectDir);
+  });
+
+  test('E2E-01: install.js --local --runtime claude exits 0 and creates installed gsd-tools.cjs', () => {
+    assert.ok(projectDir, 'projectDir must be set in before()');
+
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        cwd: projectDir,
+        encoding: 'utf8',
+        timeout: 30000,
+        env: process.env,
+      }
+    );
+
+    assert.strictEqual(
+      result.status,
+      0,
+      'install.js --local --runtime claude must exit 0\nstderr: ' + (result.stderr || '')
+    );
+
+    INSTALLED_TOOLS = path.join(projectDir, '.claude', 'gsd-ng', 'bin', 'gsd-tools.cjs');
+    assert.ok(
+      fs.existsSync(INSTALLED_TOOLS),
+      'gsd-tools.cjs must exist at installed path: ' + INSTALLED_TOOLS
+    );
+  });
+
+  test('E2E-02: installed gsd-tools.cjs responds to --help', () => {
+    assert.ok(INSTALLED_TOOLS, 'INSTALLED_TOOLS must be set from E2E-01');
+
+    const result = runInstalled(['--help'], projectDir, INSTALLED_TOOLS);
+    assert.ok(
+      result.success,
+      'installed gsd-tools.cjs --help must exit 0\nstderr: ' + result.error
+    );
+    const combinedOutput = result.output + result.error;
+    assert.ok(
+      combinedOutput.includes('gsd-tools') || combinedOutput.includes('Usage') || combinedOutput.includes('usage'),
+      'installed --help output must mention gsd-tools or Usage\noutput: ' + combinedOutput.slice(0, 500)
+    );
+  });
+
+  test('E2E-03: scaffold phase-dir creates phase directory', () => {
+    assert.ok(INSTALLED_TOOLS, 'INSTALLED_TOOLS must be set from E2E-01');
+
+    // Write a minimal ROADMAP.md with a Phase 1 entry so scaffold can locate phase context
+    const roadmapContent = [
+      '# Roadmap',
+      '',
+      '## Milestone: test',
+      '',
+      '- [ ] **Phase 1: Test phase**',
+      '',
+      '## Phase Details',
+      '',
+      '### Phase 1: Test phase',
+      '**Goal**: Test',
+      '**Requirements**: NONE',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(projectDir, '.planning', 'ROADMAP.md'), roadmapContent);
+
+    // Write a minimal STATE.md with current_phase: 1
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'milestone: test',
+      'current_phase: 1',
+      'current_plan: Not started',
+      'status: testing',
+      '---',
+      '',
+      '# Project State',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(projectDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runInstalled(
+      ['scaffold', 'phase-dir', '--phase', '1', '--name', 'test-phase'],
+      projectDir,
+      INSTALLED_TOOLS
+    );
+    assert.ok(
+      result.success,
+      'scaffold phase-dir must exit 0\nstderr: ' + result.error
+    );
+
+    const phaseDir = path.join(projectDir, '.planning', 'phases', '01-test-phase');
+    assert.ok(
+      fs.existsSync(phaseDir),
+      'Phase directory must be created at: ' + phaseDir
+    );
+  });
+
+  test('E2E-04: scaffold context creates CONTEXT.md template', () => {
+    assert.ok(INSTALLED_TOOLS, 'INSTALLED_TOOLS must be set from E2E-01');
+
+    const result = runInstalled(
+      ['scaffold', 'context', '--phase', '1'],
+      projectDir,
+      INSTALLED_TOOLS
+    );
+    assert.ok(
+      result.success,
+      'scaffold context must exit 0\nstderr: ' + result.error
+    );
+
+    const phaseDir = path.join(projectDir, '.planning', 'phases', '01-test-phase');
+    const contextFile = path.join(phaseDir, '01-CONTEXT.md');
+    assert.ok(
+      fs.existsSync(contextFile),
+      'CONTEXT.md must be created at: ' + contextFile
+    );
+  });
+
+  test('E2E-05: init plan-phase returns valid JSON', () => {
+    assert.ok(INSTALLED_TOOLS, 'INSTALLED_TOOLS must be set from E2E-01');
+
+    const result = runInstalled(
+      ['init', 'plan-phase', '1'],
+      projectDir,
+      INSTALLED_TOOLS
+    );
+    assert.ok(
+      result.success,
+      'init plan-phase must exit 0\nstderr: ' + result.error + '\noutput: ' + result.output
+    );
+
+    let parsed;
+    assert.doesNotThrow(
+      () => { parsed = JSON.parse(result.output); },
+      'init plan-phase output must be valid JSON\noutput: ' + result.output.slice(0, 500)
+    );
+    assert.ok(
+      parsed !== null && typeof parsed === 'object',
+      'init plan-phase JSON must be an object'
+    );
+    // Verify at least one expected key exists in the returned context
+    const hasExpectedKey = 'phase_dir' in parsed || 'phase_number' in parsed || 'phase' in parsed || 'plans' in parsed;
+    assert.ok(
+      hasExpectedKey,
+      'init plan-phase JSON must contain a recognized key (phase_dir, phase_number, phase, or plans)\nkeys: ' + Object.keys(parsed).join(', ')
+    );
+  });
+
+  test('E2E-06: init execute-phase returns valid JSON when PLAN.md exists', () => {
+    assert.ok(INSTALLED_TOOLS, 'INSTALLED_TOOLS must be set from E2E-01');
+
+    // Write a minimal PLAN.md into the phase directory
+    const planContent = [
+      '---',
+      'phase: 01-test-phase',
+      'plan: 01',
+      'type: execute',
+      'wave: 1',
+      'depends_on: []',
+      'files_modified: []',
+      'autonomous: true',
+      'must_haves:',
+      '  truths: ["test passes"]',
+      '  artifacts: []',
+      '  key_links: []',
+      '---',
+      '',
+      '<objective>Test plan</objective>',
+      '<tasks>',
+      '<task type="auto">',
+      '  <name>Task 1: Test</name>',
+      '  <read_first>- test.txt</read_first>',
+      '  <files>test.txt</files>',
+      '  <action>Create test file</action>',
+      '  <verify><automated>test -f test.txt</automated></verify>',
+      '  <acceptance_criteria>- test.txt exists</acceptance_criteria>',
+      '  <done>File exists</done>',
+      '</task>',
+      '</tasks>',
+      '',
+    ].join('\n');
+
+    const phaseDir = path.join(projectDir, '.planning', 'phases', '01-test-phase');
+    const planFile = path.join(phaseDir, '01-01-PLAN.md');
+    fs.writeFileSync(planFile, planContent);
+
+    const result = runInstalled(
+      ['init', 'execute-phase', '1'],
+      projectDir,
+      INSTALLED_TOOLS
+    );
+    assert.ok(
+      result.success,
+      'init execute-phase must exit 0\nstderr: ' + result.error + '\noutput: ' + result.output
+    );
+
+    let parsed;
+    assert.doesNotThrow(
+      () => { parsed = JSON.parse(result.output); },
+      'init execute-phase output must be valid JSON\noutput: ' + result.output.slice(0, 500)
+    );
+    assert.ok(
+      parsed !== null && typeof parsed === 'object',
+      'init execute-phase JSON must be an object'
+    );
+  });
+});

--- a/tests/helpers.cjs
+++ b/tests/helpers.cjs
@@ -55,7 +55,7 @@ function runGsdTools(args, cwd = process.cwd(), envOverrides = {}) {
 // Resolve a writable temp base dir — os.tmpdir() may point to /tmp/claude which doesn't
 // exist in the Claude Code sandbox. Fall back through known-writable candidates.
 function resolveTmpDir() {
-  const candidates = [process.env.TMPDIR, os.tmpdir(), '/tmp/claude-1000', '/tmp'].filter(Boolean);
+  const candidates = [process.env.TMPDIR, os.tmpdir(), `/tmp/claude-${process.getuid()}`, '/tmp'].filter(Boolean);
   for (const dir of candidates) {
     try { if (fs.existsSync(dir)) return dir; } catch {}
   }

--- a/tests/roadmap.test.cjs
+++ b/tests/roadmap.test.cjs
@@ -768,6 +768,116 @@ describe('roadmap update-plan-progress command', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// phase add command
+// roadmap analyze --current filtering
 // ─────────────────────────────────────────────────────────────────────────────
+
+describe('roadmap analyze --current filtering', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('--current filters to current phase only', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---
+gsd_state_version: 1.0
+milestone: test
+current_phase: 2
+current_plan: Not started
+status: testing
+---
+
+# Project State
+`
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+## Milestone: test
+
+- [x] **Phase 1: Foundation** (completed)
+- [ ] **Phase 2: Features**
+- [ ] **Phase 3: Polish**
+
+## Phase Details
+
+### Phase 1: Foundation
+**Goal**: Set up base
+**Requirements**: NONE
+
+### Phase 2: Features
+**Goal**: Build features
+**Requirements**: NONE
+
+### Phase 3: Polish
+**Goal**: Final polish
+**Requirements**: NONE
+`
+    );
+
+    // Create phase dirs for disk status detection
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+
+    const p2 = path.join(tmpDir, '.planning', 'phases', '02-features');
+    fs.mkdirSync(p2, { recursive: true });
+
+    const result = runGsdTools(['roadmap', 'analyze', '--current'], tmpDir);
+    assert.ok(result.success, `Command should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // When filtered by current phase (2), only phase 2 should be in phases array
+    assert.strictEqual(output.phases.length, 1, 'should return only 1 phase (current phase)');
+    assert.ok(
+      output.phases[0].number === '2' || output.phases[0].name === 'Features',
+      `phase should be phase 2 / Features, got: ${JSON.stringify(output.phases[0])}`
+    );
+  });
+
+  test('--current with no current_phase in STATE.md returns full roadmap', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---
+gsd_state_version: 1.0
+milestone: test
+current_plan: Not started
+status: testing
+---
+
+# Project State
+`
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+### Phase 1: Foundation
+**Goal**: Set up base
+
+### Phase 2: Features
+**Goal**: Build features
+
+### Phase 3: Polish
+**Goal**: Final polish
+`
+    );
+
+    const result = runGsdTools(['roadmap', 'analyze', '--current'], tmpDir);
+    assert.ok(result.success, `Command should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_count, 3, 'should return all 3 phases when no current_phase in frontmatter');
+  });
+});
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -1726,3 +1726,125 @@ describe('state adjust-quick-table command', () => {
     assert.ok(updatedContent.includes('Status'), 'Status column should be in updated content');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// state-snapshot --current filtering
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('state-snapshot --current filtering', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('--current filters decisions to current phase only', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---
+gsd_state_version: 1.0
+milestone: test
+current_phase: 2
+current_plan: Not started
+status: testing
+---
+
+# Project State
+
+**Current Phase:** 2
+**Status:** testing
+
+## Decisions Made
+
+| Phase | Decision | Rationale |
+|-------|----------|-----------|
+| 1 | Use library X | Performance |
+| 2 | Use card layout | User preference |
+| 2 | No animations | Accessibility |
+`
+    );
+
+    const result = runGsdTools(['state-snapshot', '--current'], tmpDir);
+    assert.ok(result.success, `Command should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.decisions.length, 2, 'should have 2 decisions (only phase 2)');
+    assert.ok(
+      output.decisions.every(d => d.phase === '2'),
+      'all returned decisions should be phase 2'
+    );
+    assert.ok(
+      !output.decisions.some(d => d.phase === '1'),
+      'phase 1 decisions should be filtered out'
+    );
+  });
+
+  test('--current with no current_phase in STATE.md returns all decisions', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---
+gsd_state_version: 1.0
+milestone: test
+current_plan: Not started
+status: testing
+---
+
+# Project State
+
+**Current Phase:** 1
+**Status:** testing
+
+## Decisions Made
+
+| Phase | Decision | Rationale |
+|-------|----------|-----------|
+| 1 | Use library X | Performance |
+| 2 | Use card layout | User preference |
+| 2 | No animations | Accessibility |
+`
+    );
+
+    const result = runGsdTools(['state-snapshot', '--current'], tmpDir);
+    assert.ok(result.success, `Command should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.decisions.length, 3, 'should return all 3 decisions when no current_phase in frontmatter');
+  });
+
+  test('state-snapshot without --current flag returns all decisions even with current_phase set', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---
+gsd_state_version: 1.0
+milestone: test
+current_phase: 2
+current_plan: Not started
+status: testing
+---
+
+# Project State
+
+**Current Phase:** 2
+**Status:** testing
+
+## Decisions Made
+
+| Phase | Decision | Rationale |
+|-------|----------|-----------|
+| 1 | Use library X | Performance |
+| 2 | Use card layout | User preference |
+| 2 | No animations | Accessibility |
+`
+    );
+
+    const result = runGsdTools(['state-snapshot'], tmpDir);
+    assert.ok(result.success, `Command should succeed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.decisions.length, 3, 'should return all 3 decisions when --current flag not used');
+  });
+});

--- a/tests/statusline-components.test.cjs
+++ b/tests/statusline-components.test.cjs
@@ -29,9 +29,9 @@ const {
 // ─── helpers ────────────────────────────────────────────────────────────────
 
 function makeTmpDir() {
-  // Try os.tmpdir() first; fall back to /tmp/claude-1000/ if the dir doesn't exist
+  // Try os.tmpdir() first; fall back to /tmp/claude-{uid}/ if the dir doesn't exist
   // (sandbox sets TMPDIR=/tmp/claude which may not be created on disk)
-  const candidates = [os.tmpdir(), '/tmp/claude-1000', '/tmp'];
+  const candidates = [os.tmpdir(), `/tmp/claude-${process.getuid()}`, '/tmp'];
   for (const base of candidates) {
     try {
       if (fs.existsSync(base)) {

--- a/tests/workspace.test.cjs
+++ b/tests/workspace.test.cjs
@@ -732,7 +732,7 @@ describe('resolveGitContext', () => {
     // resolveGitContext propagates throws (no internal try/catch).
     // The wrapping cmdInitExecutePhase has try/catch that returns defaults.
     // We test this via the CLI: a non-git cwd returns submodule_is_active: false.
-    const nonGitDir = fs.mkdtempSync(path.join(require('os').tmpdir(), 'gsd-nongit-'));
+    const nonGitDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-nongit-'));
     fs.mkdirSync(path.join(nonGitDir, '.planning', 'phases'), { recursive: true });
     try {
       // For init execute-phase to not immediately error on "phase not found",

--- a/tests/workspace.test.cjs
+++ b/tests/workspace.test.cjs
@@ -924,3 +924,92 @@ describe('cmdGitContext CLI integration', () => {
     assert.ok(typeof parsed.ssh_url === 'boolean', 'ssh_url should be a boolean');
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// complete-milestone in submodule workspace
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('complete-milestone in submodule workspace', () => {
+  let workspaceDir;
+
+  afterEach(() => {
+    if (workspaceDir) cleanup(workspaceDir);
+    workspaceDir = null;
+  });
+
+  test('complete-milestone exits 0 in submodule workspace', () => {
+    const { workspaceDir: wsDir } = createSubmoduleWorkspace(
+      [{ name: 'lib', path: 'lib', remoteUrl: 'https://github.com/test/lib.git' }],
+      { roadmap: true, state: true }
+    );
+    workspaceDir = wsDir;
+
+    // Write ROADMAP.md with milestone section
+    fs.writeFileSync(
+      path.join(workspaceDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Milestone: v1.0\n\n- [x] **Phase 1: Setup** (completed)\n\n## Phase Details\n\n### Phase 1: Setup\n**Goal**: Base setup\n**Requirements**: NONE\n'
+    );
+
+    // Write STATE.md with frontmatter including milestone
+    fs.writeFileSync(
+      path.join(workspaceDir, '.planning', 'STATE.md'),
+      '---\ngsd_state_version: 1.0\nmilestone: v1.0\ncurrent_phase: 1\ncurrent_plan: Not started\nstatus: testing\n---\n\n# Project State\n\n**Current Phase:** 1\n**Status:** testing\n'
+    );
+
+    // Create phase dir with a summary (needed for stats gathering)
+    const phaseDir = path.join(workspaceDir, '.planning', 'phases', '01-setup');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(phaseDir, '01-01-SUMMARY.md'),
+      '---\none-liner: "test setup completed"\n---\n\n# Summary\n'
+    );
+
+    const result = runGsdTools(['milestone', 'complete', 'v1.0'], workspaceDir);
+    assert.ok(result.success, `complete-milestone should exit 0 in submodule workspace: ${result.error}`);
+
+    const archived = path.join(workspaceDir, '.planning', 'milestones', 'v1.0-ROADMAP.md');
+    assert.ok(fs.existsSync(archived), 'ROADMAP.md should be archived at .planning/milestones/v1.0-ROADMAP.md');
+  });
+
+  test('complete-milestone archives ROADMAP.md in submodule workspace without path errors', () => {
+    const { workspaceDir: wsDir } = createSubmoduleWorkspace(
+      [{ name: 'lib', path: 'lib', remoteUrl: 'https://github.com/test/lib.git' }],
+      { roadmap: true, state: true }
+    );
+    workspaceDir = wsDir;
+
+    const roadmapContent = '# Roadmap\n\n## Milestone: v1.0\n\n- [x] **Phase 1: Setup** (completed)\n\n## Phase Details\n\n### Phase 1: Setup\n**Goal**: Base setup\n**Requirements**: NONE\n';
+
+    fs.writeFileSync(
+      path.join(workspaceDir, '.planning', 'ROADMAP.md'),
+      roadmapContent
+    );
+
+    fs.writeFileSync(
+      path.join(workspaceDir, '.planning', 'STATE.md'),
+      '---\ngsd_state_version: 1.0\nmilestone: v1.0\ncurrent_phase: 1\ncurrent_plan: Not started\nstatus: testing\n---\n\n# Project State\n\n**Current Phase:** 1\n**Status:** testing\n'
+    );
+
+    const phaseDir = path.join(workspaceDir, '.planning', 'phases', '01-setup');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(phaseDir, '01-01-SUMMARY.md'),
+      '---\none-liner: "test setup completed"\n---\n\n# Summary\n'
+    );
+
+    const result = runGsdTools(['milestone', 'complete', 'v1.0'], workspaceDir);
+    assert.ok(result.success, `complete-milestone should succeed: ${result.error}`);
+
+    // Verify archived content matches original (no path corruption)
+    const archived = path.join(workspaceDir, '.planning', 'milestones', 'v1.0-ROADMAP.md');
+    assert.ok(fs.existsSync(archived), 'archived ROADMAP.md should exist');
+    const archivedContent = fs.readFileSync(archived, 'utf-8');
+    assert.strictEqual(archivedContent, roadmapContent, 'archived content should match original without corruption');
+
+    // MILESTONES.md should exist and contain v1.0
+    const milestonesFile = path.join(workspaceDir, '.planning', 'MILESTONES.md');
+    assert.ok(fs.existsSync(milestonesFile), '.planning/MILESTONES.md should be created');
+    const milestonesContent = fs.readFileSync(milestonesFile, 'utf-8');
+    assert.ok(milestonesContent.includes('v1.0'), 'MILESTONES.md should reference v1.0');
+  });
+});


### PR DESCRIPTION
## Summary

- **45-01**: Fix Test 13 ENOENT by replacing `os.tmpdir()` with `resolveTmpDir()` in workspace.test.cjs. Replace all 6 hardcoded `/tmp/claude-1000` fallback paths with dynamic `` `/tmp/claude-${process.getuid()}` `` for portability across UIDs.
- **45-02**: Add test coverage for `--current` filtering on `state-snapshot` and `roadmap analyze` commands (7 tests). Add `complete-milestone` submodule workspace integration tests (2 tests).
- **45-03**: Create `tests/e2e/smoke.test.cjs` — full lifecycle smoke test covering install.js → scaffold → init plan-phase → init execute-phase using the **installed** copy of gsd-tools.cjs (6 tests). Add `npm run test:e2e` script.

**Test results:** 1321 unit tests (0 fail) + 6 e2e tests (0 fail). Baseline improved from failing to passing.

## Test plan

- [x] `npm test` — 1321 tests, 0 failures
- [x] `npm run test:e2e` — 6 tests, 0 failures
- [x] `grep -r '/tmp/claude-1000'` returns zero matches across tests/hooks/benchmarks
- [x] Verification: 11/11 must-haves passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>