### PR TITLE
chore: remove stale Windows references and guards

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -181,8 +181,7 @@ function expandTilde(filePath) {
 }
 
 /**
- * Build a hook command path using forward slashes for cross-platform compatibility.
- * On Windows, $HOME is not expanded by cmd.exe/PowerShell, so we use the actual path.
+ * Build a hook command path using forward slashes.
  */
 function buildHookCommand(configDir, hookName) {
   // Use forward slashes for Node.js compatibility on all platforms

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -93,7 +93,7 @@ function output(result, raw, rawValue) {
       } catch {
         // os.tmpdir() directory may not be writable (e.g. sandbox sets TMPDIR=/tmp/claude
         // but /tmp is restricted). Fall back to a known-writable sibling directory.
-        const uid = typeof process.getuid === 'function' ? process.getuid() : 1000;
+        const uid = process.getuid();
         tmpDir = path.join(path.dirname(tmpDir), path.basename(tmpDir) + '-' + uid);
         fs.mkdirSync(tmpDir, { recursive: true });
       }

--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -83,7 +83,7 @@ if (!process.env.GSD_SIMULATE_SANDBOX) {
   }
 }
 
-// Run check in background (spawn background process, windowsHide prevents console flash)
+// Run check in background (spawn detached process)
 const child = spawn(process.execPath, ['-e', `
   const fs = require('fs');
   const { execSync } = require('child_process');
@@ -125,7 +125,7 @@ const child = spawn(process.execPath, ['-e', `
 
   let latest = null;
   try {
-    latest = execSync('npm view gsd-ng version', { encoding: 'utf8', timeout: 10000, windowsHide: true }).trim();
+    latest = execSync('npm view gsd-ng version', { encoding: 'utf8', timeout: 10000 }).trim();
   } catch (e) {}
 
   let source = latest ? 'npm' : 'unknown';
@@ -229,8 +229,7 @@ const child = spawn(process.execPath, ['-e', `
   fs.writeFileSync(cacheFile, JSON.stringify(result));
 `], {
   stdio: 'ignore',
-  windowsHide: true,
-  detached: true  // Required on Windows for proper process detachment
+  detached: true
 });
 
 child.unref();

--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
-// Cross-platform test runner — resolves test file globs via Node
-// instead of relying on shell expansion (which fails on Windows PowerShell/cmd).
+// Test runner — resolves test file globs via Node instead of shell expansion.
 // Propagates NODE_V8_COVERAGE so c8 collects coverage from the child process.
 'use strict';
 


### PR DESCRIPTION
## Summary

- Remove unnecessary `typeof process.getuid` guard in `core.cjs` — `process.getuid()` is always available on Linux/macOS
- Remove stale Windows comments in `install.js`, `gsd-check-update.js`, `run-tests.cjs`
- Remove all `windowsHide: true` options in `gsd-check-update.js` (spawn options and execSync call)

GSD-NG only supports Linux/macOS (README already states "Works on Mac and Linux"). These Windows-isms were carried over from upstream and are dead code/comments.

Prompted by Copilot review comments on #13 flagging `process.getuid()` as unsafe on Windows.

## Test plan

- [x] `npm test` — 1321 tests, 0 failures
- [x] `grep -n 'windowsHide\|PowerShell\|cmd\.exe\|getuid.*function'` across all 4 files returns zero matches
- [x] No behavioral changes — only comment cleanup and guard/option removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)