### PR TITLE
Phase 47: CLI output refactor and workflow bash simplification

### DIFF
--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -1034,7 +1034,6 @@ mv .planning/debug/{slug}.md .planning/debug/resolved/
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state load)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 # commit_docs is in the JSON output
 ```
 
@@ -1096,7 +1095,7 @@ Perform lightweight verification: does the Resolution section's root_cause and f
 **In auto mode** (goal: find_and_fix with auto-close):
 
 ```bash
-AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --raw 2>/dev/null || echo "false")
+AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default "false")
 ```
 
 If `$AUTO_CFG` is `"true"` AND lightweight verification passes:
@@ -1139,7 +1138,7 @@ if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
   if [[ ! -f "$ORIGIN_PATH" ]]; then
     ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
   fi
-  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --raw 2>/dev/null || echo "")
+  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --default "")
   if [[ "$RELATED_OUTBOUND" == "null" ]]; then RELATED_OUTBOUND=""; fi
 fi
 ```
@@ -1153,7 +1152,7 @@ if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED
     [[ -f "$TODO_FILE" ]] || continue
     TODO_BASENAME=$(basename "$TODO_FILE")
     [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
-    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline --raw 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
+    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline --default "" 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
       RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
     fi
   done
@@ -1181,13 +1180,13 @@ If `$RELATED_ALL` is non-empty:
 **Auto mode:**
 ```bash
 if [[ "$AUTO_CFG" == "true" ]]; then
-  while IFS= read -r REL_TODO; do
+  printf '%s\n' "$RELATED_ALL" | while IFS= read -r REL_TODO; do
     [[ -z "$REL_TODO" ]] && continue
     REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
     node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
     node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after debug resolution" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
     echo "[auto] Closed related todo: $REL_TITLE"
-  done <<< "$RELATED_ALL"
+  done
 fi
 ```
 

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -31,7 +31,6 @@ Load execution context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
 Extract from init JSON: `executor_model`, `commit_docs`, `phase_dir`, `plans`, `incomplete_plans`.
@@ -197,8 +196,8 @@ Do NOT continue reading. Analysis without action is a stuck signal.
 Check if auto mode is active at executor start (chain flag or user preference):
 
 ```bash
-AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active 2>/dev/null || echo "false")
-AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
+AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default "false")
+AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance --default "false")
 ```
 
 Auto mode is active if either `AUTO_CHAIN` or `AUTO_CFG` is `"true"`. Store the result for checkpoint handling below.

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -311,7 +311,6 @@ Orchestrator provides: phase number/name, description/goal, requirements, constr
 Load phase context using init command:
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
 Extract from init JSON: `phase_dir`, `padded_phase`, `phase_number`, `commit_docs`.

--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -554,7 +554,6 @@ If FAIL: return to planner with specific fixes. Same revision loop as other dime
 Load phase operation context:
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
 Extract from init JSON: `phase_dir`, `phase_number`, `has_plans`, `plan_count`.

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -920,7 +920,6 @@ Load planning context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init plan-phase "${PHASE}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
 Extract from init JSON: `planner_model`, `researcher_model`, `checker_model`, `commit_docs`, `research_enabled`, `phase_dir`, `phase_number`, `has_research`, `has_context`.

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -121,7 +121,7 @@ must_haves:
 If no must_haves in frontmatter, check for Success Criteria:
 
 ```bash
-PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --raw)
+PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --json)
 ```
 
 Parse the `success_criteria` array from the JSON output. If non-empty:
@@ -348,7 +348,7 @@ Categorize: 🛑 Blocker (prevents goal) | ⚠️ Warning (incomplete) | ℹ️ 
 Check if this phase has a source todo linked via ROADMAP.md:
 
 ```bash
-PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --raw 2>/dev/null || echo "{}")
+PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --json --default "{}")
 SOURCE_TODO=$(echo "$PHASE_DATA" | node -e "
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
     try { const r=JSON.parse(d); console.log(r.source_todos || ''); } catch { console.log(''); }
@@ -364,7 +364,7 @@ RELATED_RAW=""
 for DIR in ".planning/todos/pending" ".planning/todos/completed"; do
   if [[ -f "$DIR/$SOURCE_TODO" ]]; then
     RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
-      "$DIR/$SOURCE_TODO" --field related --format newline --raw 2>/dev/null || echo "")
+      "$DIR/$SOURCE_TODO" --field related --format newline --default "")
     break
   fi
 done
@@ -375,15 +375,14 @@ Check each related todo:
 
 ```bash
 # For each related filename, check if it exists in pending/ (still open work)
-UNADDRESSED_TODOS=""
-while IFS= read -r related_file; do
+UNADDRESSED_TODOS=$(printf '%s\n' "$RELATED_LIST" | while IFS= read -r related_file; do
   [[ -z "$related_file" ]] && continue
   if [[ -f ".planning/todos/pending/$related_file" ]]; then
     TITLE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
-      ".planning/todos/pending/$related_file" --field title --raw 2>/dev/null || echo "(no title)")
-    UNADDRESSED_TODOS="${UNADDRESSED_TODOS}| $related_file | $TITLE | pending |\n"
+      ".planning/todos/pending/$related_file" --field title --default "(no title)")
+    printf '| %s | %s | pending |\n' "$related_file" "$TITLE"
   fi
-done <<< "$RELATED_LIST"
+done)
 ```
 
 If `$UNADDRESSED_TODOS` is non-empty, add a **Related Todo Warnings** section to the VERIFICATION.md output. Place this section AFTER the main verification results, clearly marked as warnings. This section does NOT change `status:` from passed to gaps_found and does NOT add items to the `gaps:` frontmatter section.

--- a/bin/install.js
+++ b/bin/install.js
@@ -820,6 +820,17 @@ const GSD_COPILOT_INSTRUCTIONS_MARKER = '<!-- GSD Configuration — managed by g
 const GSD_COPILOT_INSTRUCTIONS_CLOSE_MARKER = '<!-- /GSD Configuration -->';
 
 /**
+ * HTML comment markers wrapping the GSD AST safety block in CLAUDE.md.
+ * Idempotent: install checks for START marker before appending.
+ *
+ * AST safety: Claude Code's tree-sitter-bash heuristics cannot be suppressed
+ * via config (Issue #30435). This block documents forbidden constructs for the
+ * orchestrator session. See: https://github.com/anthropics/claude-code/issues/30435
+ */
+const GSD_AST_SAFETY_MARKER = '<!-- GSD — AST Safety Rules (managed by get-shit-done installer) -->';
+const GSD_AST_SAFETY_CLOSE_MARKER = '<!-- /GSD — AST Safety Rules -->';
+
+/**
  * Path and reference conversion applied to ALL Copilot content.
  * Converts Claude-specific paths, directory names, and command prefixes to Copilot equivalents.
  * @param {string} content - File content to convert
@@ -957,6 +968,38 @@ function mergeCopilotInstructions(instructionsPath, templateContent) {
     // Append GSD block at end
     const separator = existing.endsWith('\n') ? '\n' : '\n\n';
     fs.writeFileSync(instructionsPath, existing + separator + gsdBlock + '\n');
+  }
+}
+
+/**
+ * Append the GSD AST safety ruleset block to CLAUDE.md in cwd.
+ * Idempotent: skips if the START marker is already present.
+ * Only called for Claude Code runtime installs — Copilot CLI has no equivalent
+ * AST safety layer and must never receive this injection.
+ *
+ * AST safety: <<< here-strings, brace expansion, process substitution,
+ * and ANSI-C quoting all trigger Claude Code's tree-sitter-bash heuristics even when
+ * the command is allowlisted. See: https://github.com/anthropics/claude-code/issues/30435
+ *
+ * @param {string} claudeMdPath - Absolute path to CLAUDE.md (in project cwd)
+ */
+function injectAstSafetyBlock(claudeMdPath) {
+  // Check for existing marker (idempotency)
+  if (fs.existsSync(claudeMdPath)) {
+    const existing = fs.readFileSync(claudeMdPath, 'utf8');
+    if (existing.includes(GSD_AST_SAFETY_MARKER)) {
+      return; // Already injected — skip
+    }
+  }
+
+  const templatePath = path.join(__dirname, '..', 'gsd-ng', 'templates', 'ast-safety-rules.md');
+  const blockContent = fs.readFileSync(templatePath, 'utf8').trim();
+  const block = '\n' + blockContent + '\n';
+
+  if (fs.existsSync(claudeMdPath)) {
+    fs.appendFileSync(claudeMdPath, block, 'utf8');
+  } else {
+    fs.writeFileSync(claudeMdPath, block.trimStart(), 'utf8');
   }
 }
 
@@ -1249,6 +1292,20 @@ function install(isGlobal) {
   // Write file manifest for future modification detection
   writeManifest(targetDir);
   console.log(`  ${green}✓${reset} Wrote file manifest (${MANIFEST_NAME})`);
+
+  // Inject AST safety rules into CLAUDE.md (Claude Code only).
+  // Copilot CLI has no equivalent AST safety layer — skip entirely.
+  //
+  // AST safety: Claude Code's tree-sitter-bash heuristics fire independently of
+  // the sandbox/allowlist layer. No config option suppresses them (Issue #30435).
+  // We inject documentation for the orchestrator session here, and the same rules
+  // appear in agent-shared-context.md for subagents.
+  // See: https://github.com/anthropics/claude-code/issues/30435
+  if (!isCopilot) {
+    const claudeMdPath = path.join(process.cwd(), 'CLAUDE.md');
+    injectAstSafetyBlock(claudeMdPath);
+    console.log(`  ${green}✓${reset} Injected AST safety rules into CLAUDE.md`);
+  }
 
   // Report any backed-up local patches
   reportLocalPatches(targetDir);

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -58,12 +58,11 @@ Key constraints:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state load)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
 Extract `commit_docs` from init JSON. Resolve debugger model:
 ```bash
-debugger_model=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-debugger --raw)
+debugger_model=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-debugger)
 ```
 
 ## 1. Check Active Sessions
@@ -92,7 +91,7 @@ After all gathered, confirm ready to investigate.
 Resolve workspace topology, then fill prompt and spawn:
 
 ```bash
-WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
+WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace)
 WORKSPACE_TYPE=$(node -e "try{const w=JSON.parse(process.argv[1]);process.stdout.write(w.type||'standalone')}catch{process.stdout.write('standalone')}" "$WORKSPACE_JSON")
 SUBMODULE_PATHS=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p.join(', ')||'none')}catch{process.stdout.write('none')}" "$WORKSPACE_JSON")
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"

--- a/commands/gsd/divergence.md
+++ b/commands/gsd/divergence.md
@@ -19,7 +19,6 @@ Run the divergence command:
 ```bash
 GSD_TOOLS="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs"
 RESULT=$(node "$GSD_TOOLS" divergence)
-if [[ "$RESULT" == @file:* ]]; then RESULT=$(cat "${RESULT#@file:}"); fi
 ```
 
 Parse JSON output. If `status` is `no_upstream`, inform user they need to add an upstream remote:

--- a/commands/gsd/research-phase.md
+++ b/commands/gsd/research-phase.md
@@ -35,14 +35,13 @@ Normalize phase input in step 1 before any directory lookups.
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "$ARGUMENTS")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
 Extract from init JSON: `phase_dir`, `phase_number`, `phase_name`, `phase_found`, `commit_docs`, `has_research`, `state_path`, `requirements_path`, `context_path`, `research_path`.
 
 Resolve researcher model:
 ```bash
-RESEARCHER_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-phase-researcher --raw)
+RESEARCHER_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-phase-researcher)
 ```
 
 ## 1. Validate Phase

--- a/commands/gsd/set-profile.md
+++ b/commands/gsd/set-profile.md
@@ -9,4 +9,4 @@ allowed-tools:
 
 Show the following output to the user verbatim, with no extra commentary:
 
-!`node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-set-model-profile $ARGUMENTS --raw`
+!`node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-set-model-profile $ARGUMENTS`

--- a/gsd-ng/bin/gsd
+++ b/gsd-ng/bin/gsd
@@ -1,10 +1,5 @@
 #!/usr/bin/env bash
-# gsd — thin wrapper around gsd-tools.cjs that resolves @file: output transparently.
+# gsd -- thin wrapper around gsd-tools.cjs
 # Callers can pipe directly: gsd roadmap get-phase 17 | jq '.section'
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-OUT=$(node "$SCRIPT_DIR/gsd-tools.cjs" "$@")
-if [[ "$OUT" == @file:* ]]; then
-  cat "${OUT#@file:}"
-else
-  printf '%s' "$OUT"
-fi
+node "$SCRIPT_DIR/gsd-tools.cjs" "$@"

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -6,7 +6,7 @@
  * Replaces repetitive inline bash patterns across ~50 GSD command/workflow/agent files.
  * Centralizes: config parsing, model resolution, phase lookup, git commits, summary verification.
  *
- * Usage: node gsd-tools.cjs <command> [args] [--raw]
+ * Usage: node gsd-tools.cjs <command> [args] [--json]
  *
  * Atomic Commands:
  *   state load                         Load project config + state
@@ -162,7 +162,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { error, output: coreOutput } = require('./lib/core.cjs');
+const { error, output: coreOutput, setFileOutput, setJsonMode } = require('./lib/core.cjs');
 const state = require('./lib/state.cjs');
 const phase = require('./lib/phase.cjs');
 const roadmap = require('./lib/roadmap.cjs');
@@ -207,7 +207,7 @@ const SUBCOMMANDS = {
   phase: ['next-decimal', 'add', 'insert', 'remove', 'complete'],
   milestone: ['complete'],
   validate: ['consistency', 'health'],
-  todo: ['complete'],
+  todo: ['complete', 'list-by-phase', 'scan-phase-linked'],
   init: ['execute-phase', 'plan-phase', 'new-project', 'new-milestone', 'quick', 'resume', 'verify-work', 'phase-op', 'todos', 'milestone-op', 'map-codebase', 'progress'],
   guard: ['sync-chain', 'init-valid'],
   test: ['capture-baseline', 'compare-baseline'],
@@ -219,7 +219,7 @@ const SUBCOMMANDS = {
  * ARG_SCHEMAS[command][subcommand] = { positional: { min, max }, flags: string[] }
  *
  * Defines the expected argument shape for every compound command subcommand.
- * Used by validateSubcommandArgs() to catch creative misuse patterns before
+ * Used by validateArgs() to catch creative misuse patterns before
  * they reach the handler.
  *
  * positional.min: minimum positional (non-flag) args required
@@ -248,7 +248,7 @@ const ARG_SCHEMAS = {
     'fill':   { positional: { min: 1, max: 1 }, flags: ['--phase', '--plan', '--name', '--type', '--wave', '--fields'] },
   },
   frontmatter: {
-    'get':      { positional: { min: 1, max: 1 }, flags: ['--field', '--format'] },
+    'get':      { positional: { min: 1, max: 1 }, flags: ['--field', '--format', '--default'] },
     'set':      { positional: { min: 1, max: 1 }, flags: ['--field', '--value'] },
     'merge':    { positional: { min: 1, max: 1 }, flags: ['--data'] },
     'validate': { positional: { min: 1, max: 1 }, flags: ['--schema'] },
@@ -265,7 +265,7 @@ const ARG_SCHEMAS = {
     'list': { positional: { min: 0, max: 0 }, flags: ['--type', '--phase', '--include-archived'] },
   },
   roadmap: {
-    'get-phase':            { positional: { min: 1, max: 1 }, flags: [] },
+    'get-phase':            { positional: { min: 1, max: 1 }, flags: ['--default'] },
     'analyze':              { positional: { min: 0, max: 0 }, flags: ['--current'] },
     'update-plan-progress': { positional: { min: 1, max: 1 }, flags: [] },
     'add-phase':            { positional: { min: 0, max: null }, flags: [] },
@@ -289,7 +289,9 @@ const ARG_SCHEMAS = {
     'health':      { positional: { min: 0, max: 0 }, flags: ['--repair'] },
   },
   todo: {
-    'complete': { positional: { min: 1, max: 1 }, flags: [] },
+    'complete':          { positional: { min: 1, max: 1 }, flags: [] },
+    'list-by-phase':     { positional: { min: 1, max: 1 }, flags: [] },
+    'scan-phase-linked': { positional: { min: 1, max: 1 }, flags: [] },
   },
   init: {
     'execute-phase': { positional: { min: 1, max: 1 }, flags: [] },
@@ -313,23 +315,50 @@ const ARG_SCHEMAS = {
     'capture-baseline': { positional: { min: 2, max: 2 }, flags: [] },
     'compare-baseline': { positional: { min: 2, max: 2 }, flags: [] },
   },
+  // ─── Top-level commands with flags (_self schema convention) ─────────────
+  // Only command-specific flags; global flags (--json, --file, --pick, --cwd)
+  // are already stripped before dispatch.
+  'commit':             { _self: { positional: { min: 0, max: null }, flags: ['--amend', '--files'] } },
+  'verify-summary':     { _self: { positional: { min: 1, max: 1 }, flags: ['--check-count'] } },
+  'staleness-check':    { _self: { positional: { min: 0, max: 0 }, flags: ['--count'] } },
+  'config-get':         { _self: { positional: { min: 1, max: 1 }, flags: ['--default'] } },
+  'update':             { _self: { positional: { min: 0, max: 0 }, flags: ['--dry-run', '--local', '--global'] } },
+  'scaffold':           { _self: { positional: { min: 1, max: null }, flags: ['--phase', '--name'] } },
+  'state-snapshot':     { _self: { positional: { min: 0, max: 0 }, flags: ['--current'] } },
+  'summary-extract':    { _self: { positional: { min: 1, max: 1 }, flags: ['--fields', '--default'] } },
+  'detect-platform':    { _self: { positional: { min: 0, max: 1 }, flags: ['--field'] } },
+  'detect-workspace':   { _self: { positional: { min: 0, max: 0 }, flags: ['--field'] } },
+  'git-context':        { _self: { positional: { min: 0, max: 0 }, flags: ['--field'] } },
+  'ssh-check':          { _self: { positional: { min: 0, max: 1 }, flags: ['--field'] } },
+  'websearch':          { _self: { positional: { min: 1, max: null }, flags: ['--limit', '--freshness'] } },
+  'squash':             { _self: { positional: { min: 0, max: 1 }, flags: ['--list-backup-tags', '--dry-run', '--allow-stable', '--strategy'] } },
+  'version-bump':       { _self: { positional: { min: 0, max: 0 }, flags: ['--level', '--scheme', '--snapshot', '--field'] } },
+  'generate-changelog': { _self: { positional: { min: 1, max: 1 }, flags: ['--date'] } },
+  'issue-import':       { _self: { positional: { min: 2, max: 2 }, flags: ['--repo'] } },
+  'issue-sync':         { _self: { positional: { min: 0, max: 1 }, flags: ['--auto'] } },
+  'divergence':         { _self: { positional: { min: 0, max: 0 }, flags: ['--refresh', '--init', '--triage', '--status', '--reason', '--branch', '--base', '--remote', '--remote-branch'] } },
+  'pingpong-check':     { _self: { positional: { min: 0, max: 0 }, flags: ['--window'] } },
+  'breakout-check':     { _self: { positional: { min: 0, max: 0 }, flags: ['--plan', '--declared-files'] } },
+  'cleanup':            { _self: { positional: { min: 0, max: 0 }, flags: ['--dry-run'] } },
 };
 
 /**
- * Validate subcommand arguments against ARG_SCHEMAS before dispatch.
+ * Validate command arguments against ARG_SCHEMAS before dispatch.
  *
  * Catches: flag in positional slot, =-syntax, too-few/many positionals,
  * unknown flags. Exits with a helpful error message on any violation.
  *
  * @param {string} command - Top-level command name (e.g. 'init')
- * @param {string} subcommand - Subcommand name (e.g. 'phase-op')
- * @param {string[]} remainingArgs - args.slice(2) after global flag stripping
+ * @param {string|null} subcommand - Subcommand name (e.g. 'phase-op'), or null for top-level commands
+ * @param {string[]} remainingArgs - args after command/subcommand, after global flag stripping
  */
-function validateSubcommandArgs(command, subcommand, remainingArgs) {
-  const schema = ARG_SCHEMAS[command]?.[subcommand];
+function validateArgs(command, subcommand, remainingArgs) {
+  const lookupKey = subcommand || '_self';
+  const schema = ARG_SCHEMAS[command]?.[lookupKey];
   if (!schema) return; // No schema = permissive (safe default for unknown subcommands)
 
-  const usageHint = `Usage: ${command} ${subcommand}${schema.positional.min > 0 ? ' <arg>' + (schema.positional.max === null || schema.positional.max > 1 ? ' ...' : '') : ''}`;
+  const cmdLabel = subcommand ? `${command} ${subcommand}` : command;
+  const usageHint = `Usage: ${cmdLabel}${schema.positional.min > 0 ? ' <arg>' + (schema.positional.max === null || schema.positional.max > 1 ? ' ...' : '') : ''}`;
 
   // 1. Equals syntax detection (e.g. phase=40 instead of 40)
   for (const arg of remainingArgs) {
@@ -371,7 +400,7 @@ function validateSubcommandArgs(command, subcommand, remainingArgs) {
         error(
           `Positional argument expected, got '${arg}'.\n` +
           `${usageHint}\n` +
-          `Example: ${command} ${subcommand}${schema.positional.min > 0 ? ' 40' : ''}`
+          `Example: ${cmdLabel}${schema.positional.min > 0 ? ' 40' : ''}`
         );
       } else {
         // Unknown flag (positionals satisfied, or schema has some known flags)
@@ -393,7 +422,7 @@ function validateSubcommandArgs(command, subcommand, remainingArgs) {
             })()
           : '';
         const knownList = schema.flags.length > 0 ? schema.flags.join(', ') : 'none';
-        error(`Unknown flag '${arg}' for '${command} ${subcommand}'.${suggestion} Known flags: ${knownList}`);
+        error(`Unknown flag '${arg}' for '${cmdLabel}'.${suggestion} Known flags: ${knownList}`);
       }
     }
   }
@@ -401,13 +430,13 @@ function validateSubcommandArgs(command, subcommand, remainingArgs) {
   // 4. Count validation — positionals already computed above
   if (actualPositionals.length < schema.positional.min) {
     error(
-      `Too few arguments for '${command} ${subcommand}': expected at least ${schema.positional.min}, got ${actualPositionals.length}.\n` +
+      `Too few arguments for '${cmdLabel}': expected at least ${schema.positional.min}, got ${actualPositionals.length}.\n` +
       `${usageHint}`
     );
   }
   if (schema.positional.max !== null && actualPositionals.length > schema.positional.max) {
     error(
-      `Too many arguments for '${command} ${subcommand}': expected at most ${schema.positional.max}, got ${actualPositionals.length}.\n` +
+      `Too many arguments for '${cmdLabel}': expected at most ${schema.positional.max}, got ${actualPositionals.length}.\n` +
       `${usageHint}`
     );
   }
@@ -592,9 +621,19 @@ async function main() {
     error(`Invalid --cwd: ${cwd}`);
   }
 
-  const rawIndex = args.indexOf('--raw');
-  const raw = rawIndex !== -1;
-  if (rawIndex !== -1) args.splice(rawIndex, 1);
+  const jsonIndex = args.indexOf('--json');
+  if (jsonIndex !== -1) {
+    setJsonMode(true);
+    args.splice(jsonIndex, 1);
+  }
+
+  // --file: when present, output() writes JSON to a temp file prefixed with @file:
+  // instead of inline to stdout. Opt-in for the rare case where file output is needed.
+  const fileIndex = args.indexOf('--file');
+  if (fileIndex !== -1) {
+    setFileOutput(true);
+    args.splice(fileIndex, 1);
+  }
 
   // --pick <name>: extract a single field from JSON output (replaces jq dependency).
   // Supports dot-notation (e.g., --pick workflow.research) and bracket notation
@@ -618,6 +657,7 @@ async function main() {
   // so we intercept at the fs layer; also intercept process.stdout.write for any
   // non-output() paths (printHelp, etc.).
   if (pickField) {
+    setJsonMode(true);  // --pick needs JSON to extract fields
     _origFsWriteSync = fs.writeSync.bind(fs);
     _origStdoutWrite = process.stdout.write.bind(process.stdout);
 
@@ -672,13 +712,13 @@ async function main() {
   switch (command) {
     case 'state': {
       const subcommand = args[1];
-      validateSubcommandArgs('state', subcommand, args.slice(2));
+      validateArgs('state', subcommand, args.slice(2));
       if (subcommand === 'json') {
-        state.cmdStateJson(cwd, raw);
+        state.cmdStateJson(cwd);
       } else if (subcommand === 'update') {
         state.cmdStateUpdate(cwd, args[2], args[3]);
       } else if (subcommand === 'get') {
-        state.cmdStateGet(cwd, args[2], raw);
+        state.cmdStateGet(cwd, args[2]);
       } else if (subcommand === 'patch') {
         const patches = {};
         for (let i = 2; i < args.length; i += 2) {
@@ -688,9 +728,9 @@ async function main() {
             patches[key] = value;
           }
         }
-        state.cmdStatePatch(cwd, patches, raw);
+        state.cmdStatePatch(cwd, patches);
       } else if (subcommand === 'advance-plan') {
-        state.cmdStateAdvancePlan(cwd, raw);
+        state.cmdStateAdvancePlan(cwd);
       } else if (subcommand === 'record-metric') {
         const phaseIdx = args.indexOf('--phase');
         const planIdx = args.indexOf('--plan');
@@ -703,9 +743,9 @@ async function main() {
           duration: durationIdx !== -1 ? args[durationIdx + 1] : null,
           tasks: tasksIdx !== -1 ? args[tasksIdx + 1] : null,
           files: filesIdx !== -1 ? args[filesIdx + 1] : null,
-        }, raw);
+        });
       } else if (subcommand === 'update-progress') {
-        state.cmdStateUpdateProgress(cwd, raw);
+        state.cmdStateUpdateProgress(cwd);
       } else if (subcommand === 'add-decision') {
         const phaseIdx = args.indexOf('--phase');
         const summaryIdx = args.indexOf('--summary');
@@ -718,24 +758,24 @@ async function main() {
           summary_file: summaryFileIdx !== -1 ? args[summaryFileIdx + 1] : null,
           rationale: rationaleIdx !== -1 ? args[rationaleIdx + 1] : '',
           rationale_file: rationaleFileIdx !== -1 ? args[rationaleFileIdx + 1] : null,
-        }, raw);
+        });
       } else if (subcommand === 'add-blocker') {
         const textIdx = args.indexOf('--text');
         const textFileIdx = args.indexOf('--text-file');
         state.cmdStateAddBlocker(cwd, {
           text: textIdx !== -1 ? args[textIdx + 1] : null,
           text_file: textFileIdx !== -1 ? args[textFileIdx + 1] : null,
-        }, raw);
+        });
       } else if (subcommand === 'resolve-blocker') {
         const textIdx = args.indexOf('--text');
-        state.cmdStateResolveBlocker(cwd, textIdx !== -1 ? args[textIdx + 1] : null, raw);
+        state.cmdStateResolveBlocker(cwd, textIdx !== -1 ? args[textIdx + 1] : null);
       } else if (subcommand === 'record-session') {
         const stoppedIdx = args.indexOf('--stopped-at');
         const resumeIdx = args.indexOf('--resume-file');
         state.cmdStateRecordSession(cwd, {
           stopped_at: stoppedIdx !== -1 ? args[stoppedIdx + 1] : null,
           resume_file: resumeIdx !== -1 ? args[resumeIdx + 1] : 'None',
-        }, raw);
+        });
       } else if (subcommand === 'begin-phase') {
         const phaseIdx = args.indexOf('--phase');
         const nameIdx = args.indexOf('--name');
@@ -744,13 +784,12 @@ async function main() {
           cwd,
           phaseIdx !== -1 ? args[phaseIdx + 1] : null,
           nameIdx !== -1 ? args[nameIdx + 1] : null,
-          plansIdx !== -1 ? parseInt(args[plansIdx + 1], 10) : null,
-          raw
+          plansIdx !== -1 ? parseInt(args[plansIdx + 1], 10) : null
         );
       } else if (subcommand === 'adjust-quick-table') {
-        state.cmdStateAdjustQuickTable(cwd, raw);
+        state.cmdStateAdjustQuickTable(cwd);
       } else if (subcommand === 'load' || !subcommand) {
-        state.cmdStateLoad(cwd, raw);
+        state.cmdStateLoad(cwd);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'state');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -766,16 +805,17 @@ async function main() {
     }
 
     case 'resolve-model': {
-      commands.cmdResolveModel(cwd, args[1], raw);
+      commands.cmdResolveModel(cwd, args[1]);
       break;
     }
 
     case 'find-phase': {
-      phase.cmdFindPhase(cwd, args[1], raw);
+      phase.cmdFindPhase(cwd, args[1]);
       break;
     }
 
     case 'commit': {
+      validateArgs('commit', null, args.slice(1));
       const amend = args.includes('--amend');
       const filesIndex = args.indexOf('--files');
       // Collect all positional args between command name and first flag,
@@ -785,23 +825,24 @@ async function main() {
       const messageArgs = args.slice(1, endIndex).filter(a => !a.startsWith('--'));
       const message = messageArgs.join(' ') || undefined;
       const files = filesIndex !== -1 ? args.slice(filesIndex + 1).filter(a => !a.startsWith('--')) : [];
-      commands.cmdCommit(cwd, message, files, raw, amend);
+      commands.cmdCommit(cwd, message, files, amend);
       break;
     }
 
     case 'verify-summary': {
+      validateArgs('verify-summary', null, args.slice(1));
       const summaryPath = args[1];
       const countIndex = args.indexOf('--check-count');
       const checkCount = countIndex !== -1 ? parseInt(args[countIndex + 1], 10) : 2;
-      verify.cmdVerifySummary(cwd, summaryPath, checkCount, raw);
+      verify.cmdVerifySummary(cwd, summaryPath, checkCount);
       break;
     }
 
     case 'template': {
       const subcommand = args[1];
-      validateSubcommandArgs('template', subcommand, args.slice(2));
+      validateArgs('template', subcommand, args.slice(2));
       if (subcommand === 'select') {
-        template.cmdTemplateSelect(cwd, args[2], raw);
+        template.cmdTemplateSelect(cwd, args[2]);
       } else if (subcommand === 'fill') {
         const templateType = args[2];
         const phaseIdx = args.indexOf('--phase');
@@ -817,7 +858,7 @@ async function main() {
           type: typeIdx !== -1 ? args[typeIdx + 1] : 'execute',
           wave: waveIdx !== -1 ? args[waveIdx + 1] : '1',
           fields: fieldsIdx !== -1 ? JSON.parse(args[fieldsIdx + 1]) : {},
-        }, raw);
+        });
       } else {
         const suggestions = suggestSubcommand(subcommand, 'template');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -834,22 +875,24 @@ async function main() {
 
     case 'frontmatter': {
       const subcommand = args[1];
-      validateSubcommandArgs('frontmatter', subcommand, args.slice(2));
+      validateArgs('frontmatter', subcommand, args.slice(2));
       const file = args[2];
       if (subcommand === 'get') {
         const fieldIdx = args.indexOf('--field');
         const formatIdx = args.indexOf('--format');
-        frontmatter.cmdFrontmatterGet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, raw, formatIdx !== -1 ? args[formatIdx + 1] : null);
+        const defaultIdx = args.indexOf('--default');
+        const defaultValue = defaultIdx !== -1 ? args[defaultIdx + 1] : undefined;
+        frontmatter.cmdFrontmatterGet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, formatIdx !== -1 ? args[formatIdx + 1] : null, defaultValue);
       } else if (subcommand === 'set') {
         const fieldIdx = args.indexOf('--field');
         const valueIdx = args.indexOf('--value');
-        frontmatter.cmdFrontmatterSet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, valueIdx !== -1 ? args[valueIdx + 1] : undefined, raw);
+        frontmatter.cmdFrontmatterSet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, valueIdx !== -1 ? args[valueIdx + 1] : undefined);
       } else if (subcommand === 'merge') {
         const dataIdx = args.indexOf('--data');
-        frontmatter.cmdFrontmatterMerge(cwd, file, dataIdx !== -1 ? args[dataIdx + 1] : null, raw);
+        frontmatter.cmdFrontmatterMerge(cwd, file, dataIdx !== -1 ? args[dataIdx + 1] : null);
       } else if (subcommand === 'validate') {
         const schemaIdx = args.indexOf('--schema');
-        frontmatter.cmdFrontmatterValidate(cwd, file, schemaIdx !== -1 ? args[schemaIdx + 1] : null, raw);
+        frontmatter.cmdFrontmatterValidate(cwd, file, schemaIdx !== -1 ? args[schemaIdx + 1] : null);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'frontmatter');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -866,19 +909,19 @@ async function main() {
 
     case 'verify': {
       const subcommand = args[1];
-      validateSubcommandArgs('verify', subcommand, args.slice(2));
+      validateArgs('verify', subcommand, args.slice(2));
       if (subcommand === 'plan-structure') {
-        verify.cmdVerifyPlanStructure(cwd, args[2], raw);
+        verify.cmdVerifyPlanStructure(cwd, args[2]);
       } else if (subcommand === 'phase-completeness') {
-        verify.cmdVerifyPhaseCompleteness(cwd, args[2], raw);
+        verify.cmdVerifyPhaseCompleteness(cwd, args[2]);
       } else if (subcommand === 'references') {
-        verify.cmdVerifyReferences(cwd, args[2], raw);
+        verify.cmdVerifyReferences(cwd, args[2]);
       } else if (subcommand === 'commits') {
-        verify.cmdVerifyCommits(cwd, args.slice(2), raw);
+        verify.cmdVerifyCommits(cwd, args.slice(2));
       } else if (subcommand === 'artifacts') {
-        verify.cmdVerifyArtifacts(cwd, args[2], raw);
+        verify.cmdVerifyArtifacts(cwd, args[2]);
       } else if (subcommand === 'key-links') {
-        verify.cmdVerifyKeyLinks(cwd, args[2], raw);
+        verify.cmdVerifyKeyLinks(cwd, args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'verify');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -894,68 +937,74 @@ async function main() {
     }
 
     case 'generate-slug': {
-      commands.cmdGenerateSlug(args[1], raw);
+      commands.cmdGenerateSlug(args[1]);
       break;
     }
 
     case 'current-timestamp': {
-      commands.cmdCurrentTimestamp(args[1] || 'full', raw);
+      commands.cmdCurrentTimestamp(args[1] || 'full');
       break;
     }
 
     case 'list-todos': {
-      commands.cmdListTodos(cwd, args[1], raw);
+      commands.cmdListTodos(cwd, args[1]);
       break;
     }
 
     case 'recurring-due': {
-      commands.cmdRecurringDue(cwd, raw);
+      // --default accepted for consistency but recurring-due always returns valid output
+      commands.cmdRecurringDue(cwd);
       break;
     }
 
     case 'staleness-check': {
-      commands.cmdStalenessCheck(cwd, raw);
+      validateArgs('staleness-check', null, args.slice(1));
+      const countFlag = args.includes('--count');
+      commands.cmdStalenessCheck(cwd, countFlag);
       break;
     }
 
     case 'verify-path-exists': {
-      commands.cmdVerifyPathExists(cwd, args[1], raw);
+      commands.cmdVerifyPathExists(cwd, args[1]);
       break;
     }
 
     case 'config-ensure-section': {
-      config.cmdConfigEnsureSection(cwd, raw);
+      config.cmdConfigEnsureSection(cwd);
       break;
     }
 
     case 'config-set': {
-      config.cmdConfigSet(cwd, args[1], args[2], raw);
+      config.cmdConfigSet(cwd, args[1], args[2]);
       break;
     }
 
     case "config-set-model-profile": {
-      config.cmdConfigSetModelProfile(cwd, args[1], raw);
+      config.cmdConfigSetModelProfile(cwd, args[1]);
       break;
     }
 
     case 'config-get': {
-      config.cmdConfigGet(cwd, args[1], raw);
+      validateArgs('config-get', null, args.slice(1));
+      const defaultIdx = args.indexOf('--default');
+      const defaultValue = defaultIdx !== -1 ? args[defaultIdx + 1] : undefined;
+      config.cmdConfigGet(cwd, args[1], defaultValue);
       break;
     }
 
     case 'init-get': {
-      init.cmdInitGet(args[1], args[2], raw);
+      init.cmdInitGet(args[1], args[2]);
       break;
     }
 
     case 'history-digest': {
-      commands.cmdHistoryDigest(cwd, raw);
+      commands.cmdHistoryDigest(cwd);
       break;
     }
 
     case 'phases': {
       const subcommand = args[1];
-      validateSubcommandArgs('phases', subcommand, args.slice(2));
+      validateArgs('phases', subcommand, args.slice(2));
       if (subcommand === 'list') {
         const typeIndex = args.indexOf('--type');
         const phaseIndex = args.indexOf('--phase');
@@ -964,7 +1013,7 @@ async function main() {
           phase: phaseIndex !== -1 ? args[phaseIndex + 1] : null,
           includeArchived: args.includes('--include-archived'),
         };
-        phase.cmdPhasesList(cwd, options, raw);
+        phase.cmdPhasesList(cwd, options);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'phases');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -981,9 +1030,11 @@ async function main() {
 
     case 'roadmap': {
       const subcommand = args[1];
-      validateSubcommandArgs('roadmap', subcommand, args.slice(2));
+      validateArgs('roadmap', subcommand, args.slice(2));
       if (subcommand === 'get-phase') {
-        roadmap.cmdRoadmapGetPhase(cwd, args[2], raw);
+        const defaultIdx = args.indexOf('--default');
+        const defaultValue = defaultIdx !== -1 ? args[defaultIdx + 1] : undefined;
+        roadmap.cmdRoadmapGetPhase(cwd, args[2], defaultValue);
       } else if (subcommand === 'analyze') {
         const analyzeCurrentFilter = args.slice(2).includes('--current');
         let analyzePhaseFilter = null;
@@ -998,12 +1049,12 @@ async function main() {
             }
           } catch {}
         }
-        roadmap.cmdRoadmapAnalyze(cwd, raw, analyzePhaseFilter);
+        roadmap.cmdRoadmapAnalyze(cwd, analyzePhaseFilter);
       } else if (subcommand === 'update-plan-progress') {
-        roadmap.cmdRoadmapUpdatePlanProgress(cwd, args[2], raw);
+        roadmap.cmdRoadmapUpdatePlanProgress(cwd, args[2]);
       } else if (subcommand === 'add-phase') {
         // Alias: redirect to phase add
-        phase.cmdPhaseAdd(cwd, args.slice(2).join(' '), raw);
+        phase.cmdPhaseAdd(cwd, args.slice(2).join(' '));
       } else {
         const suggestions = suggestSubcommand(subcommand, 'roadmap');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -1020,9 +1071,9 @@ async function main() {
 
     case 'requirements': {
       const subcommand = args[1];
-      validateSubcommandArgs('requirements', subcommand, args.slice(2));
+      validateArgs('requirements', subcommand, args.slice(2));
       if (subcommand === 'mark-complete') {
-        milestone.cmdRequirementsMarkComplete(cwd, args.slice(2), raw);
+        milestone.cmdRequirementsMarkComplete(cwd, args.slice(2));
       } else {
         const suggestions = suggestSubcommand(subcommand, 'requirements');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -1039,7 +1090,7 @@ async function main() {
 
     case 'test': {
       const subcommand = args[1];
-      validateSubcommandArgs('test', subcommand, args.slice(2));
+      validateArgs('test', subcommand, args.slice(2));
       if (subcommand === 'capture-baseline') {
         testBaseline.captureBaseline(args[2], args[3]);
       } else if (subcommand === 'compare-baseline') {
@@ -1060,18 +1111,18 @@ async function main() {
 
     case 'phase': {
       const subcommand = args[1];
-      validateSubcommandArgs('phase', subcommand, args.slice(2));
+      validateArgs('phase', subcommand, args.slice(2));
       if (subcommand === 'next-decimal') {
-        phase.cmdPhaseNextDecimal(cwd, args[2], raw);
+        phase.cmdPhaseNextDecimal(cwd, args[2]);
       } else if (subcommand === 'add') {
-        phase.cmdPhaseAdd(cwd, args.slice(2).join(' '), raw);
+        phase.cmdPhaseAdd(cwd, args.slice(2).join(' '));
       } else if (subcommand === 'insert') {
-        phase.cmdPhaseInsert(cwd, args[2], args.slice(3).join(' '), raw);
+        phase.cmdPhaseInsert(cwd, args[2], args.slice(3).join(' '));
       } else if (subcommand === 'remove') {
         const forceFlag = args.includes('--force');
-        phase.cmdPhaseRemove(cwd, args[2], { force: forceFlag }, raw);
+        phase.cmdPhaseRemove(cwd, args[2], { force: forceFlag });
       } else if (subcommand === 'complete') {
-        phase.cmdPhaseComplete(cwd, args[2], raw);
+        phase.cmdPhaseComplete(cwd, args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'phase');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -1088,7 +1139,7 @@ async function main() {
 
     case 'milestone': {
       const subcommand = args[1];
-      validateSubcommandArgs('milestone', subcommand, args.slice(2));
+      validateArgs('milestone', subcommand, args.slice(2));
       if (subcommand === 'complete') {
         const nameIndex = args.indexOf('--name');
         const archivePhases = args.includes('--archive-phases');
@@ -1102,7 +1153,7 @@ async function main() {
           }
           milestoneName = nameArgs.join(' ') || null;
         }
-        milestone.cmdMilestoneComplete(cwd, args[2], { name: milestoneName, archivePhases }, raw);
+        milestone.cmdMilestoneComplete(cwd, args[2], { name: milestoneName, archivePhases });
       } else {
         const suggestions = suggestSubcommand(subcommand, 'milestone');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -1119,12 +1170,12 @@ async function main() {
 
     case 'validate': {
       const subcommand = args[1];
-      validateSubcommandArgs('validate', subcommand, args.slice(2));
+      validateArgs('validate', subcommand, args.slice(2));
       if (subcommand === 'consistency') {
-        verify.cmdValidateConsistency(cwd, raw);
+        verify.cmdValidateConsistency(cwd);
       } else if (subcommand === 'health') {
         const repairFlag = args.includes('--repair');
-        verify.cmdValidateHealth(cwd, { repair: repairFlag }, raw);
+        verify.cmdValidateHealth(cwd, { repair: repairFlag });
       } else {
         const suggestions = suggestSubcommand(subcommand, 'validate');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -1141,21 +1192,25 @@ async function main() {
 
     case 'progress': {
       const subcommand = args[1] || 'json';
-      commands.cmdProgressRender(cwd, subcommand, raw);
+      commands.cmdProgressRender(cwd, subcommand);
       break;
     }
 
     case 'stats': {
       const subcommand = args[1] || 'json';
-      commands.cmdStats(cwd, subcommand, raw);
+      commands.cmdStats(cwd, subcommand);
       break;
     }
 
     case 'todo': {
       const subcommand = args[1];
-      validateSubcommandArgs('todo', subcommand, args.slice(2));
+      validateArgs('todo', subcommand, args.slice(2));
       if (subcommand === 'complete') {
-        commands.cmdTodoComplete(cwd, args[2], raw);
+        commands.cmdTodoComplete(cwd, args[2]);
+      } else if (subcommand === 'list-by-phase') {
+        commands.cmdTodoListByPhase(cwd, args[2]);
+      } else if (subcommand === 'scan-phase-linked') {
+        commands.cmdTodoScanPhaseLinked(cwd, args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'todo');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
@@ -1171,14 +1226,16 @@ async function main() {
     }
 
     case 'update': {
+      validateArgs('update', null, args.slice(1));
       const dryRun = args.includes('--dry-run');
       const localInstall = args.includes('--local');
       const globalInstall = args.includes('--global');
-      commands.cmdUpdate(cwd, { dryRun, local: localInstall, global: globalInstall }, raw);
+      commands.cmdUpdate(cwd, { dryRun, local: localInstall, global: globalInstall });
       break;
     }
 
     case 'scaffold': {
+      validateArgs('scaffold', null, args.slice(1));
       const scaffoldType = args[1];
       const phaseIndex = args.indexOf('--phase');
       const nameIndex = args.indexOf('--name');
@@ -1186,54 +1243,54 @@ async function main() {
         phase: phaseIndex !== -1 ? args[phaseIndex + 1] : null,
         name: nameIndex !== -1 ? args.slice(nameIndex + 1).join(' ') : null,
       };
-      commands.cmdScaffold(cwd, scaffoldType, scaffoldOptions, raw);
+      commands.cmdScaffold(cwd, scaffoldType, scaffoldOptions);
       break;
     }
 
     case 'init': {
       const workflow = args[1];
-      validateSubcommandArgs('init', workflow, args.slice(2));
+      validateArgs('init', workflow, args.slice(2));
       switch (workflow) {
         case 'execute-phase':
-          init.cmdInitExecutePhase(cwd, args[2], raw);
+          init.cmdInitExecutePhase(cwd, args[2]);
           break;
         case 'plan-phase':
-          init.cmdInitPlanPhase(cwd, args[2], raw);
+          init.cmdInitPlanPhase(cwd, args[2]);
           break;
         case 'new-project':
-          init.cmdInitNewProject(cwd, raw);
+          init.cmdInitNewProject(cwd);
           break;
         case 'new-milestone':
-          init.cmdInitNewMilestone(cwd, raw);
+          init.cmdInitNewMilestone(cwd);
           break;
         case 'quick': {
           const verifyFlagIdx = args.indexOf('--verify');
           const verifyMode = verifyFlagIdx !== -1;
           // Remove --verify from args before joining as description
           const descArgs = args.slice(2).filter((_, i) => i + 2 !== verifyFlagIdx);
-          init.cmdInitQuick(cwd, descArgs.join(' '), verifyMode, raw);
+          init.cmdInitQuick(cwd, descArgs.join(' '), verifyMode);
           break;
         }
         case 'resume':
-          init.cmdInitResume(cwd, raw);
+          init.cmdInitResume(cwd);
           break;
         case 'verify-work':
-          init.cmdInitVerifyWork(cwd, args[2], raw);
+          init.cmdInitVerifyWork(cwd, args[2]);
           break;
         case 'phase-op':
-          init.cmdInitPhaseOp(cwd, args[2], raw);
+          init.cmdInitPhaseOp(cwd, args[2]);
           break;
         case 'todos':
-          init.cmdInitTodos(cwd, args[2], raw);
+          init.cmdInitTodos(cwd, args[2]);
           break;
         case 'milestone-op':
-          init.cmdInitMilestoneOp(cwd, raw);
+          init.cmdInitMilestoneOp(cwd);
           break;
         case 'map-codebase':
-          init.cmdInitMapCodebase(cwd, raw);
+          init.cmdInitMapCodebase(cwd);
           break;
         case 'progress':
-          init.cmdInitProgress(cwd, raw);
+          init.cmdInitProgress(cwd);
           break;
         default:
           {
@@ -1252,11 +1309,12 @@ async function main() {
     }
 
     case 'phase-plan-index': {
-      phase.cmdPhasePlanIndex(cwd, args[1], raw);
+      phase.cmdPhasePlanIndex(cwd, args[1]);
       break;
     }
 
     case 'state-snapshot': {
+      validateArgs('state-snapshot', null, args.slice(1));
       const currentFilter = args.includes('--current');
       let phaseForFilter = null;
       if (currentFilter) {
@@ -1270,100 +1328,109 @@ async function main() {
           }
         } catch {}
       }
-      state.cmdStateSnapshot(cwd, raw, phaseForFilter);
+      state.cmdStateSnapshot(cwd, phaseForFilter);
       break;
     }
 
     case 'summary-extract': {
+      validateArgs('summary-extract', null, args.slice(1));
       const summaryPath = args[1];
       const fieldsIndex = args.indexOf('--fields');
       const fields = fieldsIndex !== -1 ? args[fieldsIndex + 1].split(',') : null;
-      commands.cmdSummaryExtract(cwd, summaryPath, fields, raw);
+      const seDefaultIdx = args.indexOf('--default');
+      const seDefaultValue = seDefaultIdx !== -1 ? args[seDefaultIdx + 1] : undefined;
+      commands.cmdSummaryExtract(cwd, summaryPath, fields, seDefaultValue);
       break;
     }
 
     case 'detect-platform': {
-      // Support --field <name> --raw for scalar extraction (e.g. detect-platform --field platform --raw)
+      validateArgs('detect-platform', null, args.slice(1));
+      // Support --field <name> for scalar extraction (e.g. detect-platform --field platform)
       const dpFieldIdx = args.indexOf('--field');
       const dpField = dpFieldIdx !== -1 ? args[dpFieldIdx + 1] : null;
       // Use the first non-flag positional argument as the remote name
       const dpRemoteArg = args[1] && !args[1].startsWith('--') ? args[1] : null;
-      if (dpField && raw) {
+      if (dpField) {
         // silent=true: returns result without calling output()/process.exit()
-        const dpResult = commands.cmdDetectPlatform(cwd, dpRemoteArg, false, true);
+        const dpResult = commands.cmdDetectPlatform(cwd, dpRemoteArg, true);
         if (dpResult && dpResult[dpField] !== undefined) {
-          process.stdout.write(String(dpResult[dpField]));
+          coreOutput(dpResult[dpField]);
         }
         process.exit(0);
       }
-      commands.cmdDetectPlatform(cwd, dpRemoteArg, raw);
+      commands.cmdDetectPlatform(cwd, dpRemoteArg);
       break;
     }
 
     case 'detect-workspace': {
-      // Support --field <name> --raw for scalar extraction
+      validateArgs('detect-workspace', null, args.slice(1));
+      // Support --field <name> for scalar extraction
       const dwFieldIdx = args.indexOf('--field');
       const dwField = dwFieldIdx !== -1 ? args[dwFieldIdx + 1] : null;
-      if (dwField && raw) {
-        const dwResult = workspace.cmdDetectWorkspace(cwd, false, true);
+      if (dwField) {
+        const dwResult = workspace.cmdDetectWorkspace(cwd, true);
         if (dwResult && dwResult[dwField] !== undefined) {
-          process.stdout.write(String(dwResult[dwField]));
+          coreOutput(dwResult[dwField]);
         }
         process.exit(0);
       }
-      workspace.cmdDetectWorkspace(cwd, raw);
+      workspace.cmdDetectWorkspace(cwd);
       break;
     }
 
     case 'git-context': {
-      // Support --field <name> --raw for scalar extraction
+      validateArgs('git-context', null, args.slice(1));
+      // Support --field <name> for scalar extraction
       const gcFieldIdx = args.indexOf('--field');
       const gcField = gcFieldIdx !== -1 ? args[gcFieldIdx + 1] : null;
-      if (gcField && raw) {
-        const gcResult = workspace.cmdGitContext(cwd, false, true);
+      if (gcField) {
+        const gcResult = workspace.cmdGitContext(cwd, true);
         if (gcResult && gcResult[gcField] !== undefined) {
-          process.stdout.write(String(gcResult[gcField]));
+          coreOutput(gcResult[gcField]);
         }
         process.exit(0);
       }
-      workspace.cmdGitContext(cwd, raw);
+      workspace.cmdGitContext(cwd);
       break;
     }
 
     case 'ssh-check': {
+      validateArgs('ssh-check', null, args.slice(1));
       const sshUrl = args[1] && !args[1].startsWith('--') ? args[1] : '';
-      // Support --field <name> --raw for scalar extraction
+      // Support --field <name> for scalar extraction
       const scFieldIdx = args.indexOf('--field');
       const scField = scFieldIdx !== -1 ? args[scFieldIdx + 1] : null;
-      if (scField && raw) {
-        const scResult = workspace.cmdSshCheck(sshUrl, false, true);
+      if (scField) {
+        const scResult = workspace.cmdSshCheck(sshUrl, true);
         if (scResult && scResult[scField] !== undefined) {
-          process.stdout.write(String(scResult[scField]));
+          coreOutput(scResult[scField]);
         }
         process.exit(0);
       }
-      workspace.cmdSshCheck(sshUrl, raw);
+      workspace.cmdSshCheck(sshUrl);
       break;
     }
 
     case 'discover-test-command': {
       const result = commands.discoverTestCommand(cwd);
-      coreOutput(result, raw);
+      coreOutput(result);
       break;
     }
 
     case 'websearch': {
+      validateArgs('websearch', null, args.slice(1));
       const query = args[1];
       const limitIdx = args.indexOf('--limit');
       const freshnessIdx = args.indexOf('--freshness');
       await commands.cmdWebsearch(query, {
         limit: limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 10,
         freshness: freshnessIdx !== -1 ? args[freshnessIdx + 1] : null,
-      }, raw);
+      });
       break;
     }
 
     case 'squash': {
+      validateArgs('squash', null, args.slice(1));
       const listBackupTags = args.includes('--list-backup-tags');
       const phase = listBackupTags ? null : args[1];
       const dryRun = args.includes('--dry-run');
@@ -1375,25 +1442,26 @@ async function main() {
         dryRun,
         allowStable,
         listBackupTags,
-      }, raw);
+      });
       break;
     }
 
     case 'version-bump': {
+      validateArgs('version-bump', null, args.slice(1));
       const levelIdx = args.indexOf('--level');
       const schemeIdx = args.indexOf('--scheme');
       const snapshot = args.includes('--snapshot');
       const vbFieldIdx = args.indexOf('--field');
       const vbField = vbFieldIdx !== -1 ? args[vbFieldIdx + 1] : null;
-      if (vbField && raw) {
+      if (vbField) {
         // silent=true: returns result without calling output()/process.exit()
         const vbResult = commands.cmdVersionBump(cwd, {
           level: levelIdx >= 0 ? args[levelIdx + 1] : null,
           scheme: schemeIdx >= 0 ? args[schemeIdx + 1] : null,
           snapshot,
-        }, false, true);
+        }, true);
         if (vbResult && vbResult[vbField] !== undefined) {
-          process.stdout.write(String(vbResult[vbField]));
+          coreOutput(vbResult[vbField]);
         }
         process.exit(0);
       }
@@ -1401,69 +1469,69 @@ async function main() {
         level: levelIdx >= 0 ? args[levelIdx + 1] : null,
         scheme: schemeIdx >= 0 ? args[schemeIdx + 1] : null,
         snapshot,
-      }, raw);
+      });
       break;
     }
 
     case 'generate-changelog': {
+      validateArgs('generate-changelog', null, args.slice(1));
       const version = args[1];
       const dateIdx = args.indexOf('--date');
       commands.cmdGenerateChangelog(cwd, version, {
         date: dateIdx >= 0 ? args[dateIdx + 1] : null,
-      }, raw);
+      });
       break;
     }
 
     case 'generate-allowlist': {
-      commands.cmdGenerateAllowlist(cwd, raw);
+      commands.cmdGenerateAllowlist(cwd);
       break;
     }
 
     case 'resolve-type-alias': {
       // Resolve a short commit type to its branch prefix alias using git.type_aliases config.
-      // Usage: gsd-tools resolve-type-alias feat --raw
+      // Usage: gsd-tools resolve-type-alias feat
       const typeArg = args[1] || 'feat';
       // git.type_aliases is nested in config.json under the git section.
       // loadConfig() returns a flat object so we read the raw config file directly.
       const rtaConfigPath = path.join(cwd, '.planning', 'config.json');
       let rtaAliases = { feat: 'feature', fix: 'bugfix', chore: 'chore', refactor: 'refactor' };
       try {
-        const rawCfg = JSON.parse(fs.readFileSync(rtaConfigPath, 'utf-8'));
-        if (rawCfg.git && rawCfg.git.type_aliases) {
-          rtaAliases = rawCfg.git.type_aliases;
+        const rtaCfg = JSON.parse(fs.readFileSync(rtaConfigPath, 'utf-8'));
+        if (rtaCfg.git && rtaCfg.git.type_aliases) {
+          rtaAliases = rtaCfg.git.type_aliases;
         }
       } catch {}
       const resolvedAlias = rtaAliases[typeArg] !== undefined ? rtaAliases[typeArg] : typeArg;
-      if (raw) {
-        process.stdout.write(resolvedAlias);
-        process.exit(0);
-      }
-      coreOutput({ type: typeArg, alias: resolvedAlias }, false, resolvedAlias);
+      coreOutput({ type: typeArg, alias: resolvedAlias }, resolvedAlias);
       break;
     }
 
     case 'issue-import': {
+      validateArgs('issue-import', null, args.slice(1));
       const platform = args[1];
       const number = args[2];
       const repoIdx = args.indexOf('--repo');
       const repo = repoIdx >= 0 ? args[repoIdx + 1] : null;
-      commands.cmdIssueImport(cwd, platform, number, repo, raw);
+      commands.cmdIssueImport(cwd, platform, number, repo);
       break;
     }
 
     case 'issue-sync': {
+      validateArgs('issue-sync', null, args.slice(1));
       const phase = args[1] || null;
       const auto = args.includes('--auto');
-      commands.cmdIssueSync(cwd, phase, { auto }, raw);
+      commands.cmdIssueSync(cwd, phase, { auto });
       break;
     }
 
     case 'issue-list-refs': {
-      commands.cmdIssueListRefs(cwd, raw);
+      commands.cmdIssueListRefs(cwd);
       break;
     }
 
     case 'divergence': {
+      validateArgs('divergence', null, args.slice(1));
       const refreshFlag = args.includes('--refresh');
       const initFlag = args.includes('--init');
       const triageIdx = args.indexOf('--triage');
@@ -1484,34 +1552,37 @@ async function main() {
         remote: remoteIdx !== -1 ? args[remoteIdx + 1] : null,
         remoteBranch: remoteBranchIdx !== -1 ? args[remoteBranchIdx + 1] : null,
       };
-      commands.cmdDivergence(cwd, opts, raw);
+      commands.cmdDivergence(cwd, opts);
       break;
     }
 
     case 'pingpong-check': {
+      validateArgs('pingpong-check', null, args.slice(1));
       const windowIdx = args.indexOf('--window');
-      commands.cmdPingpongCheck(cwd, windowIdx !== -1 ? ['--window', args[windowIdx + 1]] : [], raw);
+      commands.cmdPingpongCheck(cwd, windowIdx !== -1 ? ['--window', args[windowIdx + 1]] : []);
       break;
     }
 
     case 'breakout-check': {
+      validateArgs('breakout-check', null, args.slice(1));
       const planIdx = args.indexOf('--plan');
       const filesIdx = args.indexOf('--declared-files');
       const checkArgs = [];
       if (planIdx !== -1) { checkArgs.push('--plan', args[planIdx + 1]); }
       if (filesIdx !== -1) { checkArgs.push('--declared-files', args[filesIdx + 1]); }
-      commands.cmdBreakoutCheck(cwd, checkArgs, raw);
+      commands.cmdBreakoutCheck(cwd, checkArgs);
       break;
     }
 
     case 'cleanup': {
+      validateArgs('cleanup', null, args.slice(1));
       const dryRun = args.includes('--dry-run');
-      commands.cmdCleanup(cwd, { dryRun }, raw);
+      commands.cmdCleanup(cwd, { dryRun });
       break;
     }
 
     case 'help':
-      commands.cmdHelp(cwd, args.slice(1), raw);
+      commands.cmdHelp(cwd, args.slice(1));
       break;
 
     case '--help':
@@ -1521,11 +1592,11 @@ async function main() {
 
     case 'guard': {
       const subcommand = args[1];
-      validateSubcommandArgs('guard', subcommand, args.slice(2));
+      validateArgs('guard', subcommand, args.slice(2));
       if (subcommand === 'sync-chain') {
-        guard.cmdGuardSyncChain(cwd, args.slice(2).join(' '), raw);
+        guard.cmdGuardSyncChain(cwd, args.slice(2).join(' '));
       } else if (subcommand === 'init-valid') {
-        guard.cmdGuardInitValid(args[2], raw);
+        guard.cmdGuardInitValid(args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'guard');
         if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -10,7 +10,7 @@ const { extractFrontmatter } = require('./frontmatter.cjs');
 const { MODEL_PROFILES } = require('./model-profiles.cjs');
 const { validatePath, scanForInjection, wrapUntrustedContent, logSecurityEvent } = require('./security.cjs');
 
-function cmdGenerateSlug(text, raw) {
+function cmdGenerateSlug(text) {
   if (!text) {
     error('text required for slug generation');
   }
@@ -21,10 +21,10 @@ function cmdGenerateSlug(text, raw) {
     .replace(/^-+|-+$/g, '');
 
   const result = { slug };
-  output(result, raw, slug);
+  output(result, slug);
 }
 
-function cmdCurrentTimestamp(format, raw) {
+function cmdCurrentTimestamp(format) {
   const now = new Date();
   let result;
 
@@ -41,10 +41,10 @@ function cmdCurrentTimestamp(format, raw) {
       break;
   }
 
-  output({ timestamp: result }, raw, result);
+  output({ timestamp: result }, result);
 }
 
-function cmdListTodos(cwd, area, raw) {
+function cmdListTodos(cwd, area) {
   const { todosPending: pendingDir } = planningPaths(cwd);
 
   let count = 0;
@@ -78,10 +78,10 @@ function cmdListTodos(cwd, area, raw) {
   } catch {}
 
   const result = { count, todos };
-  output(result, raw, count.toString());
+  output(result, count.toString());
 }
 
-function cmdVerifyPathExists(cwd, targetPath, raw) {
+function cmdVerifyPathExists(cwd, targetPath) {
   if (!targetPath) {
     error('path required for verification');
   }
@@ -90,7 +90,7 @@ function cmdVerifyPathExists(cwd, targetPath, raw) {
   if (!path.isAbsolute(targetPath)) {
     const pathCheck = validatePath(targetPath, cwd);
     if (!pathCheck.safe) {
-      output({ exists: false, type: null, error: pathCheck.error }, raw, 'false');
+      output({ exists: false, type: null, error: pathCheck.error }, 'false');
       return;
     }
   }
@@ -101,14 +101,14 @@ function cmdVerifyPathExists(cwd, targetPath, raw) {
     const stats = fs.statSync(fullPath);
     const type = stats.isDirectory() ? 'directory' : stats.isFile() ? 'file' : 'other';
     const result = { exists: true, type };
-    output(result, raw, 'true');
+    output(result, 'true');
   } catch {
     const result = { exists: false, type: null };
-    output(result, raw, 'false');
+    output(result, 'false');
   }
 }
 
-function cmdHistoryDigest(cwd, raw) {
+function cmdHistoryDigest(cwd) {
   const { phases: phasesDir } = planningPaths(cwd);
   const digest = { phases: {}, decisions: [], tech_stack: new Set() };
 
@@ -136,7 +136,7 @@ function cmdHistoryDigest(cwd, raw) {
 
   if (allPhaseDirs.length === 0) {
     digest.tech_stack = [];
-    output(digest, raw);
+    output(digest);
     return;
   }
 
@@ -203,13 +203,13 @@ function cmdHistoryDigest(cwd, raw) {
     });
     digest.tech_stack = [...digest.tech_stack];
 
-    output(digest, raw);
+    output(digest);
   } catch (e) {
     error('Failed to generate history digest: ' + e.message);
   }
 }
 
-function cmdResolveModel(cwd, agentType, raw) {
+function cmdResolveModel(cwd, agentType) {
   if (!agentType) {
     error('agent-type required');
   }
@@ -222,7 +222,7 @@ function cmdResolveModel(cwd, agentType, raw) {
   const result = agentModels
     ? { model, profile }
     : { model, profile, unknown_agent: true };
-  output(result, raw, model);
+  output(result, model);
 }
 
 function applyCommitFormat(message, config, context) {
@@ -259,7 +259,7 @@ function appendIssueTrailers(message, trailers) {
   return message + '\n\n' + lines.join('\n');
 }
 
-function cmdCommit(cwd, message, files, raw, amend) {
+function cmdCommit(cwd, message, files, amend) {
   if (!message && !amend) {
     error('commit message required');
   }
@@ -269,14 +269,14 @@ function cmdCommit(cwd, message, files, raw, amend) {
   // Check commit_docs config
   if (!config.commit_docs) {
     const result = { committed: false, hash: null, reason: 'skipped_commit_docs_false' };
-    output(result, raw, 'skipped');
+    output(result, 'skipped');
     return;
   }
 
   // Check if .planning is gitignored
   if (isGitIgnored(cwd, '.planning')) {
     const result = { committed: false, hash: null, reason: 'skipped_gitignored' };
-    output(result, raw, 'skipped');
+    output(result, 'skipped');
     return;
   }
 
@@ -297,11 +297,11 @@ function cmdCommit(cwd, message, files, raw, amend) {
   if (commitResult.exitCode !== 0) {
     if (commitResult.stdout.includes('nothing to commit') || commitResult.stderr.includes('nothing to commit')) {
       const result = { committed: false, hash: null, reason: 'nothing_to_commit' };
-      output(result, raw, 'nothing');
+      output(result, 'nothing');
       return;
     }
     const result = { committed: false, hash: null, reason: 'nothing_to_commit', error: commitResult.stderr };
-    output(result, raw, 'nothing');
+    output(result, 'nothing');
     return;
   }
 
@@ -309,10 +309,10 @@ function cmdCommit(cwd, message, files, raw, amend) {
   const hashResult = execGit(cwd, ['rev-parse', '--short', 'HEAD']);
   const hash = hashResult.exitCode === 0 ? hashResult.stdout : null;
   const result = { committed: true, hash, reason: 'committed' };
-  output(result, raw, hash || 'committed');
+  output(result, hash || 'committed');
 }
 
-function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
+function cmdSummaryExtract(cwd, summaryPath, fields, defaultValue) {
   if (!summaryPath) {
     error('summary-path required for summary-extract');
   }
@@ -320,7 +320,8 @@ function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
   const fullPath = path.join(cwd, summaryPath);
 
   if (!fs.existsSync(fullPath)) {
-    output({ error: 'File not found', path: summaryPath }, raw);
+    if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+    output({ error: 'File not found', path: summaryPath });
     return;
   }
 
@@ -371,24 +372,24 @@ function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
         filtered[field] = fullResult[field];
       }
     }
-    output(filtered, raw);
+    output(filtered);
     return;
   }
 
-  output(fullResult, raw);
+  output(fullResult);
 }
 
-async function cmdWebsearch(query, options, raw) {
+async function cmdWebsearch(query, options) {
   const apiKey = process.env.BRAVE_API_KEY;
 
   if (!apiKey) {
     // No key = silent skip, agent falls back to built-in WebSearch
-    output({ available: false, reason: 'BRAVE_API_KEY not set' }, raw, '');
+    output({ available: false, reason: 'BRAVE_API_KEY not set' }, '');
     return;
   }
 
   if (!query) {
-    output({ available: false, error: 'Query required' }, raw, '');
+    output({ available: false, error: 'Query required' }, '');
     return;
   }
 
@@ -416,7 +417,7 @@ async function cmdWebsearch(query, options, raw) {
     );
 
     if (!response.ok) {
-      output({ available: false, error: `API error: ${response.status}` }, raw, '');
+      output({ available: false, error: `API error: ${response.status}` }, '');
       return;
     }
 
@@ -434,13 +435,13 @@ async function cmdWebsearch(query, options, raw) {
       query,
       count: results.length,
       results
-    }, raw, results.map(r => `${r.title}\n${r.url}\n${r.description}`).join('\n\n'));
+    }, results.map(r => `${r.title}\n${r.url}\n${r.description}`).join('\n\n'));
   } catch (err) {
-    output({ available: false, error: err.message }, raw, '');
+    output({ available: false, error: err.message }, '');
   }
 }
 
-function cmdProgressRender(cwd, format, raw) {
+function cmdProgressRender(cwd, format) {
   const { phases: phasesDir, roadmap: roadmapPath } = planningPaths(cwd);
   const milestone = getMilestoneInfo(cwd);
 
@@ -487,13 +488,13 @@ function cmdProgressRender(cwd, format, raw) {
     for (const p of phases) {
       out += `| ${p.number} | ${p.name} | ${p.summaries}/${p.plans} | ${p.status} |\n`;
     }
-    output({ rendered: out }, raw, out);
+    output({ rendered: out }, out);
   } else if (format === 'bar') {
     const barWidth = 20;
     const filled = Math.round((percent / 100) * barWidth);
     const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(barWidth - filled);
     const text = `[${bar}] ${totalSummaries}/${totalPlans} plans (${percent}%)`;
-    output({ bar: text, percent, completed: totalSummaries, total: totalPlans }, raw, text);
+    output({ bar: text, percent, completed: totalSummaries, total: totalPlans }, text);
   } else {
     // JSON format
     output({
@@ -503,7 +504,7 @@ function cmdProgressRender(cwd, format, raw) {
       total_plans: totalPlans,
       total_summaries: totalSummaries,
       percent,
-    }, raw);
+    });
   }
 }
 
@@ -538,7 +539,7 @@ function isRecurringDue(todoData) {
   return (Date.now() - lastCompleted) >= intervalMs;
 }
 
-function cmdTodoComplete(cwd, filename, raw) {
+function cmdTodoComplete(cwd, filename) {
   if (!filename) {
     error('filename required for todo complete');
   }
@@ -575,7 +576,6 @@ function cmdTodoComplete(cwd, filename, raw) {
     fs.writeFileSync(sourcePath, updatedContent, 'utf-8');
     output(
       { completed: true, recurring: true, file: filename, date: todayDate, next_due: fm.interval || 'unknown' },
-      raw,
       `recurring-reset: ${filename}`
     );
     return;
@@ -604,7 +604,7 @@ function cmdTodoComplete(cwd, filename, raw) {
       try {
         const commitHash = getLatestCommitHash(cwd);
         const syncResults = syncSingleRef(fm.external_ref, { commitHash }, itConfig);
-        output({ completed: true, file: filename, date: today, synced: syncResults }, raw, 'completed');
+        output({ completed: true, file: filename, date: today, synced: syncResults }, 'completed');
         return;
       } catch (_e) {
         // Sync failure is non-fatal — fall through to normal completion output
@@ -612,16 +612,103 @@ function cmdTodoComplete(cwd, filename, raw) {
     }
   }
 
-  output({ completed: true, file: filename, date: today }, raw, 'completed');
+  output({ completed: true, file: filename, date: today }, 'completed');
+}
+
+/**
+ * List pending todo filenames whose frontmatter phase field matches the given phase number.
+ *
+ * @param {string} cwd
+ * @param {string|number} phase - Phase number to match
+ */
+function cmdTodoListByPhase(cwd, phase) {
+  if (!phase) error('phase required for todo list-by-phase');
+  const { todosPending } = planningPaths(cwd);
+  let files = [];
+  try {
+    files = fs.readdirSync(todosPending).filter(f => f.endsWith('.md'));
+  } catch (_e) {
+    // Directory doesn't exist — return empty
+    output([]);
+    return;
+  }
+  const matches = [];
+  for (const file of files) {
+    try {
+      const content = fs.readFileSync(path.join(todosPending, file), 'utf-8');
+      const fm = extractFrontmatter(content);
+      if (String(fm.phase) === String(phase)) matches.push(file);
+    } catch (_e) {
+      // Skip unreadable files
+    }
+  }
+  output(matches);
+}
+
+/**
+ * List pending todo filenames that are referenced in ROADMAP.md Source Todos for the given phase.
+ * Only returns todos that actually exist in the pending directory.
+ *
+ * @param {string} cwd
+ * @param {string|number} phase - Phase number to look up in ROADMAP
+ */
+function cmdTodoScanPhaseLinked(cwd, phase) {
+  if (!phase) error('phase required for todo scan-phase-linked');
+  const { todosPending, roadmap: roadmapPath } = planningPaths(cwd);
+
+  // Read ROADMAP and parse source_todos for the given phase
+  let sourceTodosStr = null;
+  try {
+    if (!fs.existsSync(roadmapPath)) {
+      output([]);
+      return;
+    }
+    const content = fs.readFileSync(roadmapPath, 'utf-8');
+    const escapedPhase = String(phase).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const phasePattern = new RegExp(`#{2,4}\\s*Phase\\s+${escapedPhase}:\\s*[^\\n]+`, 'i');
+    const headerMatch = content.match(phasePattern);
+    if (!headerMatch) {
+      output([]);
+      return;
+    }
+    const sectionStart = headerMatch.index;
+    const restOfContent = content.slice(sectionStart);
+    const nextHeaderMatch = restOfContent.match(/\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i);
+    const sectionEnd = nextHeaderMatch ? sectionStart + nextHeaderMatch.index : content.length;
+    const section = content.slice(sectionStart, sectionEnd);
+    const sourceTodosMatch = section.match(/\*\*Source Todos\*\*:\s*([^\n]+)/i);
+    if (sourceTodosMatch) sourceTodosStr = sourceTodosMatch[1].trim();
+  } catch (_e) {
+    output([]);
+    return;
+  }
+
+  if (!sourceTodosStr) {
+    output([]);
+    return;
+  }
+
+  // Parse source_todos string: backtick-wrapped, comma-separated
+  const todoFiles = sourceTodosStr
+    .replace(/`/g, '').split(',').map(s => s.trim()).filter(Boolean);
+
+  // Return only files that exist in pending dir
+  const existing = todoFiles.filter(f => {
+    try {
+      return fs.existsSync(path.join(todosPending, f));
+    } catch (_e) {
+      return false;
+    }
+  });
+  output(existing);
 }
 
 /**
  * List recurring todos that are past their interval (due for attention).
  *
  * @param {string} cwd
- * @param {boolean} raw
  */
-function cmdRecurringDue(cwd, raw) {
+function cmdRecurringDue(cwd) {
   const { todosPending: pendingDir } = planningPaths(cwd);
   const due = [];
 
@@ -652,12 +739,11 @@ function cmdRecurringDue(cwd, raw) {
 
   output(
     { count: due.length, todos: due },
-    raw,
     due.length > 0 ? due.map(d => d.file).join(', ') : 'none due'
   );
 }
 
-function cmdScaffold(cwd, type, options, raw) {
+function cmdScaffold(cwd, type, options) {
   const { phase, name } = options;
   const padded = phase ? normalizePhaseName(phase) : '00';
   const today = new Date().toISOString().split('T')[0];
@@ -698,7 +784,7 @@ function cmdScaffold(cwd, type, options, raw) {
       fs.mkdirSync(phasesParent, { recursive: true });
       const dirPath = path.join(phasesParent, dirName);
       fs.mkdirSync(dirPath, { recursive: true });
-      output({ created: true, directory: `.planning/phases/${dirName}`, path: dirPath }, raw, dirPath);
+      output({ created: true, directory: `.planning/phases/${dirName}`, path: dirPath }, dirPath);
       return;
     }
     default:
@@ -706,16 +792,16 @@ function cmdScaffold(cwd, type, options, raw) {
   }
 
   if (fs.existsSync(filePath)) {
-    output({ created: false, reason: 'already_exists', path: filePath }, raw, 'exists');
+    output({ created: false, reason: 'already_exists', path: filePath }, 'exists');
     return;
   }
 
   fs.writeFileSync(filePath, content, 'utf-8');
   const relPath = toPosixPath(path.relative(cwd, filePath));
-  output({ created: true, path: relPath }, raw, relPath);
+  output({ created: true, path: relPath }, relPath);
 }
 
-function cmdStats(cwd, format, raw) {
+function cmdStats(cwd, format) {
   const { phases: phasesDir, roadmap: roadmapPath, requirements: reqPath, state: statePath } = planningPaths(cwd);
   const milestone = getMilestoneInfo(cwd);
   const isDirInMilestone = getMilestonePhaseFilter(cwd);
@@ -865,9 +951,9 @@ function cmdStats(cwd, format, raw) {
       out += '\n';
     }
     if (lastActivity) out += `**Last activity:** ${lastActivity}\n`;
-    output({ rendered: out }, raw, out);
+    output({ rendered: out }, out);
   } else {
-    output(result, raw);
+    output(result);
   }
 }
 
@@ -1159,7 +1245,7 @@ function buildImportComment(style, context) {
   return 'Tracked for resolution.';
 }
 
-function cmdDetectPlatform(cwd, remote, raw, silent) {
+function cmdDetectPlatform(cwd, remote, silent) {
   const { spawnSync } = require('child_process');
 
   // 1. Check config override
@@ -1224,11 +1310,11 @@ function cmdDetectPlatform(cwd, remote, raw, silent) {
 
   // When called in silent mode (field extraction path), skip output/exit and return the result.
   if (silent) return result;
-  output(result, raw, platform || 'unknown');
+  output(result, platform || 'unknown');
   return result; // unreachable (output calls process.exit), retained for clarity
 }
 
-function cmdSquash(cwd, phase, options, raw) {
+function cmdSquash(cwd, phase, options) {
   const { strategy, dryRun, allowStable, listBackupTags: listTags } = options;
 
   // Handle --list-backup-tags subcommand
@@ -1237,7 +1323,7 @@ function cmdSquash(cwd, phase, options, raw) {
     const tags = tagResult.exitCode === 0 && tagResult.stdout
       ? tagResult.stdout.split('\n').filter(Boolean)
       : [];
-    output({ tags }, raw, tags.join('\n'));
+    output({ tags }, tags.join('\n'));
     return;
   }
 
@@ -1305,7 +1391,7 @@ function cmdSquash(cwd, phase, options, raw) {
 
   // Dry run: return plan without executing (safe even on stable branches)
   if (dryRun) {
-    output({ dry_run: true, strategy, phase, groups, executed: false }, raw,
+    output({ dry_run: true, strategy, phase, groups, executed: false },
       `DRY RUN (${strategy}):\n` + groups.map(g => `  ${g.name}: ${g.message.split('\n')[0]}`).join('\n'));
     return;
   }
@@ -1369,7 +1455,7 @@ function cmdSquash(cwd, phase, options, raw) {
     groups: groups.length,
     backup_tag: backupTags[backupTags.length - 1] || backupTag,
     executed: true,
-  }, raw, `Squashed (${strategy}): ${groups.length} group(s), backup: ${backupTag}`);
+  }, `Squashed (${strategy}): ${groups.length} group(s), backup: ${backupTag}`);
 }
 
 /**
@@ -1496,7 +1582,7 @@ function generateChangelog(version, date, summaries) {
  * Bump version in package.json and write VERSION file.
  * Reads bump level from commit type analysis if not explicitly provided.
  */
-function cmdVersionBump(cwd, options, raw, silent) {
+function cmdVersionBump(cwd, options, silent) {
   const { level: explicitLevel, scheme: explicitScheme, snapshot } = options;
   const config = loadConfig(cwd);
   const scheme = explicitScheme || config.versioning_scheme || 'semver';
@@ -1560,7 +1646,7 @@ function cmdVersionBump(cwd, options, raw, silent) {
   };
   // When called in silent mode (field extraction path), skip output/exit and return the result.
   if (silent) return versionResult;
-  output(versionResult, raw, newVersion);
+  output(versionResult, newVersion);
   return versionResult; // unreachable (output calls process.exit), retained for clarity
 }
 
@@ -1568,7 +1654,7 @@ function cmdVersionBump(cwd, options, raw, silent) {
  * Generate CHANGELOG.md entries from SUMMARY.md files across all phases.
  * Inserts the new version block after the [Unreleased] section.
  */
-function cmdGenerateChangelog(cwd, version, options, raw) {
+function cmdGenerateChangelog(cwd, version, options) {
   const { date: dateOverride } = options;
   const date = dateOverride || new Date().toISOString().split('T')[0];
 
@@ -1648,7 +1734,7 @@ function cmdGenerateChangelog(cwd, version, options, raw) {
     date,
     entries: summaries.length,
     path: 'CHANGELOG.md',
-  }, raw, `CHANGELOG.md updated with ${summaries.length} entries for v${version}`);
+  }, `CHANGELOG.md updated with ${summaries.length} entries for v${version}`);
 }
 
 /**
@@ -1677,10 +1763,9 @@ const LABEL_AREA_MAP = {
  * @param {string} platform - github|gitlab|forgejo|gitea
  * @param {number|string} number - Issue number
  * @param {string|null} repo - Optional repo override
- * @param {boolean} raw - Raw JSON output
  * @returns {{ imported, todo_file, title, external_ref, commented }}
  */
-function cmdIssueImport(cwd, platform, number, repo, raw) {
+function cmdIssueImport(cwd, platform, number, repo) {
   loadConfig(cwd); // Ensure config is loaded (side-effects: migration)
   // Read issue_tracker config directly from config.json since loadConfig
   // returns a flat structured object and does not expose the raw issue_tracker section.
@@ -1829,7 +1914,7 @@ function cmdIssueImport(cwd, platform, number, repo, raw) {
     commented,
   };
 
-  output(result, raw, `Imported ${externalRef} -> ${filename}`);
+  output(result, `Imported ${externalRef} -> ${filename}`);
   return result;
 }
 
@@ -1938,7 +2023,6 @@ function applyVerifyLabel(platform, number, repo, verifyLabel) {
  * @param {string} cwd
  * @param {string|null} phase - Filter to specific phase (not used in current minimal impl)
  * @param {{ auto: boolean }} options - auto=true means outbound-only
- * @param {boolean} raw - Raw JSON output
  * @returns {{ synced, conflicts, skipped }}
  */
 /**
@@ -2004,7 +2088,7 @@ function syncSingleRef(refStr, commentContext, itConfig) {
   return results;
 }
 
-function cmdIssueSync(cwd, phase, options, raw) {
+function cmdIssueSync(cwd, phase, options) {
   const opts = options || {};
   loadConfig(cwd); // Ensure config is loaded (side-effects: migration)
   // Read issue_tracker config directly from config.json since loadConfig
@@ -2081,7 +2165,7 @@ function cmdIssueSync(cwd, phase, options, raw) {
   }
 
   const result = { synced, conflicts, skipped };
-  output(result, raw,
+  output(result, 
     `Synced ${synced.length} ref(s), ${conflicts.length} conflict(s), ${skipped} skipped`
   );
   return result;
@@ -2092,10 +2176,9 @@ function cmdIssueSync(cwd, phase, options, raw) {
  * Deduplicates by ref_string.
  *
  * @param {string} cwd
- * @param {boolean} raw - Raw JSON output
  * @returns {{ refs: Array<{source, ref_string, parsed}>, count }}
  */
-function cmdIssueListRefs(cwd, raw) {
+function cmdIssueListRefs(cwd) {
   const refs = [];
   const seen = new Set();
 
@@ -2147,14 +2230,18 @@ function cmdIssueListRefs(cwd, raw) {
   }
 
   const result = { refs, count: refs.length };
-  output(result, raw, `Found ${refs.length} external ref(s)`);
+  output(result, `Found ${refs.length} external ref(s)`);
   return result;
 }
 
-function cmdStalenessCheck(cwd, raw) {
+function cmdStalenessCheck(cwd, countOnly = false) {
   const { codebase: codebaseDir } = planningPaths(cwd);
   if (!fs.existsSync(codebaseDir)) {
-    output({ stale: [], all_stale: false }, raw, 'no codebase directory');
+    if (countOnly) {
+      output(0, '0');
+    } else {
+      output({ stale: [], all_stale: false }, 'no codebase directory');
+    }
     return;
   }
 
@@ -2195,15 +2282,19 @@ function cmdStalenessCheck(cwd, raw) {
     } catch {}
   }
 
+  if (countOnly) {
+    output(stale.length, String(stale.length));
+    return;
+  }
+
   const allStale = stale.length === docs.length;
   output(
     { stale, all_stale: allStale, total_docs: docs.length },
-    raw,
     stale.length > 0 ? stale.map(s => s.doc).join(', ') : 'none'
   );
 }
 
-function cmdHelp(cwd, args, raw) {
+function cmdHelp(cwd, args) {
   const commandsDir = path.join(__dirname, '..', '..', '..', 'commands', 'gsd');
   let commands = [];
 
@@ -2225,7 +2316,7 @@ function cmdHelp(cwd, args, raw) {
     commands.sort((a, b) => a.name.localeCompare(b.name));
   } catch (e) {
     const result = { commands: [], error: 'Commands directory not found' };
-    output(result, raw, 'Commands directory not found');
+    output(result, 'Commands directory not found');
     return;
   }
 
@@ -2241,7 +2332,7 @@ function cmdHelp(cwd, args, raw) {
   }
 
   const result = { commands };
-  output(result, raw, formatHelpText(commands));
+  output(result, formatHelpText(commands));
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -2587,9 +2678,8 @@ function rewriteDivergenceTable(filePath, triageState) {
  *
  * @param {string} cwd
  * @param {{ refresh?: boolean, init?: boolean, triage?: string, status?: string, reason?: string, branch?: string, base?: string, remote?: string, remoteBranch?: string }} opts
- * @param {boolean} raw
  */
-function cmdDivergence(cwd, opts, raw) {
+function cmdDivergence(cwd, opts) {
   const { divergence: divergencePath } = planningPaths(cwd);
 
   // ── Branch mode: track drift between base and branch ──────────────────────
@@ -2663,7 +2753,7 @@ function cmdDivergence(cwd, opts, raw) {
       } catch {}
 
       writeDivergenceBranchSection(divergencePath, sectionKey, allCommits);
-      output({ status: 'initialized', section: sectionKey, commits: allCommits.length }, raw,
+      output({ status: 'initialized', section: sectionKey, commits: allCommits.length },
         `Initialized branch section '${sectionKey}' with ${allCommits.length} commits`);
       return;
     }
@@ -2703,7 +2793,7 @@ function cmdDivergence(cwd, opts, raw) {
         status: e.status || 'pending', reason: e.reason || '',
       }));
       writeDivergenceBranchSection(divergencePath, sectionKey, commits);
-      output({ status: 'updated', hash, new_status: status, section: sectionKey }, raw,
+      output({ status: 'updated', hash, new_status: status, section: sectionKey },
         `Updated ${hash} in ${sectionKey}: ${status}${reason ? ' — ' + reason : ''}`);
       return;
     }
@@ -2753,7 +2843,7 @@ function cmdDivergence(cwd, opts, raw) {
           unknown: commits.filter(c => c.classification === 'unknown').length,
         },
       },
-    }, raw, summaryText);
+    }, summaryText);
     return;
   }
 
@@ -2766,7 +2856,7 @@ function cmdDivergence(cwd, opts, raw) {
   } catch {}
 
   if (!upstreamUrl) {
-    output({ status: 'no_upstream', commits: [] }, raw, `No '${remoteName}' remote found. Add one with: git remote add ${remoteName} <url>`);
+    output({ status: 'no_upstream', commits: [] }, `No '${remoteName}' remote found. Add one with: git remote add ${remoteName} <url>`);
     return;
   }
 
@@ -2808,7 +2898,7 @@ function cmdDivergence(cwd, opts, raw) {
     } catch {}
 
     writeDivergenceFile(divergencePath, upstreamUrl, allCommits, remoteName);
-    output({ status: 'initialized', commits: allCommits.length }, raw, `Initialized DIVERGENCE.md with ${allCommits.length} upstream commits`);
+    output({ status: 'initialized', commits: allCommits.length }, `Initialized DIVERGENCE.md with ${allCommits.length} upstream commits`);
     return;
   }
 
@@ -2843,7 +2933,7 @@ function cmdDivergence(cwd, opts, raw) {
 
     triageState.set(hash, { ...entry, status, reason });
     rewriteDivergenceTable(divergencePath, triageState);
-    output({ status: 'updated', hash, new_status: status }, raw, `Updated ${hash}: ${status}${reason ? ' — ' + reason : ''}`);
+    output({ status: 'updated', hash, new_status: status }, `Updated ${hash}: ${status}${reason ? ' — ' + reason : ''}`);
     return;
   }
 
@@ -2900,7 +2990,7 @@ function cmdDivergence(cwd, opts, raw) {
     upstream: upstreamUrl,
     commits,
     summary: { pending, picked, skipped, deferred, total: commits.length },
-  }, raw, summaryText);
+  }, summaryText);
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3066,9 +3156,8 @@ function detectOscillation(commits) {
  *
  * @param {string} cwd - Working directory
  * @param {string[]} args - CLI args (supports --window N)
- * @param {boolean} raw - Raw output mode
  */
-function cmdPingpongCheck(cwd, args, raw) {
+function cmdPingpongCheck(cwd, args) {
   const windowIdx = args.indexOf('--window');
   const window = windowIdx !== -1 ? parseInt(args[windowIdx + 1], 10) || 20 : 20;
 
@@ -3076,14 +3165,14 @@ function cmdPingpongCheck(cwd, args, raw) {
 
   if (result.exitCode !== 0 || !result.stdout || !result.stdout.trim()) {
     const response = { status: 'ok', reason: 'no git history', details: { oscillating_files: [], agent_sequence: [] } };
-    output(response, raw, 'ok');
+    output(response, 'ok');
     return;
   }
 
   const commits = parseCommitLog(result.stdout);
   const detection = detectOscillation(commits);
 
-  output(detection, raw, detection.status);
+  output(detection, detection.status);
 }
 
 /**
@@ -3212,9 +3301,8 @@ function detectBreakout(commits, declaredFiles) {
  *
  * @param {string} cwd - Working directory
  * @param {string[]} args - CLI args: --plan {id} --declared-files f1,f2,f3
- * @param {boolean} raw - Raw output mode
  */
-function cmdBreakoutCheck(cwd, args, raw) {
+function cmdBreakoutCheck(cwd, args) {
   const planIdx = args.indexOf('--plan');
   const planId = planIdx !== -1 ? args[planIdx + 1] : null;
   const filesIdx = args.indexOf('--declared-files');
@@ -3222,7 +3310,7 @@ function cmdBreakoutCheck(cwd, args, raw) {
 
   if (!planId) {
     const response = { status: 'ok', reason: 'No --plan specified', details: { unexpected_files: [] } };
-    output(response, raw, 'ok');
+    output(response, 'ok');
     return;
   }
 
@@ -3233,17 +3321,17 @@ function cmdBreakoutCheck(cwd, args, raw) {
 
   if (result.exitCode !== 0 || !result.stdout || !result.stdout.trim()) {
     const response = { status: 'ok', reason: 'No matching commits found', details: { unexpected_files: [] } };
-    output(response, raw, 'ok');
+    output(response, 'ok');
     return;
   }
 
   const commits = parseCommitLog(result.stdout);
   const detection = detectBreakout(commits, declaredFiles);
 
-  output(detection, raw, detection.status);
+  output(detection, detection.status);
 }
 
-function cmdGenerateAllowlist(cwd, raw) {
+function cmdGenerateAllowlist(cwd) {
   // 1. Load static template as baseline
   const templatePath = path.join(__dirname, '..', '..', 'templates', 'settings-sandbox.json');
   let template;
@@ -3302,11 +3390,7 @@ function cmdGenerateAllowlist(cwd, raw) {
   };
 
   // 5. Output
-  if (raw) {
-    output(result, true, JSON.stringify(result, null, 2));
-  } else {
-    output(result, false, `Generated allowlist with ${allEntries.length} entries (${staticEntries.size} static + ${dynamicEntries.size} dynamic)`);
-  }
+  output(result);
 }
 
 /**
@@ -3469,7 +3553,7 @@ function discoverTestCommand(cwd) {
  * 4. Cross-reference against .planning/phases/ directories that still exist
  * 5. dryRun: return preview; otherwise: mkdir + renameSync each phase dir
  */
-function cmdCleanup(cwd, options, raw) {
+function cmdCleanup(cwd, options) {
   const { dryRun } = options || {};
   const { milestonesFile: milestonesFilePath, milestones: milestonesDir, phases: phasesDir } = planningPaths(cwd);
 
@@ -3479,7 +3563,7 @@ function cmdCleanup(cwd, options, raw) {
     milestonesContent = fs.readFileSync(milestonesFilePath, 'utf-8');
   } catch {
     const result = { milestones: [], nothing_to_do: true, error: 'MILESTONES.md not found' };
-    output(result, raw, 'MILESTONES.md not found. Nothing to clean up.');
+    output(result, 'MILESTONES.md not found. Nothing to clean up.');
     return;
   }
 
@@ -3498,7 +3582,7 @@ function cmdCleanup(cwd, options, raw) {
 
   if (completedVersions.length === 0) {
     const result = { milestones: [], nothing_to_do: true };
-    output(result, raw, 'No completed milestones found. Nothing to clean up.');
+    output(result, 'No completed milestones found. Nothing to clean up.');
     return;
   }
 
@@ -3605,11 +3689,11 @@ function cmdCleanup(cwd, options, raw) {
         }
       }
     }
-    output(result, raw, text);
+    output(result, text);
   } else {
     const total = milestoneResults.filter(m => !m.skipped).reduce((sum, m) => sum + (m.phases_to_archive ? m.phases_to_archive.length : 0), 0);
     const mCount = milestoneResults.filter(m => !m.skipped && m.phases_to_archive && m.phases_to_archive.length > 0).length;
-    output(result, raw, `Archived ${total} phase directories from ${mCount} milestones.`);
+    output(result, `Archived ${total} phase directories from ${mCount} milestones.`);
   }
 }
 
@@ -3676,10 +3760,9 @@ function detectInstallLocation(cwd) {
  *
  * @param {string} cwd - Working directory
  * @param {{ dryRun: boolean, local: boolean, global: boolean }} options
- * @param {boolean} raw - Raw output flag
  * @param {{ latestVersion: string|null, updateSource: string|null } | null} _testOverrides - Test injection
  */
-function cmdUpdate(cwd, options, raw, _testOverrides) {
+function cmdUpdate(cwd, options, _testOverrides) {
   const { dryRun = false } = options || {};
   const homeDir = process.env.GSD_TEST_HOME || os.homedir();
 
@@ -3696,7 +3779,7 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
     return output({
       status: 'unknown_version',
       message: 'No VERSION file found. Run npx gsd-ng@latest to install.',
-    }, raw);
+    });
   }
 
   const { isLocal, installedVersion } = installInfo;
@@ -3771,7 +3854,7 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
     return output({
       status: 'both_unavailable',
       message: 'Could not check for updates (npm and GitHub both unavailable).',
-    }, raw);
+    });
   }
 
   // 3. Compare versions
@@ -3781,14 +3864,14 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
       status: 'already_current',
       installed,
       latest: latestVersion,
-    }, raw);
+    });
   }
   if (cmp > 0) {
     return output({
       status: 'ahead',
       installed,
       latest: latestVersion,
-    }, raw);
+    });
   }
 
   // 4. Dry-run: return info without executing
@@ -3800,7 +3883,7 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
       update_source: updateSource,
       install_type: isLocal ? 'local' : 'global',
       update_available: true,
-    }, raw);
+    });
   }
 
   // 5. Execute update
@@ -3820,7 +3903,7 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
       to: latestVersion,
       source: updateSource,
       install_command: installCommand,
-    }, raw);
+    });
   }
 
   if (updateSource === 'npm') {
@@ -3833,7 +3916,7 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
       return output({
         status: 'error',
         message: 'Update failed: ' + (e.message || 'unknown error'),
-      }, raw);
+      });
     }
   } else {
     // GitHub path: download tarball, extract, run install.js
@@ -3891,7 +3974,7 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
       return output({
         status: 'error',
         message: 'Update failed: ' + (e.message || 'unknown error'),
-      }, raw);
+      });
     }
     try { fs.rmSync(tmpExtractDir, { recursive: true, force: true }); } catch {}
   }
@@ -3908,7 +3991,7 @@ function cmdUpdate(cwd, options, raw, _testOverrides) {
     from: installed,
     to: latestVersion,
     source: updateSource,
-  }, raw);
+  });
 }
 
 module.exports = {
@@ -3927,6 +4010,8 @@ module.exports = {
   parseDuration,
   isRecurringDue,
   cmdTodoComplete,
+  cmdTodoListByPhase,
+  cmdTodoScanPhaseLinked,
   cmdRecurringDue,
   cmdScaffold,
   cmdStats,

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -131,12 +131,12 @@ function ensureConfigFile(cwd) {
  * Note that this exits the process (via `output()`) even in the happy path; use
  * `ensureConfigFile()` directly if you need to avoid this.
  */
-function cmdConfigEnsureSection(cwd, raw) {
+function cmdConfigEnsureSection(cwd) {
   const ensureConfigFileResult = ensureConfigFile(cwd);
   if (ensureConfigFileResult.created) {
-    output(ensureConfigFileResult, raw, 'created');
+    output(ensureConfigFileResult, 'created');
   } else {
-    output(ensureConfigFileResult, raw, 'exists');
+    output(ensureConfigFileResult, 'exists');
   }
 }
 
@@ -189,7 +189,7 @@ function setConfigValue(cwd, keyPath, parsedValue) {
  * Note that this exits the process (via `output()`) even in the happy path; use `setConfigValue()`
  * directly if you need to avoid this.
  */
-function cmdConfigSet(cwd, keyPath, value, raw) {
+function cmdConfigSet(cwd, keyPath, value) {
   if (!keyPath) {
     error('Usage: config-set <key.path> <value>');
   }
@@ -211,10 +211,10 @@ function cmdConfigSet(cwd, keyPath, value, raw) {
   else if (!isNaN(value) && value !== '') parsedValue = Number(value);
 
   const setConfigValueResult = setConfigValue(cwd, keyPath, parsedValue);
-  output(setConfigValueResult, raw, `${keyPath}=${parsedValue}`);
+  output(setConfigValueResult, `${keyPath}=${parsedValue}`);
 }
 
-function cmdConfigGet(cwd, keyPath, raw) {
+function cmdConfigGet(cwd, keyPath, defaultValue) {
   const { config: configPath } = planningPaths(cwd);
 
   if (!keyPath) {
@@ -230,6 +230,10 @@ function cmdConfigGet(cwd, keyPath, raw) {
     if (fs.existsSync(configPath)) {
       config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
     } else {
+      if (defaultValue !== undefined) {
+        output(defaultValue, String(defaultValue));
+        return;
+      }
       error('No config.json found at ' + configPath);
     }
   } catch (err) {
@@ -242,16 +246,24 @@ function cmdConfigGet(cwd, keyPath, raw) {
   let current = config;
   for (const key of keys) {
     if (current === undefined || current === null || typeof current !== 'object') {
+      if (defaultValue !== undefined) {
+        output(defaultValue, String(defaultValue));
+        return;
+      }
       error(`Key not found: ${keyPath}`);
     }
     current = current[key];
   }
 
   if (current === undefined) {
+    if (defaultValue !== undefined) {
+      output(defaultValue, String(defaultValue));
+      return;
+    }
     error(`Key not found: ${keyPath}`);
   }
 
-  output(current, raw, String(current));
+  output(current, String(current));
 }
 
 /**
@@ -259,7 +271,7 @@ function cmdConfigGet(cwd, keyPath, raw) {
  *
  * Note that this exits the process (via `output()`) even in the happy path.
  */
-function cmdConfigSetModelProfile(cwd, profile, raw) {
+function cmdConfigSetModelProfile(cwd, profile) {
   if (!profile) {
     error(`Usage: config-set-model-profile <${VALID_PROFILES.join('|')}>`);
   }
@@ -273,7 +285,7 @@ function cmdConfigSetModelProfile(cwd, profile, raw) {
   ensureConfigFile(cwd);
 
   // Set the model profile in the config
-  const { previousValue } = setConfigValue(cwd, 'model_profile', normalizedProfile, raw);
+  const { previousValue } = setConfigValue(cwd, 'model_profile', normalizedProfile);
   const previousProfile = previousValue || 'balanced';
 
   // Build result value / message and return
@@ -289,7 +301,7 @@ function cmdConfigSetModelProfile(cwd, profile, raw) {
     previousProfile,
     agentToModelMap
   );
-  output(result, raw, rawValue);
+  output(result, rawValue);
 }
 
 /**

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -77,32 +77,54 @@ function reapStaleTempFiles(prefix = 'gsd-', { maxAgeMs = 5 * 60 * 1000, dirsOnl
   }
 }
 
-function output(result, raw, rawValue) {
+// Module-level file output flag: when true, output() writes large payloads to
+// a temp file prefixed with @file:. Off by default -- inline is the standard path.
+// Activated via --file global flag in gsd-tools.cjs.
+let _fileOutput = false;
+function setFileOutput(val) { _fileOutput = val; }
+
+// Module-level JSON mode flag: when true, output() always emits JSON regardless
+// of displayValue. Activated via --json global flag or --pick in gsd-tools.cjs.
+let _jsonMode = false;
+function setJsonMode(val) { _jsonMode = val; }
+
+/**
+ * Write JSON to a temp file and return the @file: prefixed path.
+ * Factored out to avoid duplication between _jsonMode and auto-JSON paths.
+ */
+function writeToTempFile(json) {
+  reapStaleTempFiles();
+  let tmpDir = require('os').tmpdir();
+  try {
+    fs.mkdirSync(tmpDir, { recursive: true });
+  } catch {
+    // os.tmpdir() directory may not be writable (e.g. sandbox sets TMPDIR=/tmp/claude
+    // but /tmp is restricted). Fall back to a known-writable sibling directory.
+    const uid = process.getuid();
+    tmpDir = path.join(path.dirname(tmpDir), path.basename(tmpDir) + '-' + uid);
+    fs.mkdirSync(tmpDir, { recursive: true });
+  }
+  const tmpPath = path.join(tmpDir, `gsd-${Date.now()}.json`);
+  fs.writeFileSync(tmpPath, json, 'utf-8');
+  return '@file:' + tmpPath;
+}
+
+function output(result, displayValue) {
   let data;
-  if (raw && rawValue !== undefined) {
-    data = String(rawValue);
-  } else {
+  if (_jsonMode) {
+    // --json flag: always JSON, ignore displayValue
     const json = JSON.stringify(result, null, 2);
-    // Large payloads exceed Claude Code's Bash tool buffer (~50KB).
-    // Write to tmpfile and output the path prefixed with @file: so callers can detect it.
-    if (json.length > 50000) {
-      reapStaleTempFiles();
-      let tmpDir = require('os').tmpdir();
-      try {
-        fs.mkdirSync(tmpDir, { recursive: true });
-      } catch {
-        // os.tmpdir() directory may not be writable (e.g. sandbox sets TMPDIR=/tmp/claude
-        // but /tmp is restricted). Fall back to a known-writable sibling directory.
-        const uid = process.getuid();
-        tmpDir = path.join(path.dirname(tmpDir), path.basename(tmpDir) + '-' + uid);
-        fs.mkdirSync(tmpDir, { recursive: true });
-      }
-      const tmpPath = path.join(tmpDir, `gsd-${Date.now()}.json`);
-      fs.writeFileSync(tmpPath, json, 'utf-8');
-      data = '@file:' + tmpPath;
-    } else {
-      data = json;
-    }
+    data = _fileOutput ? writeToTempFile(json) : json;
+  } else if (displayValue !== undefined) {
+    // displayValue provided: emit as string (NO _fileOutput for scalar output)
+    data = String(displayValue);
+  } else if (result !== null && typeof result === 'object') {
+    // Object/array with no displayValue: auto-JSON
+    const json = JSON.stringify(result, null, 2);
+    data = _fileOutput ? writeToTempFile(json) : json;
+  } else {
+    // Scalar with no displayValue: stringify
+    data = String(result);
   }
   // process.stdout.write() is async when stdout is a pipe — process.exit()
   // can tear down the process before the reader consumes the buffer.
@@ -602,6 +624,8 @@ function extractOneLinerFromBody(content) {
 
 module.exports = {
   output,
+  setFileOutput,
+  setJsonMode,
   error,
   reapStaleTempFiles,
   safeReadFile,

--- a/gsd-ng/bin/lib/frontmatter.cjs
+++ b/gsd-ng/bin/lib/frontmatter.cjs
@@ -231,25 +231,31 @@ const FRONTMATTER_SCHEMAS = {
   verification: { required: ['phase', 'verified', 'status', 'score'] },
 };
 
-function cmdFrontmatterGet(cwd, filePath, field, raw, format) {
+function cmdFrontmatterGet(cwd, filePath, field, format, defaultValue) {
   if (!filePath) { error('file path required'); }
   const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: filePath }, raw); return; }
+  if (!content) {
+    if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+    output({ error: 'File not found', path: filePath }); return;
+  }
   const fm = extractFrontmatter(content);
   if (field) {
     const value = fm[field];
-    if (value === undefined) { output({ error: 'Field not found', field }, raw); return; }
+    if (value === undefined) {
+      if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+      output({ error: 'Field not found', field }); return;
+    }
     const rawString = (format === 'newline' && Array.isArray(value))
       ? value.join('\n')
       : (Array.isArray(value) ? value.join(', ') : String(value));
-    output({ [field]: value }, raw, rawString);
+    output({ [field]: value }, rawString);
   } else {
-    output(fm, raw);
+    output(fm);
   }
 }
 
-function cmdFrontmatterSet(cwd, filePath, field, value, raw) {
+function cmdFrontmatterSet(cwd, filePath, field, value) {
   if (!filePath || !field || value === undefined) { error('file, field, and value required'); }
   const fieldCheck = validateFieldName(field);
   if (!fieldCheck.valid) {
@@ -262,7 +268,7 @@ function cmdFrontmatterSet(cwd, filePath, field, value, raw) {
     }
   }
   const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
-  if (!fs.existsSync(fullPath)) { output({ error: 'File not found', path: filePath }, raw); return; }
+  if (!fs.existsSync(fullPath)) { output({ error: 'File not found', path: filePath }); return; }
   const content = fs.readFileSync(fullPath, 'utf-8');
   const fm = extractFrontmatter(content);
   let parsedValue;
@@ -270,10 +276,10 @@ function cmdFrontmatterSet(cwd, filePath, field, value, raw) {
   fm[field] = parsedValue;
   const newContent = spliceFrontmatter(content, fm);
   fs.writeFileSync(fullPath, newContent, 'utf-8');
-  output({ updated: true, field, value: parsedValue }, raw, 'true');
+  output({ updated: true, field, value: parsedValue }, 'true');
 }
 
-function cmdFrontmatterMerge(cwd, filePath, data, raw) {
+function cmdFrontmatterMerge(cwd, filePath, data) {
   if (!filePath || !data) { error('file and data required'); }
   if (!path.isAbsolute(filePath)) {
     const pathCheck = validatePath(filePath, cwd);
@@ -282,7 +288,7 @@ function cmdFrontmatterMerge(cwd, filePath, data, raw) {
     }
   }
   const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
-  if (!fs.existsSync(fullPath)) { output({ error: 'File not found', path: filePath }, raw); return; }
+  if (!fs.existsSync(fullPath)) { output({ error: 'File not found', path: filePath }); return; }
   const content = fs.readFileSync(fullPath, 'utf-8');
   const fm = extractFrontmatter(content);
   let mergeData;
@@ -290,20 +296,20 @@ function cmdFrontmatterMerge(cwd, filePath, data, raw) {
   Object.assign(fm, mergeData);
   const newContent = spliceFrontmatter(content, fm);
   fs.writeFileSync(fullPath, newContent, 'utf-8');
-  output({ merged: true, fields: Object.keys(mergeData) }, raw, 'true');
+  output({ merged: true, fields: Object.keys(mergeData) }, 'true');
 }
 
-function cmdFrontmatterValidate(cwd, filePath, schemaName, raw) {
+function cmdFrontmatterValidate(cwd, filePath, schemaName) {
   if (!filePath || !schemaName) { error('file and schema required'); }
   const schema = FRONTMATTER_SCHEMAS[schemaName];
   if (!schema) { error(`Unknown schema: ${schemaName}. Available: ${Object.keys(FRONTMATTER_SCHEMAS).join(', ')}`); }
   const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: filePath }, raw); return; }
+  if (!content) { output({ error: 'File not found', path: filePath }); return; }
   const fm = extractFrontmatter(content);
   const missing = schema.required.filter(f => fm[f] === undefined);
   const present = schema.required.filter(f => fm[f] !== undefined);
-  output({ valid: missing.length === 0, missing, present, schema: schemaName }, raw, missing.length === 0 ? 'valid' : 'invalid');
+  output({ valid: missing.length === 0, missing, present, schema: schemaName }, missing.length === 0 ? 'valid' : 'invalid');
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/guard.cjs
+++ b/gsd-ng/bin/lib/guard.cjs
@@ -15,9 +15,8 @@ const { setConfigValue } = require('./config.cjs');
  *
  * @param {string} cwd - Working directory
  * @param {string} argumentsStr - Raw $ARGUMENTS string from workflow
- * @param {boolean} raw - Raw output flag
  */
-function cmdGuardSyncChain(cwd, argumentsStr, raw) {
+function cmdGuardSyncChain(cwd, argumentsStr) {
   // Check for --auto as a standalone token (not substring like --auto-advance)
   const tokens = (argumentsStr || '').split(/\s+/);
   const hasAuto = tokens.includes('--auto');
@@ -27,7 +26,7 @@ function cmdGuardSyncChain(cwd, argumentsStr, raw) {
     setConfigValue(cwd, 'workflow._auto_chain_active', false);
   }
 
-  output({ synced: true, had_auto: hasAuto }, raw);
+  output({ synced: true, had_auto: hasAuto });
 }
 
 /**
@@ -38,9 +37,8 @@ function cmdGuardSyncChain(cwd, argumentsStr, raw) {
  * or fails JSON.parse — indicating that the preceding init command failed.
  *
  * @param {string} jsonStr - The $INIT string to validate
- * @param {boolean} raw - Raw output flag
  */
-function cmdGuardInitValid(jsonStr, raw) {
+function cmdGuardInitValid(jsonStr) {
   if (!jsonStr || !jsonStr.trim()) {
     error('guard init-valid: $INIT is empty or malformed — did the init command fail?');
   }
@@ -49,7 +47,7 @@ function cmdGuardInitValid(jsonStr, raw) {
   } catch {
     error('guard init-valid: $INIT is empty or malformed — did the init command fail?');
   }
-  output({ valid: true }, raw);
+  output({ valid: true });
 }
 
 module.exports = { cmdGuardSyncChain, cmdGuardInitValid };

--- a/gsd-ng/bin/lib/init.cjs
+++ b/gsd-ng/bin/lib/init.cjs
@@ -10,7 +10,7 @@ const { validatePhaseNumber } = require('./security.cjs');
 const { adjustQuickTable } = require('./state.cjs');
 const { resolveGitContext } = require('./workspace.cjs');
 
-function cmdInitExecutePhase(cwd, phase, raw) {
+function cmdInitExecutePhase(cwd, phase) {
   if (!phase) {
     error('phase required for init execute-phase');
   }
@@ -162,10 +162,10 @@ function cmdInitExecutePhase(cwd, phase, raw) {
         : null;
   }
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitPlanPhase(cwd, phase, raw) {
+function cmdInitPlanPhase(cwd, phase) {
   if (!phase) {
     error('phase required for init plan-phase');
   }
@@ -284,10 +284,10 @@ function cmdInitPlanPhase(cwd, phase, raw) {
     result.has_gap_research = false;
   }
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitNewProject(cwd, raw) {
+function cmdInitNewProject(cwd) {
   const config = loadConfig(cwd);
 
   // Detect existing code
@@ -335,10 +335,10 @@ function cmdInitNewProject(cwd, raw) {
     project_path: '.planning/PROJECT.md',
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitNewMilestone(cwd, raw) {
+function cmdInitNewMilestone(cwd) {
   const config = loadConfig(cwd);
   const milestone = getMilestoneInfo(cwd);
 
@@ -367,10 +367,10 @@ function cmdInitNewMilestone(cwd, raw) {
     state_path: '.planning/STATE.md',
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitQuick(cwd, description, verifyMode, raw) {
+function cmdInitQuick(cwd, description, verifyMode) {
   const config = loadConfig(cwd);
   const now = new Date();
   const slug = description ? generateSlugInternal(description)?.substring(0, 40) : null;
@@ -445,10 +445,10 @@ function cmdInitQuick(cwd, description, verifyMode, raw) {
     table_has_status,
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitResume(cwd, raw) {
+function cmdInitResume(cwd) {
   const config = loadConfig(cwd);
 
   // Check for interrupted agent
@@ -477,10 +477,10 @@ function cmdInitResume(cwd, raw) {
     commit_docs: config.commit_docs,
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitVerifyWork(cwd, phase, raw) {
+function cmdInitVerifyWork(cwd, phase) {
   if (!phase) {
     error('phase required for init verify-work');
   }
@@ -532,10 +532,10 @@ function cmdInitVerifyWork(cwd, phase, raw) {
     has_verification: phaseInfo?.has_verification || false,
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitPhaseOp(cwd, phase, raw) {
+function cmdInitPhaseOp(cwd, phase) {
   if (phase) {
     const phaseCheck = validatePhaseNumber(String(phase));
     if (!phaseCheck.valid) {
@@ -654,10 +654,10 @@ function cmdInitPhaseOp(cwd, phase, raw) {
     } catch {}
   }
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitTodos(cwd, area, raw) {
+function cmdInitTodos(cwd, area) {
   const config = loadConfig(cwd);
   const now = new Date();
 
@@ -713,10 +713,10 @@ function cmdInitTodos(cwd, area, raw) {
     pending_dir_exists: pathExistsInternal(cwd, '.planning/todos/pending'),
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitMilestoneOp(cwd, raw) {
+function cmdInitMilestoneOp(cwd) {
   const config = loadConfig(cwd);
   const milestone = getMilestoneInfo(cwd);
 
@@ -819,10 +819,10 @@ function cmdInitMilestoneOp(cwd, raw) {
     result.type_aliases = gitCtx.type_aliases;
   }
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitMapCodebase(cwd, raw) {
+function cmdInitMapCodebase(cwd) {
   const config = loadConfig(cwd);
 
   // Check for existing codebase maps
@@ -853,10 +853,10 @@ function cmdInitMapCodebase(cwd, raw) {
     codebase_dir_exists: pathExistsInternal(cwd, '.planning/codebase'),
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdInitProgress(cwd, raw) {
+function cmdInitProgress(cwd) {
   const config = loadConfig(cwd);
   const milestone = getMilestoneInfo(cwd);
 
@@ -1002,7 +1002,7 @@ function cmdInitProgress(cwd, raw) {
     config_path: '.planning/config.json',
   };
 
-  output(result, raw);
+  output(result);
 }
 
 const INIT_FIELD_DEFAULTS = {
@@ -1066,9 +1066,9 @@ const INIT_FIELD_DEFAULTS = {
   requirements_path: '.planning/REQUIREMENTS.md',
 };
 
-function cmdInitGet(jsonStr, fieldName, raw) {
+function cmdInitGet(jsonStr, fieldName) {
   if (!fieldName) {
-    error('Usage: init-get <json> <field> [--raw]');
+    error('Usage: init-get <json> <field>');
   }
   let parsed = null;
   if (jsonStr) {
@@ -1087,7 +1087,7 @@ function cmdInitGet(jsonStr, fieldName, raw) {
     const value = parsed[fieldName];
     if (value !== undefined && value !== null) {
       const rawStr = Array.isArray(value) ? JSON.stringify(value) : String(value);
-      output(value, raw, rawStr);
+      output(value, rawStr);
       return;
     }
   }
@@ -1095,11 +1095,11 @@ function cmdInitGet(jsonStr, fieldName, raw) {
   if (Object.prototype.hasOwnProperty.call(INIT_FIELD_DEFAULTS, fieldName)) {
     const def = INIT_FIELD_DEFAULTS[fieldName];
     const rawStr = Array.isArray(def) ? JSON.stringify(def) : (def === null ? '' : String(def));
-    output(def, raw, rawStr);
+    output(def, rawStr);
     return;
   }
   // Unknown field — return null (raw: empty string)
-  output(null, raw, '');
+  output(null, '');
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/milestone.cjs
+++ b/gsd-ng/bin/lib/milestone.cjs
@@ -8,7 +8,7 @@ const { escapeRegex, getMilestonePhaseFilter, extractOneLinerFromBody, output, e
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 
-function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
+function cmdRequirementsMarkComplete(cwd, reqIdsRaw) {
   if (!reqIdsRaw || reqIdsRaw.length === 0) {
     error('requirement IDs required. Usage: requirements mark-complete REQ-01,REQ-02 or REQ-01 REQ-02');
   }
@@ -27,7 +27,7 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
 
   const { requirements: reqPath } = planningPaths(cwd);
   if (!fs.existsSync(reqPath)) {
-    output({ updated: false, reason: 'REQUIREMENTS.md not found', ids: reqIds }, raw, 'no requirements file');
+    output({ updated: false, reason: 'REQUIREMENTS.md not found', ids: reqIds }, 'no requirements file');
     return;
   }
 
@@ -82,10 +82,10 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
     already_complete: alreadyComplete,
     not_found: notFound,
     total: reqIds.length,
-  }, raw, `${updated.length}/${reqIds.length} requirements marked complete`);
+  }, `${updated.length}/${reqIds.length} requirements marked complete`);
 }
 
-function cmdMilestoneComplete(cwd, version, options, raw) {
+function cmdMilestoneComplete(cwd, version, options) {
   if (!version) {
     error('version required for milestone complete (e.g., v1.0)');
   }
@@ -244,7 +244,7 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
     state_updated: fs.existsSync(statePath),
   };
 
-  output(result, raw);
+  output(result);
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/phase.cjs
+++ b/gsd-ng/bin/lib/phase.cjs
@@ -8,16 +8,16 @@ const { escapeRegex, normalizePhaseName, comparePhaseNum, findPhaseInternal, get
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 
-function cmdPhasesList(cwd, options, raw) {
+function cmdPhasesList(cwd, options) {
   const { phases: phasesDir } = planningPaths(cwd);
   const { type, phase, includeArchived } = options;
 
   // If no phases directory, return empty
   if (!fs.existsSync(phasesDir)) {
     if (type) {
-      output({ files: [], count: 0 }, raw, '');
+      output({ files: [], count: 0 }, '');
     } else {
-      output({ directories: [], count: 0 }, raw, '');
+      output({ directories: [], count: 0 }, '');
     }
     return;
   }
@@ -43,7 +43,7 @@ function cmdPhasesList(cwd, options, raw) {
       const normalized = normalizePhaseName(phase);
       const match = dirs.find(d => d.startsWith(normalized));
       if (!match) {
-        output({ files: [], count: 0, phase_dir: null, error: 'Phase not found' }, raw, '');
+        output({ files: [], count: 0, phase_dir: null, error: 'Phase not found' }, '');
         return;
       }
       dirs = [match];
@@ -73,18 +73,18 @@ function cmdPhasesList(cwd, options, raw) {
         count: files.length,
         phase_dir: phase ? dirs[0].replace(/^\d+(?:\.\d+)*-?/, '') : null,
       };
-      output(result, raw, files.join('\n'));
+      output(result, files.join('\n'));
       return;
     }
 
     // Default: list directories
-    output({ directories: dirs, count: dirs.length }, raw, dirs.join('\n'));
+    output({ directories: dirs, count: dirs.length }, dirs.join('\n'));
   } catch (e) {
     error('Failed to list phases: ' + e.message);
   }
 }
 
-function cmdPhaseNextDecimal(cwd, basePhase, raw) {
+function cmdPhaseNextDecimal(cwd, basePhase) {
   const { phases: phasesDir } = planningPaths(cwd);
   const normalized = normalizePhaseName(basePhase);
 
@@ -97,7 +97,7 @@ function cmdPhaseNextDecimal(cwd, basePhase, raw) {
         next: `${normalized}.1`,
         existing: [],
       },
-      raw,
+
       `${normalized}.1`
     );
     return;
@@ -141,7 +141,7 @@ function cmdPhaseNextDecimal(cwd, basePhase, raw) {
         next: nextDecimal,
         existing: existingDecimals,
       },
-      raw,
+
       nextDecimal
     );
   } catch (e) {
@@ -149,7 +149,7 @@ function cmdPhaseNextDecimal(cwd, basePhase, raw) {
   }
 }
 
-function cmdFindPhase(cwd, phase, raw) {
+function cmdFindPhase(cwd, phase) {
   if (!phase) {
     error('phase identifier required');
   }
@@ -165,7 +165,7 @@ function cmdFindPhase(cwd, phase, raw) {
 
     const match = dirs.find(d => d.startsWith(normalized));
     if (!match) {
-      output(notFound, raw, '');
+      output(notFound, '');
       return;
     }
 
@@ -187,9 +187,9 @@ function cmdFindPhase(cwd, phase, raw) {
       summaries,
     };
 
-    output(result, raw, result.directory);
+    output(result, result.directory);
   } catch {
-    output(notFound, raw, '');
+    output(notFound, '');
   }
 }
 
@@ -198,7 +198,7 @@ function extractObjective(content) {
   return m ? m[1].trim() : null;
 }
 
-function cmdPhasePlanIndex(cwd, phase, raw) {
+function cmdPhasePlanIndex(cwd, phase) {
   if (!phase) {
     error('phase required for phase-plan-index');
   }
@@ -222,7 +222,7 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
   }
 
   if (!phaseDir) {
-    output({ phase: normalized, error: 'Phase not found', plans: [], waves: {}, incomplete: [], has_checkpoints: false }, raw);
+    output({ phase: normalized, error: 'Phase not found', plans: [], waves: {}, incomplete: [], has_checkpoints: false });
     return;
   }
 
@@ -306,7 +306,7 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
     overlaps: detectFileOverlaps(plans),
   };
 
-  output(result, raw);
+  output(result);
 }
 
 /**
@@ -401,7 +401,7 @@ function insertCheckboxLine(rawContent, phaseNum, description, afterPhase) {
   return lines.join('\n');
 }
 
-function cmdPhaseAdd(cwd, description, raw) {
+function cmdPhaseAdd(cwd, description) {
   if (!description) {
     error('description required for phase add');
   }
@@ -458,10 +458,10 @@ function cmdPhaseAdd(cwd, description, raw) {
     directory: `.planning/phases/${dirName}`,
   };
 
-  output(result, raw, paddedNum);
+  output(result, paddedNum);
 }
 
-function cmdPhaseInsert(cwd, afterPhase, description, raw) {
+function cmdPhaseInsert(cwd, afterPhase, description) {
   if (!afterPhase || !description) {
     error('after-phase and description required for phase insert');
   }
@@ -543,10 +543,10 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
     directory: `.planning/phases/${dirName}`,
   };
 
-  output(result, raw, decimalPhase);
+  output(result, decimalPhase);
 }
 
-function cmdPhaseRemove(cwd, targetPhase, options, raw) {
+function cmdPhaseRemove(cwd, targetPhase, options) {
   if (!targetPhase) {
     error('phase number required for phase remove');
   }
@@ -795,10 +795,10 @@ function cmdPhaseRemove(cwd, targetPhase, options, raw) {
     state_updated: fs.existsSync(statePath),
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdPhaseComplete(cwd, phaseNum, raw) {
+function cmdPhaseComplete(cwd, phaseNum) {
   if (!phaseNum) {
     error('phase number required for phase complete');
   }
@@ -1001,7 +1001,7 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
     requirements_updated: requirementsUpdated,
   };
 
-  output(result, raw);
+  output(result);
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/roadmap.cjs
+++ b/gsd-ng/bin/lib/roadmap.cjs
@@ -6,11 +6,12 @@ const fs = require('fs');
 const path = require('path');
 const { escapeRegex, normalizePhaseName, output, error, findPhaseInternal, extractCurrentMilestone, replaceInCurrentMilestone, planningPaths } = require('./core.cjs');
 
-function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
+function cmdRoadmapGetPhase(cwd, phaseNum, defaultValue) {
   const { roadmap: roadmapPath } = planningPaths(cwd);
 
   if (!fs.existsSync(roadmapPath)) {
-    output({ found: false, error: 'ROADMAP.md not found' }, raw, '');
+    if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+    output({ found: false, error: 'ROADMAP.md not found' }, '');
     return;
   }
 
@@ -37,17 +38,19 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
 
       if (checklistMatch) {
         // Phase exists in summary but missing detail section - malformed ROADMAP
+        if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
         output({
           found: false,
           phase_number: phaseNum,
           phase_name: checklistMatch[1].trim(),
           error: 'malformed_roadmap',
           message: `Phase ${phaseNum} exists in summary list but missing "### Phase ${phaseNum}:" detail section. ROADMAP.md needs both formats.`
-        }, raw, '');
+        }, '');
         return;
       }
 
-      output({ found: false, phase_number: phaseNum }, raw, '');
+      if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+      output({ found: false, phase_number: phaseNum }, '');
       return;
     }
 
@@ -92,7 +95,7 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
         source_todos,
         section,
       },
-      raw,
+
       section
     );
   } catch (e) {
@@ -100,11 +103,11 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
   }
 }
 
-function cmdRoadmapAnalyze(cwd, raw, phaseFilter) {
+function cmdRoadmapAnalyze(cwd, phaseFilter) {
   const { roadmap: roadmapPath, phases: phasesDir } = planningPaths(cwd);
 
   if (!fs.existsSync(roadmapPath)) {
-    output({ error: 'ROADMAP.md not found', milestones: [], phases: [], current_phase: null }, raw);
+    output({ error: 'ROADMAP.md not found', milestones: [], phases: [], current_phase: null });
     return;
   }
 
@@ -242,10 +245,10 @@ function cmdRoadmapAnalyze(cwd, raw, phaseFilter) {
     missing_phase_details: missingDetails.length > 0 ? missingDetails : null,
   };
 
-  output(result, raw);
+  output(result);
 }
 
-function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
+function cmdRoadmapUpdatePlanProgress(cwd, phaseNum) {
   if (!phaseNum) {
     error('phase number required for roadmap update-plan-progress');
   }
@@ -261,7 +264,7 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
   const summaryCount = phaseInfo.summaries.length;
 
   if (planCount === 0) {
-    output({ updated: false, reason: 'No plans found', plan_count: 0, summary_count: 0 }, raw, 'no plans');
+    output({ updated: false, reason: 'No plans found', plan_count: 0, summary_count: 0 }, 'no plans');
     return;
   }
 
@@ -270,7 +273,7 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
   const today = new Date().toISOString().split('T')[0];
 
   if (!fs.existsSync(roadmapPath)) {
-    output({ updated: false, reason: 'ROADMAP.md not found', plan_count: planCount, summary_count: summaryCount }, raw, 'no roadmap');
+    output({ updated: false, reason: 'ROADMAP.md not found', plan_count: planCount, summary_count: summaryCount }, 'no roadmap');
     return;
   }
 
@@ -339,7 +342,7 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
     summary_count: summaryCount,
     status,
     complete: isComplete,
-  }, raw, `${summaryCount}/${planCount} ${status}`);
+  }, `${summaryCount}/${planCount} ${status}`);
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/state.cjs
+++ b/gsd-ng/bin/lib/state.cjs
@@ -20,7 +20,7 @@ function stateExtractField(content, fieldName) {
   return plainMatch ? plainMatch[1].trim() : null;
 }
 
-function cmdStateLoad(cwd, raw) {
+function cmdStateLoad(cwd) {
   const config = loadConfig(cwd);
   const { state: stateMdPath, config: configPath, roadmap: roadmapPath } = planningPaths(cwd);
 
@@ -42,28 +42,6 @@ function cmdStateLoad(cwd, raw) {
     roadmap_exists: roadmapExists,
     config_exists: configExists,
   };
-
-  // For --raw, output a condensed key=value format
-  if (raw) {
-    const c = config;
-    const lines = [
-      `model_profile=${c.model_profile}`,
-      `commit_docs=${c.commit_docs}`,
-      `branching_strategy=${c.branching_strategy}`,
-      `phase_branch_template=${c.phase_branch_template}`,
-      `milestone_branch_template=${c.milestone_branch_template}`,
-      `target_branch=${c.target_branch || 'main'}`,
-      `parallelization=${c.parallelization}`,
-      `research=${c.research}`,
-      `plan_checker=${c.plan_checker}`,
-      `verifier=${c.verifier}`,
-      `config_exists=${configExists}`,
-      `roadmap_exists=${roadmapExists}`,
-      `state_exists=${stateExists}`,
-    ];
-    process.stdout.write(lines.join('\n'));
-    process.exit(0);
-  }
 
   output(result);
 }
@@ -120,12 +98,12 @@ function parseSectionContent(content) {
   return Object.keys(result).length > 0 ? result : content;  // Fallback to raw string if nothing parsed
 }
 
-function cmdStateGet(cwd, section, raw) {
+function cmdStateGet(cwd, section) {
   const { state: statePath } = planningPaths(cwd);
 
   if (!section) {
     // No section arg: delegate to cmdStateSnapshot (already returns structured JSON)
-    return cmdStateSnapshot(cwd, raw);
+    return cmdStateSnapshot(cwd);
   }
 
   try {
@@ -137,7 +115,7 @@ function cmdStateGet(cwd, section, raw) {
     const boldMatch = content.match(boldPattern);
     if (boldMatch) {
       const value = sanitizeForPrompt(boldMatch[1].trim());
-      output({ [section]: value }, raw, value);
+      output({ [section]: value }, value);
       return;
     }
 
@@ -146,7 +124,7 @@ function cmdStateGet(cwd, section, raw) {
     const plainMatch = content.match(plainPattern);
     if (plainMatch) {
       const value = sanitizeForPrompt(plainMatch[1].trim());
-      output({ [section]: value }, raw, value);
+      output({ [section]: value }, value);
       return;
     }
 
@@ -156,11 +134,11 @@ function cmdStateGet(cwd, section, raw) {
     if (sectionMatch) {
       const sectionContent = sanitizeForPrompt(sectionMatch[1].trim());
       const structured = parseSectionContent(sectionContent);
-      output({ [section]: structured }, raw, JSON.stringify(structured));
+      output({ [section]: structured }, JSON.stringify(structured));
       return;
     }
 
-    output({ error: `Section or field "${section}" not found` }, raw, '');
+    output({ error: `Section or field "${section}" not found` }, '');
   } catch {
     error('STATE.md not found');
   }
@@ -177,7 +155,7 @@ function readTextArgOrFile(cwd, value, filePath, label) {
   }
 }
 
-function cmdStatePatch(cwd, patches, raw) {
+function cmdStatePatch(cwd, patches) {
   const { state: statePath } = planningPaths(cwd);
   try {
     let content = fs.readFileSync(statePath, 'utf-8');
@@ -204,7 +182,7 @@ function cmdStatePatch(cwd, patches, raw) {
       writeStateMd(statePath, content, cwd);
     }
 
-    output(results, raw, results.updated.length > 0 ? 'true' : 'false');
+    output(results, results.updated.length > 0 ? 'true' : 'false');
   } catch {
     error('STATE.md not found');
   }
@@ -277,9 +255,9 @@ function stateReplaceFieldWithFallback(content, fieldName, newValue) {
   return content.trimEnd() + '\n**' + fieldName + ':** ' + newValue + '\n';
 }
 
-function cmdStateAdvancePlan(cwd, raw) {
+function cmdStateAdvancePlan(cwd) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw); return; }
+  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const today = new Date().toISOString().split('T')[0];
@@ -304,7 +282,7 @@ function cmdStateAdvancePlan(cwd, raw) {
   }
 
   if (isNaN(currentPlan) || isNaN(totalPlans)) {
-    output({ error: 'Cannot parse Current Plan or Total Plans in Phase from STATE.md' }, raw);
+    output({ error: 'Cannot parse Current Plan or Total Plans in Phase from STATE.md' });
     return;
   }
 
@@ -319,7 +297,7 @@ function cmdStateAdvancePlan(cwd, raw) {
     content = replaceField(content, 'Status', null, 'Phase complete — ready for verification');
     content = replaceField(content, 'Last Activity', 'Last activity', today);
     writeStateMd(statePath, content, cwd);
-    output({ advanced: false, reason: 'last_plan', current_plan: currentPlan, total_plans: totalPlans, status: 'ready_for_verification' }, raw, 'false');
+    output({ advanced: false, reason: 'last_plan', current_plan: currentPlan, total_plans: totalPlans, status: 'ready_for_verification' }, 'false');
   } else {
     const newPlan = currentPlan + 1;
     if (useCompoundFormat) {
@@ -332,19 +310,19 @@ function cmdStateAdvancePlan(cwd, raw) {
     content = replaceField(content, 'Status', null, 'Ready to execute');
     content = replaceField(content, 'Last Activity', 'Last activity', today);
     writeStateMd(statePath, content, cwd);
-    output({ advanced: true, previous_plan: currentPlan, current_plan: newPlan, total_plans: totalPlans }, raw, 'true');
+    output({ advanced: true, previous_plan: currentPlan, current_plan: newPlan, total_plans: totalPlans }, 'true');
   }
 }
 
-function cmdStateRecordMetric(cwd, options, raw) {
+function cmdStateRecordMetric(cwd, options) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw); return; }
+  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const { phase, plan, duration, tasks, files } = options;
 
   if (!phase || !plan || !duration) {
-    output({ error: 'phase, plan, and duration required' }, raw);
+    output({ error: 'phase, plan, and duration required' });
     return;
   }
 
@@ -364,15 +342,15 @@ function cmdStateRecordMetric(cwd, options, raw) {
 
     content = content.replace(metricsPattern, (_match, header) => `${header}${tableBody}\n`);
     writeStateMd(statePath, content, cwd);
-    output({ recorded: true, phase, plan, duration }, raw, 'true');
+    output({ recorded: true, phase, plan, duration }, 'true');
   } else {
-    output({ recorded: false, reason: 'Performance Metrics section not found in STATE.md' }, raw, 'false');
+    output({ recorded: false, reason: 'Performance Metrics section not found in STATE.md' }, 'false');
   }
 }
 
-function cmdStateUpdateProgress(cwd, raw) {
+function cmdStateUpdateProgress(cwd) {
   const { state: statePath, phases: phasesDir } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw); return; }
+  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
 
   let content = fs.readFileSync(statePath, 'utf-8');
 
@@ -404,19 +382,19 @@ function cmdStateUpdateProgress(cwd, raw) {
   if (boldProgressPattern.test(content)) {
     content = content.replace(boldProgressPattern, (_match, prefix) => `${prefix}${progressStr}`);
     writeStateMd(statePath, content, cwd);
-    output({ updated: true, percent, completed: totalSummaries, total: totalPlans, bar: progressStr }, raw, progressStr);
+    output({ updated: true, percent, completed: totalSummaries, total: totalPlans, bar: progressStr }, progressStr);
   } else if (plainProgressPattern.test(content)) {
     content = content.replace(plainProgressPattern, (_match, prefix) => `${prefix}${progressStr}`);
     writeStateMd(statePath, content, cwd);
-    output({ updated: true, percent, completed: totalSummaries, total: totalPlans, bar: progressStr }, raw, progressStr);
+    output({ updated: true, percent, completed: totalSummaries, total: totalPlans, bar: progressStr }, progressStr);
   } else {
-    output({ updated: false, reason: 'Progress field not found in STATE.md' }, raw, 'false');
+    output({ updated: false, reason: 'Progress field not found in STATE.md' }, 'false');
   }
 }
 
-function cmdStateAddDecision(cwd, options, raw) {
+function cmdStateAddDecision(cwd, options) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw); return; }
+  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
 
   const { phase, summary, summary_file, rationale, rationale_file } = options;
   let summaryText = null;
@@ -426,11 +404,11 @@ function cmdStateAddDecision(cwd, options, raw) {
     summaryText = readTextArgOrFile(cwd, summary, summary_file, 'summary');
     rationaleText = readTextArgOrFile(cwd, rationale || '', rationale_file, 'rationale');
   } catch (err) {
-    output({ added: false, reason: err.message }, raw, 'false');
+    output({ added: false, reason: err.message }, 'false');
     return;
   }
 
-  if (!summaryText) { output({ error: 'summary required' }, raw); return; }
+  if (!summaryText) { output({ error: 'summary required' }); return; }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const entry = `- [Phase ${phase || '?'}]: ${summaryText}${rationaleText ? ` — ${rationaleText}` : ''}`;
@@ -446,26 +424,26 @@ function cmdStateAddDecision(cwd, options, raw) {
     sectionBody = sectionBody.trimEnd() + '\n' + entry + '\n';
     content = content.replace(sectionPattern, (_match, header) => `${header}${sectionBody}`);
     writeStateMd(statePath, content, cwd);
-    output({ added: true, decision: entry }, raw, 'true');
+    output({ added: true, decision: entry }, 'true');
   } else {
-    output({ added: false, reason: 'Decisions section not found in STATE.md' }, raw, 'false');
+    output({ added: false, reason: 'Decisions section not found in STATE.md' }, 'false');
   }
 }
 
-function cmdStateAddBlocker(cwd, text, raw) {
+function cmdStateAddBlocker(cwd, text) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw); return; }
+  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
   const blockerOptions = typeof text === 'object' && text !== null ? text : { text };
   let blockerText = null;
 
   try {
     blockerText = readTextArgOrFile(cwd, blockerOptions.text, blockerOptions.text_file, 'blocker');
   } catch (err) {
-    output({ added: false, reason: err.message }, raw, 'false');
+    output({ added: false, reason: err.message }, 'false');
     return;
   }
 
-  if (!blockerText) { output({ error: 'text required' }, raw); return; }
+  if (!blockerText) { output({ error: 'text required' }); return; }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const entry = `- ${blockerText}`;
@@ -479,16 +457,16 @@ function cmdStateAddBlocker(cwd, text, raw) {
     sectionBody = sectionBody.trimEnd() + '\n' + entry + '\n';
     content = content.replace(sectionPattern, (_match, header) => `${header}${sectionBody}`);
     writeStateMd(statePath, content, cwd);
-    output({ added: true, blocker: blockerText }, raw, 'true');
+    output({ added: true, blocker: blockerText }, 'true');
   } else {
-    output({ added: false, reason: 'Blockers section not found in STATE.md' }, raw, 'false');
+    output({ added: false, reason: 'Blockers section not found in STATE.md' }, 'false');
   }
 }
 
-function cmdStateResolveBlocker(cwd, text, raw) {
+function cmdStateResolveBlocker(cwd, text) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw); return; }
-  if (!text) { output({ error: 'text required' }, raw); return; }
+  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
+  if (!text) { output({ error: 'text required' }); return; }
 
   let content = fs.readFileSync(statePath, 'utf-8');
 
@@ -511,15 +489,15 @@ function cmdStateResolveBlocker(cwd, text, raw) {
 
     content = content.replace(sectionPattern, (_match, header) => `${header}${newBody}`);
     writeStateMd(statePath, content, cwd);
-    output({ resolved: true, blocker: text }, raw, 'true');
+    output({ resolved: true, blocker: text }, 'true');
   } else {
-    output({ resolved: false, reason: 'Blockers section not found in STATE.md' }, raw, 'false');
+    output({ resolved: false, reason: 'Blockers section not found in STATE.md' }, 'false');
   }
 }
 
-function cmdStateRecordSession(cwd, options, raw) {
+function cmdStateRecordSession(cwd, options) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }, raw); return; }
+  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const now = new Date().toISOString();
@@ -546,17 +524,17 @@ function cmdStateRecordSession(cwd, options, raw) {
 
   if (updated.length > 0) {
     writeStateMd(statePath, content, cwd);
-    output({ recorded: true, updated }, raw, 'true');
+    output({ recorded: true, updated }, 'true');
   } else {
-    output({ recorded: false, reason: 'No session fields found in STATE.md' }, raw, 'false');
+    output({ recorded: false, reason: 'No session fields found in STATE.md' }, 'false');
   }
 }
 
-function cmdStateSnapshot(cwd, raw, phaseFilter) {
+function cmdStateSnapshot(cwd, phaseFilter) {
   const { state: statePath } = planningPaths(cwd);
 
   if (!fs.existsSync(statePath)) {
-    output({ error: 'STATE.md not found' }, raw);
+    output({ error: 'STATE.md not found' });
     return;
   }
 
@@ -655,7 +633,7 @@ function cmdStateSnapshot(cwd, raw, phaseFilter) {
     session,
   };
 
-  output(result, raw);
+  output(result);
 }
 
 // ─── State Frontmatter Sync ──────────────────────────────────────────────────
@@ -810,10 +788,10 @@ function writeStateMd(statePath, content, cwd) {
   fs.writeFileSync(statePath, synced, 'utf-8');
 }
 
-function cmdStateJson(cwd, raw) {
+function cmdStateJson(cwd) {
   const { state: statePath } = planningPaths(cwd);
   if (!fs.existsSync(statePath)) {
-    output({ error: 'STATE.md not found' }, raw, 'STATE.md not found');
+    output({ error: 'STATE.md not found' }, 'STATE.md not found');
     return;
   }
 
@@ -823,11 +801,11 @@ function cmdStateJson(cwd, raw) {
   if (!fm || Object.keys(fm).length === 0) {
     const body = stripFrontmatter(content);
     const built = buildStateFrontmatter(body, cwd);
-    output(built, raw, JSON.stringify(built, null, 2));
+    output(built, JSON.stringify(built, null, 2));
     return;
   }
 
-  output(fm, raw, JSON.stringify(fm, null, 2));
+  output(fm, JSON.stringify(fm, null, 2));
 }
 
 /**
@@ -837,15 +815,15 @@ function cmdStateJson(cwd, raw) {
  * Current Phase Name, Current Plan, Total Plans in Phase, Current focus body,
  * and Current Position section.
  */
-function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount, raw) {
+function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount) {
   const { state: statePath } = planningPaths(cwd);
   if (!fs.existsSync(statePath)) {
-    output({ updated: false, error: 'STATE.md not found' }, raw);
+    output({ updated: false, error: 'STATE.md not found' });
     return;
   }
 
   if (!phaseNumber || !phaseName || !planCount) {
-    output({ updated: false, error: '--phase, --name, and --plans are required' }, raw);
+    output({ updated: false, error: '--phase, --name, and --plans are required' });
     return;
   }
 
@@ -889,7 +867,7 @@ function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount, raw) {
   }
 
   writeStateMd(statePath, content, cwd);
-  output({ updated: true, phase: phaseNum, name: phaseName, plans: planCount, failed }, raw, 'true');
+  output({ updated: true, phase: phaseNum, name: phaseName, plans: planCount, failed }, 'true');
 }
 
 /**
@@ -984,9 +962,9 @@ function adjustQuickTable(cwd) {
   return { adjusted: true, table_has_status: true };
 }
 
-function cmdStateAdjustQuickTable(cwd, raw) {
+function cmdStateAdjustQuickTable(cwd) {
   const result = adjustQuickTable(cwd);
-  output(result, raw);
+  output(result);
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/template.cjs
+++ b/gsd-ng/bin/lib/template.cjs
@@ -7,7 +7,7 @@ const path = require('path');
 const { normalizePhaseName, findPhaseInternal, generateSlugInternal, toPosixPath, output, error } = require('./core.cjs');
 const { reconstructFrontmatter } = require('./frontmatter.cjs');
 
-function cmdTemplateSelect(cwd, planPath, raw) {
+function cmdTemplateSelect(cwd, planPath) {
   if (!planPath) {
     error('plan-path required');
   }
@@ -46,19 +46,19 @@ function cmdTemplateSelect(cwd, planPath, raw) {
     }
 
     const result = { template, type, taskCount, fileCount, hasDecisions };
-    output(result, raw, template);
+    output(result, template);
   } catch (e) {
     // Fallback to standard
-    output({ template: 'templates/summary-standard.md', type: 'standard', error: e.message }, raw, 'templates/summary-standard.md');
+    output({ template: 'templates/summary-standard.md', type: 'standard', error: e.message }, 'templates/summary-standard.md');
   }
 }
 
-function cmdTemplateFill(cwd, templateType, options, raw) {
+function cmdTemplateFill(cwd, templateType, options) {
   if (!templateType) { error('template type required: summary, plan, or verification'); }
   if (!options.phase) { error('--phase required'); }
 
   const phaseInfo = findPhaseInternal(cwd, options.phase);
-  if (!phaseInfo || !phaseInfo.found) { output({ error: 'Phase not found', phase: options.phase }, raw); return; }
+  if (!phaseInfo || !phaseInfo.found) { output({ error: 'Phase not found', phase: options.phase }); return; }
 
   const padded = normalizePhaseName(options.phase);
   const today = new Date().toISOString().split('T')[0];
@@ -210,13 +210,13 @@ function cmdTemplateFill(cwd, templateType, options, raw) {
   const outPath = path.join(cwd, phaseInfo.directory, fileName);
 
   if (fs.existsSync(outPath)) {
-    output({ error: 'File already exists', path: toPosixPath(path.relative(cwd, outPath)) }, raw);
+    output({ error: 'File already exists', path: toPosixPath(path.relative(cwd, outPath)) });
     return;
   }
 
   fs.writeFileSync(outPath, fullContent, 'utf-8');
   const relPath = toPosixPath(path.relative(cwd, outPath));
-  output({ created: true, path: relPath, template: templateType }, raw, relPath);
+  output({ created: true, path: relPath, template: templateType }, relPath);
 }
 
 module.exports = { cmdTemplateSelect, cmdTemplateFill };

--- a/gsd-ng/bin/lib/verify.cjs
+++ b/gsd-ng/bin/lib/verify.cjs
@@ -10,7 +10,7 @@ const { extractFrontmatter, spliceFrontmatter, parseMustHavesBlock } = require('
 const { writeStateMd } = require('./state.cjs');
 const { detectWorkspaceType, generateMemoriesSection, generateMemoryMd } = require('./workspace.cjs');
 
-function cmdVerifySummary(cwd, summaryPath, checkFileCount, raw) {
+function cmdVerifySummary(cwd, summaryPath, checkFileCount) {
   if (!summaryPath) {
     error('summary-path required');
   }
@@ -30,7 +30,7 @@ function cmdVerifySummary(cwd, summaryPath, checkFileCount, raw) {
       },
       errors: ['SUMMARY.md not found'],
     };
-    output(result, raw, 'failed');
+    output(result, 'failed');
     return;
   }
 
@@ -103,14 +103,14 @@ function cmdVerifySummary(cwd, summaryPath, checkFileCount, raw) {
 
   const passed = missing.length === 0 && selfCheck !== 'failed';
   const result = { passed, checks, errors };
-  output(result, raw, passed ? 'passed' : 'failed');
+  output(result, passed ? 'passed' : 'failed');
 }
 
-function cmdVerifyPlanStructure(cwd, filePath, raw) {
+function cmdVerifyPlanStructure(cwd, filePath) {
   if (!filePath) { error('file path required'); }
   const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: filePath }, raw); return; }
+  if (!content) { output({ error: 'File not found', path: filePath }); return; }
 
   const fm = extractFrontmatter(content);
   const errors = [];
@@ -164,14 +164,14 @@ function cmdVerifyPlanStructure(cwd, filePath, raw) {
     task_count: tasks.length,
     tasks,
     frontmatter_fields: Object.keys(fm),
-  }, raw, errors.length === 0 ? 'valid' : 'invalid');
+  }, errors.length === 0 ? 'valid' : 'invalid');
 }
 
-function cmdVerifyPhaseCompleteness(cwd, phase, raw) {
+function cmdVerifyPhaseCompleteness(cwd, phase) {
   if (!phase) { error('phase required'); }
   const phaseInfo = findPhaseInternal(cwd, phase);
   if (!phaseInfo || !phaseInfo.found) {
-    output({ error: 'Phase not found', phase }, raw);
+    output({ error: 'Phase not found', phase });
     return;
   }
 
@@ -181,7 +181,7 @@ function cmdVerifyPhaseCompleteness(cwd, phase, raw) {
 
   // List plans and summaries
   let files;
-  try { files = fs.readdirSync(phaseDir); } catch { output({ error: 'Cannot read phase directory' }, raw); return; }
+  try { files = fs.readdirSync(phaseDir); } catch { output({ error: 'Cannot read phase directory' }); return; }
 
   const plans = files.filter(f => f.match(/-PLAN\.md$/i));
   const summaries = files.filter(f => f.match(/-SUMMARY\.md$/i));
@@ -211,14 +211,14 @@ function cmdVerifyPhaseCompleteness(cwd, phase, raw) {
     orphan_summaries: orphanSummaries,
     errors,
     warnings,
-  }, raw, errors.length === 0 ? 'complete' : 'incomplete');
+  }, errors.length === 0 ? 'complete' : 'incomplete');
 }
 
-function cmdVerifyReferences(cwd, filePath, raw) {
+function cmdVerifyReferences(cwd, filePath) {
   if (!filePath) { error('file path required'); }
   const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: filePath }, raw); return; }
+  if (!content) { output({ error: 'File not found', path: filePath }); return; }
 
   const found = [];
   const missing = [];
@@ -256,10 +256,10 @@ function cmdVerifyReferences(cwd, filePath, raw) {
     found: found.length,
     missing,
     total: found.length + missing.length,
-  }, raw, missing.length === 0 ? 'valid' : 'invalid');
+  }, missing.length === 0 ? 'valid' : 'invalid');
 }
 
-function cmdVerifyCommits(cwd, hashes, raw) {
+function cmdVerifyCommits(cwd, hashes) {
   if (!hashes || hashes.length === 0) { error('At least one commit hash required'); }
 
   const valid = [];
@@ -278,18 +278,18 @@ function cmdVerifyCommits(cwd, hashes, raw) {
     valid,
     invalid,
     total: hashes.length,
-  }, raw, invalid.length === 0 ? 'valid' : 'invalid');
+  }, invalid.length === 0 ? 'valid' : 'invalid');
 }
 
-function cmdVerifyArtifacts(cwd, planFilePath, raw) {
+function cmdVerifyArtifacts(cwd, planFilePath) {
   if (!planFilePath) { error('plan file path required'); }
   const fullPath = path.isAbsolute(planFilePath) ? planFilePath : path.join(cwd, planFilePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: planFilePath }, raw); return; }
+  if (!content) { output({ error: 'File not found', path: planFilePath }); return; }
 
   const artifacts = parseMustHavesBlock(content, 'artifacts');
   if (artifacts.length === 0) {
-    output({ error: 'No must_haves.artifacts found in frontmatter', path: planFilePath }, raw);
+    output({ error: 'No must_haves.artifacts found in frontmatter', path: planFilePath });
     return;
   }
 
@@ -333,18 +333,18 @@ function cmdVerifyArtifacts(cwd, planFilePath, raw) {
     passed,
     total: results.length,
     artifacts: results,
-  }, raw, passed === results.length ? 'valid' : 'invalid');
+  }, passed === results.length ? 'valid' : 'invalid');
 }
 
-function cmdVerifyKeyLinks(cwd, planFilePath, raw) {
+function cmdVerifyKeyLinks(cwd, planFilePath) {
   if (!planFilePath) { error('plan file path required'); }
   const fullPath = path.isAbsolute(planFilePath) ? planFilePath : path.join(cwd, planFilePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: planFilePath }, raw); return; }
+  if (!content) { output({ error: 'File not found', path: planFilePath }); return; }
 
   const keyLinks = parseMustHavesBlock(content, 'key_links');
   if (keyLinks.length === 0) {
-    output({ error: 'No must_haves.key_links found in frontmatter', path: planFilePath }, raw);
+    output({ error: 'No must_haves.key_links found in frontmatter', path: planFilePath });
     return;
   }
 
@@ -393,10 +393,10 @@ function cmdVerifyKeyLinks(cwd, planFilePath, raw) {
     verified,
     total: results.length,
     links: results,
-  }, raw, verified === results.length ? 'valid' : 'invalid');
+  }, verified === results.length ? 'valid' : 'invalid');
 }
 
-function cmdValidateConsistency(cwd, raw) {
+function cmdValidateConsistency(cwd) {
   const { roadmap: roadmapPath, phases: phasesDir } = planningPaths(cwd);
   const errors = [];
   const warnings = [];
@@ -404,7 +404,7 @@ function cmdValidateConsistency(cwd, raw) {
   // Check for ROADMAP
   if (!fs.existsSync(roadmapPath)) {
     errors.push('ROADMAP.md not found');
-    output({ passed: false, errors, warnings }, raw, 'failed');
+    output({ passed: false, errors, warnings }, 'failed');
     return;
   }
 
@@ -513,10 +513,10 @@ function cmdValidateConsistency(cwd, raw) {
   } catch {}
 
   const passed = errors.length === 0;
-  output({ passed, errors, warnings, warning_count: warnings.length }, raw, passed ? 'passed' : 'failed');
+  output({ passed, errors, warnings, warning_count: warnings.length }, passed ? 'passed' : 'failed');
 }
 
-function cmdValidateHealth(cwd, options, raw) {
+function cmdValidateHealth(cwd, options) {
   // Guard: detect if CWD is the home directory (likely accidental)
   const resolved = path.resolve(cwd);
   if (resolved === os.homedir()) {
@@ -526,7 +526,7 @@ function cmdValidateHealth(cwd, options, raw) {
       warnings: [],
       info: [{ code: 'I010', message: `Resolved CWD: ${resolved}` }],
       repairable_count: 0,
-    }, raw);
+    });
     return;
   }
 
@@ -554,7 +554,7 @@ function cmdValidateHealth(cwd, options, raw) {
       warnings,
       info,
       repairable_count: 0,
-    }, raw);
+    });
     return;
   }
 
@@ -1193,7 +1193,7 @@ function cmdValidateHealth(cwd, options, raw) {
     info,
     repairable_count: repairableCount,
     repairs_performed: repairActions.length > 0 ? repairActions : undefined,
-  }, raw);
+  });
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/workspace.cjs
+++ b/gsd-ng/bin/lib/workspace.cjs
@@ -256,7 +256,7 @@ function resolveGitContext(cwd) {
 
     const sshUrl = Boolean(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
 
-    const platformInfo = cmdDetectPlatform(cwd, remote, null, true) || {};
+    const platformInfo = cmdDetectPlatform(cwd, remote, true) || {};
 
     return {
       is_submodule: false,
@@ -372,7 +372,7 @@ function resolveGitContext(cwd) {
 
   const sshUrl = Boolean(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
 
-  const platformInfo = cmdDetectPlatform(subCwd, remote, null, true) || {};
+  const platformInfo = cmdDetectPlatform(subCwd, remote, true) || {};
 
   return {
     is_submodule: true,
@@ -406,26 +406,24 @@ function resolveGitContext(cwd) {
  * CLI wrapper for detectWorkspaceType. Outputs JSON via output().
  *
  * @param {string} cwd - Working directory
- * @param {boolean} raw - Whether to output raw value
  * @param {boolean} silent - If true, return result without calling output()
  */
-function cmdDetectWorkspace(cwd, raw, silent) {
+function cmdDetectWorkspace(cwd, silent) {
   const result = detectWorkspaceType(cwd);
   if (silent) return result;
-  output(result, raw);
+  output(result);
 }
 
 /**
  * CLI wrapper for resolveGitContext. Outputs JSON via output().
  *
  * @param {string} cwd - Working directory
- * @param {boolean} raw - Whether to output raw value
  * @param {boolean} silent - If true, return result without calling output()
  */
-function cmdGitContext(cwd, raw, silent) {
+function cmdGitContext(cwd, silent) {
   const result = resolveGitContext(cwd);
   if (silent) return result;
-  output(result, raw);
+  output(result);
 }
 
 /**
@@ -433,16 +431,15 @@ function cmdGitContext(cwd, raw, silent) {
  * Returns structured JSON with ssh_required, agent_running, status, message.
  *
  * @param {string} remoteUrl - The git remote URL to check
- * @param {boolean} raw - Whether to output raw JSON
  * @param {boolean} silent - If true, return result without output()/process.exit()
  */
-function cmdSshCheck(remoteUrl, raw, silent) {
+function cmdSshCheck(remoteUrl, silent) {
   const sshRequired = !!(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
 
   if (!sshRequired) {
     const result = { ssh_required: false, agent_running: false, status: 'not_required', message: 'Remote does not use SSH' };
     if (silent) return result;
-    output(result, raw);
+    output(result);
     return;
   }
 
@@ -478,7 +475,7 @@ function cmdSshCheck(remoteUrl, raw, silent) {
 
   const result = { ssh_required: true, agent_running: agentRunning, status, message };
   if (silent) return result;
-  output(result, raw);
+  output(result);
 }
 
 // ─── Exports ──────────────────────────────────────────────────────────────────

--- a/gsd-ng/references/agent-shared-context.md
+++ b/gsd-ng/references/agent-shared-context.md
@@ -12,3 +12,43 @@ Before executing, discover project context:
 
 This ensures project-specific patterns, conventions, and best practices are applied during execution.
 </project_context>
+
+<claude_code_bash_safety>
+<!-- Claude Code only — GitHub Copilot CLI has no equivalent AST safety layer. -->
+<!-- These rules apply to all agents running under Claude Code. -->
+<!--
+  Claude Code's bash AST safety layer (tree-sitter-bash in bashSecurity.ts) fires
+  independently of the permission/allowlist/sandbox layer. No config option exists to
+  suppress these heuristics. See: https://github.com/anthropics/claude-code/issues/30435
+-->
+
+## Bash constructs that trigger Claude Code AST safety prompts
+
+When generating bash commands, avoid these constructs. They cause Claude Code to pause
+and prompt even when the command is allowlisted or sandbox is disabled.
+
+### Forbidden constructs and safe alternatives
+
+| Forbidden | Safe alternative | Issue |
+|-----------|-----------------|-------|
+| `<<< "$VAR"` here-strings | `echo "$VAR" \|` or `printf '%s' "$VAR" \|` | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+| `for x in {a,b,c}` brace expansion | explicit list: `for x in a b c` | [#42400](https://github.com/anthropics/claude-code/issues/42400) — **regression**, removable if #42400 fixed |
+| `<(cmd)` process substitution | temp file: `cmd > "$TMPDIR/f"; diff "$TMPDIR/f" ...` | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+| `$'\x41'` ANSI-C quoting | use literal characters or `printf` | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+| multi-line heredoc `<< 'EOF'` | write to temp file first, pass path | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+| `$()` in complex nested contexts | pre-capture to variable in a prior simple command | [#31373](https://github.com/anthropics/claude-code/issues/31373) — by design |
+
+### Additional by-design heuristics (no workaround eliminates them fully)
+
+- `&&` compound chains may re-prompt in some contexts — split into separate Bash calls when possible. See [#28183](https://github.com/anthropics/claude-code/issues/28183).
+- `for` loops may trigger spurious directory prompts — use `while IFS= read -r` with a pipe instead when iterating lines. See [#22502](https://github.com/anthropics/claude-code/issues/22502).
+- `bypassPermissions` mode does NOT suppress AST heuristics. See [#39875](https://github.com/anthropics/claude-code/issues/39875).
+
+### Note on the brace expansion workaround
+
+The `{a,b,c}` brace expansion trigger was introduced in Claude Code v2.1.90 and is
+suspected to be a regression (Issue [#42400](https://github.com/anthropics/claude-code/issues/42400),
+open as of 2026-04-04). Unlike the other heuristics, this one may be removed in a patch
+release. If #42400 is resolved upstream, the explicit-list workarounds in GSD workflows
+can be reverted.
+</claude_code_bash_safety>

--- a/gsd-ng/references/decimal-phase-calculation.md
+++ b/gsd-ng/references/decimal-phase-calculation.md
@@ -37,9 +37,9 @@ DECIMAL_PHASE=$(printf '%s\n' "$DECIMAL_INFO" | jq -r '.next')
 BASE_PHASE=$(printf '%s\n' "$DECIMAL_INFO" | jq -r '.base_phase')
 ```
 
-Or with --raw flag:
+Or with flag:
 ```bash
-DECIMAL_PHASE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phase next-decimal "${AFTER_PHASE}" --raw)
+DECIMAL_PHASE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phase next-decimal "${AFTER_PHASE}")
 # Returns just: 06.1
 ```
 
@@ -57,7 +57,7 @@ DECIMAL_PHASE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phase next-decimal
 Decimal phase directories use the full decimal number:
 
 ```bash
-SLUG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" generate-slug "$DESCRIPTION" --raw)
+SLUG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" generate-slug "$DESCRIPTION")
 PHASE_DIR=".planning/phases/${DECIMAL_PHASE}-${SLUG}"
 mkdir -p "$PHASE_DIR"
 ```

--- a/gsd-ng/references/phase-argument-parsing.md
+++ b/gsd-ng/references/phase-argument-parsing.md
@@ -57,5 +57,5 @@ fi
 Use `find-phase` for directory lookup:
 
 ```bash
-PHASE_DIR=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" find-phase "${PHASE}" --raw)
+PHASE_DIR=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" find-phase "${PHASE}")
 ```

--- a/gsd-ng/references/planning-config.md
+++ b/gsd-ng/references/planning-config.md
@@ -68,12 +68,10 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: update state" --file
 
 # Load config via state load (returns JSON):
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state load)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 # commit_docs is available in the JSON output
 
 # Or use init commands which include commit_docs:
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "1")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 # commit_docs is included in all init command outputs
 ```
 
@@ -171,14 +169,12 @@ To use uncommitted mode:
 Use `init execute-phase` which returns all config as JSON:
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "1")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 # JSON output includes: branching_strategy, phase_branch_template, milestone_branch_template
 ```
 
 Or use `state load` for the config values:
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state load)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 # Parse branching_strategy, phase_branch_template, milestone_branch_template from JSON
 ```
 

--- a/gsd-ng/references/verification-patterns-deep.md
+++ b/gsd-ng/references/verification-patterns-deep.md
@@ -164,7 +164,7 @@ npx prisma migrate status 2>/dev/null | grep -v "pending"
 ```
 ```bash
 # Can query the table (automated)
-npx prisma db execute --stdin <<< "SELECT COUNT(*) FROM $table_name"
+echo "SELECT COUNT(*) FROM $table_name" | npx prisma db execute --stdin
 ```
 ```bash
 # File exists and exports function

--- a/gsd-ng/templates/ast-safety-rules.md
+++ b/gsd-ng/templates/ast-safety-rules.md
@@ -1,0 +1,30 @@
+<!-- GSD — AST Safety Rules (managed by get-shit-done installer) -->
+
+## GSD — AST Safety Rules
+
+Claude Code's bash AST safety layer (tree-sitter-bash in `bashSecurity.ts`) fires
+independently of the permission/allowlist/sandbox layer. No config option exists to
+suppress these heuristics. This block documents which bash constructs to avoid.
+See: https://github.com/anthropics/claude-code/issues/30435
+
+### Forbidden constructs and safe alternatives
+
+| Forbidden | Safe alternative | Issue |
+|-----------|-----------------|-------|
+| `<<< "$VAR"` here-strings | `echo "$VAR" |` or `printf '%s' "$VAR" |` | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+| `for x in {a,b,c}` brace expansion | explicit list: `for x in a b c` | [#42400](https://github.com/anthropics/claude-code/issues/42400) — **regression**, removable if #42400 fixed |
+| `<(cmd)` process substitution | temp file: `cmd > "$TMPDIR/f"` | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+| `$'\x41'` ANSI-C quoting | literal characters or `printf` | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+| multi-line heredoc `<< 'EOF'` | write to temp file first, pass path | [#30435](https://github.com/anthropics/claude-code/issues/30435) — by design |
+
+### Note on brace expansion
+
+<!-- AST safety: brace expansion {a,b,c} triggers sandbox prompts in Claude Code v2.1.90+
+     (regression, may be fixed upstream — check #42400 before removing).
+     See: https://github.com/anthropics/claude-code/issues/42400 -->
+
+The `{a,b,c}` brace expansion trigger was introduced in v2.1.90 and is suspected to be a
+regression (Issue [#42400](https://github.com/anthropics/claude-code/issues/42400)). If it
+is fixed upstream, explicit-list workarounds in GSD workflows can be reverted.
+
+<!-- /GSD — AST Safety Rules -->

--- a/gsd-ng/workflows/add-phase.md
+++ b/gsd-ng/workflows/add-phase.md
@@ -30,10 +30,8 @@ Load phase operation context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "0")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "0")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/gsd-ng/workflows/add-tests.md
+++ b/gsd-ng/workflows/add-tests.md
@@ -36,10 +36,8 @@ Load phase operation context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/gsd-ng/workflows/add-todo.md
+++ b/gsd-ng/workflows/add-todo.md
@@ -15,10 +15,8 @@ Load todo context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init todos)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init todos)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -109,7 +107,7 @@ Use values from init context: `timestamp` and `date` are already available.
 
 Generate slug for the title:
 ```bash
-slug=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" generate-slug "$title" --raw)
+slug=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" generate-slug "$title")
 ```
 
 Write to `.planning/todos/pending/${date}-${slug}.md`:
@@ -161,7 +159,7 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
 
 # Append to related: on the existing todo (may already have related: entries)
 EXISTING_RELATED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
-  ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --raw 2>/dev/null || echo "")
+  ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" --field related --default "")
 UPDATED_RELATED=$(echo "$EXISTING_RELATED" | node -e "
   const newFile = process.argv[1];
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{

--- a/gsd-ng/workflows/audit-milestone.md
+++ b/gsd-ng/workflows/audit-milestone.md
@@ -12,10 +12,8 @@ Read all files referenced by the invoking prompt's execution_context before star
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init milestone-op)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init milestone-op)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -27,7 +25,7 @@ Extract from init JSON: `milestone_version`, `milestone_name`, `phase_count`, `c
 
 Resolve integration checker model:
 ```bash
-integration_checker_model=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-integration-checker --raw)
+integration_checker_model=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-integration-checker)
 ```
 
 ## 1. Determine Milestone Scope
@@ -48,7 +46,7 @@ For each phase directory, read the VERIFICATION.md:
 
 ```bash
 # For each phase, use find-phase to resolve the directory (handles archived phases)
-PHASE_INFO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" find-phase 01 --raw)
+PHASE_INFO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" find-phase 01)
 # Extract directory from JSON, then read VERIFICATION.md from that directory
 # Repeat for each phase number from ROADMAP.md
 ```
@@ -141,7 +139,7 @@ For each REQ-ID, determine status using all three sources:
 Skip if `workflow.nyquist_validation` is explicitly `false` (absent = enabled).
 
 ```bash
-NYQUIST_CONFIG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.nyquist_validation --raw 2>/dev/null)
+NYQUIST_CONFIG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.nyquist_validation 2>/dev/null)
 ```
 
 If `false`: skip entirely.

--- a/gsd-ng/workflows/check-todos.md
+++ b/gsd-ng/workflows/check-todos.md
@@ -16,9 +16,8 @@ Gather todo data from CLI:
 ```bash
 AREA_FILTER=""
 if [[ -n "$ARGUMENTS" ]]; then AREA_FILTER="$ARGUMENTS"; fi
-TODOS_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" list-todos $AREA_FILTER --raw)
-if [[ "$TODOS_JSON" == @file:* ]]; then TODOS_JSON=$(cat "${TODOS_JSON#@file:}"); fi
-RECURRING_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" recurring-due --raw 2>/dev/null || echo '{"count":0,"todos":[]}')
+TODOS_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" list-todos $AREA_FILTER)
+RECURRING_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" recurring-due)
 PENDING_DIR=".planning/todos/pending"
 ```
 

--- a/gsd-ng/workflows/complete-milestone.md
+++ b/gsd-ng/workflows/complete-milestone.md
@@ -533,10 +533,8 @@ Use `init milestone-op` for context, or load config directly:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init milestone-op)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init milestone-op)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -546,28 +544,28 @@ fi
 
 ```bash
 # Load git config for branch handling (read from $INIT so per-submodule overrides apply)
-BRANCHING_STRATEGY=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" branching_strategy --raw 2>/dev/null)
-TARGET_BRANCH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" target_branch --raw 2>/dev/null)
-COMMIT_DOCS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" commit_docs --raw 2>/dev/null)
+BRANCHING_STRATEGY=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" branching_strategy 2>/dev/null)
+TARGET_BRANCH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" target_branch 2>/dev/null)
+COMMIT_DOCS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" commit_docs 2>/dev/null)
 ```
 
-Note: `config-get` with `--raw` returns the value directly (not JSON-wrapped). If the key doesn't exist (old config without git section), the `|| echo` fallback provides the default.
+Note: `config-get` returns the value directly as a scalar string by default. If the key doesn't exist (old config without git section), the `|| echo` fallback provides the default.
 
 Extract `branching_strategy`, `phase_branch_template`, `milestone_branch_template`, `target_branch`, and `commit_docs` from init JSON.
 
 **Submodule-aware routing:** Extract submodule context from `$INIT`:
 
 ```bash
-SUBMODULE_IS_ACTIVE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_is_active --raw 2>/dev/null)
-SUBMODULE_GIT_CWD=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_git_cwd --raw 2>/dev/null)
-SUBMODULE_AMBIGUOUS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_ambiguous --raw 2>/dev/null)
+SUBMODULE_IS_ACTIVE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_is_active 2>/dev/null)
+SUBMODULE_GIT_CWD=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_git_cwd 2>/dev/null)
+SUBMODULE_AMBIGUOUS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_ambiguous 2>/dev/null)
 ```
 
 **Ambiguity guard:** If `$SUBMODULE_AMBIGUOUS` is `"true"`, multiple submodules have changes and branch routing cannot be determined. Ask the user to select which submodule(s) to branch:
 
 ```bash
 if [ "$SUBMODULE_AMBIGUOUS" = "true" ]; then
-  AMBIGUOUS_PATHS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" ambiguous_paths --raw 2>/dev/null)
+  AMBIGUOUS_PATHS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" ambiguous_paths 2>/dev/null)
   AMBIGUOUS_COUNT=$(echo "$AMBIGUOUS_PATHS" | node -e "try{const a=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(a.length)}catch{console.log(0)}" 2>/dev/null)
   if [ "$AMBIGUOUS_COUNT" -le 2 ] && [ "$AMBIGUOUS_COUNT" -gt 0 ]; then
     PATH1=$(echo "$AMBIGUOUS_PATHS" | node -e "const a=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(a[0]||'')" 2>/dev/null)
@@ -608,7 +606,7 @@ fi
 ```bash
 # Effective target branch: use submodule target branch when in submodule context
 if [ "$SUBMODULE_IS_ACTIVE" = "true" ] && [ "$SUBMODULE_AMBIGUOUS" != "true" ] && [ -n "$SUBMODULE_GIT_CWD" ]; then
-  SUBMODULE_TARGET_BRANCH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_target_branch --raw 2>/dev/null)
+  SUBMODULE_TARGET_BRANCH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_target_branch 2>/dev/null)
   EFFECTIVE_TARGET_BRANCH="$SUBMODULE_TARGET_BRANCH"
 else
   EFFECTIVE_TARGET_BRANCH="$TARGET_BRANCH"
@@ -789,14 +787,13 @@ fi
 **Read versioning scheme from config:**
 
 ```bash
-VERSIONING_SCHEME=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.versioning_scheme --raw 2>/dev/null || echo "semver")
+VERSIONING_SCHEME=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.versioning_scheme --default "semver")
 ```
 
 **Auto-derive bump level from milestone commit types, then confirm with user:**
 
 ```bash
 BUMP_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" version-bump --scheme "$VERSIONING_SCHEME")
-if [[ "$BUMP_RESULT" == @file:* ]]; then BUMP_RESULT=$(cat "${BUMP_RESULT#@file:}"); fi
 ```
 
 Parse `version`, `previous`, `level`, `scheme` from result JSON.
@@ -813,16 +810,14 @@ If user provides override level:
 
 ```bash
 BUMP_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" version-bump --level {override} --scheme "$VERSIONING_SCHEME")
-if [[ "$BUMP_RESULT" == @file:* ]]; then BUMP_RESULT=$(cat "${BUMP_RESULT#@file:}"); fi
 ```
 
 **Generate CHANGELOG.md entries from all SUMMARY.md files:**
 
 ```bash
-NEW_VERSION=$(echo "$BUMP_RESULT" | node -e "process.stdin.resume();let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{console.log(JSON.parse(d).version)}catch{}})")
+NEW_VERSION="$BUMP_RESULT"
 TODAY=$(date +%Y-%m-%d)
 CHANGELOG_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" generate-changelog "$NEW_VERSION" --date "$TODAY")
-if [[ "$CHANGELOG_RESULT" == @file:* ]]; then CHANGELOG_RESULT=$(cat "${CHANGELOG_RESULT#@file:}"); fi
 ```
 
 Present changelog preview:

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -26,10 +26,8 @@ if [ -z "$PHASE_ARG" ]; then
 fi
 
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE_ARG}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -47,25 +45,25 @@ Extract from init JSON:
 - `PHASE_SLUG` ← `phase_slug`
 - `PHASE_DIR_NAME` ← basename of `phase_dir`
 
-Resolve submodule-aware git routing from $INIT (already loaded with @file: handling above):
+Resolve submodule-aware git routing from $INIT:
 
 ```bash
-# Read submodule fields from $INIT (already loaded with @file: handling above)
+# Read submodule fields from $INIT
 IS_SUBMODULE=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.submodule_is_active||false))}catch{process.stdout.write('false')}" "$INIT")
 GIT_CWD=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_git_cwd||'.')}catch{process.stdout.write('.')}" "$INIT")
-PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" remote --raw 2>/dev/null)
-PUSH_TARGET=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" target_branch --raw 2>/dev/null); if [ -z "$PUSH_TARGET" ]; then PUSH_TARGET="main"; fi
+PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" remote 2>/dev/null)
+PUSH_TARGET=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" target_branch 2>/dev/null); if [ -z "$PUSH_TARGET" ]; then PUSH_TARGET="main"; fi
 AMBIGUOUS=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(String(c.submodule_ambiguous||false))}catch{process.stdout.write('false')}" "$INIT")
 SUBMODULE_REMOTE_URL=$(node -e "try{const c=JSON.parse(process.argv[1]);process.stdout.write(c.submodule_remote_url||'')}catch{process.stdout.write('')}" "$INIT")
 
 # Platform: read from $INIT (per-submodule override applies), fall back to detect-platform
-PLATFORM=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" platform --raw 2>/dev/null)
+PLATFORM=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" platform 2>/dev/null)
 if [ -z "$PLATFORM" ]; then
-  PLATFORM=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field platform --raw)
+  PLATFORM=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field platform)
 fi
-CLI=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli --raw)
-CLI_INSTALLED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli_installed --raw)
-CLI_INSTALL_URL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli_install_url --raw)
+CLI=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli)
+CLI_INSTALLED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli_installed)
+CLI_INSTALL_URL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --field cli_install_url)
 ```
 
 Use `$PUSH_REMOTE`, `$PUSH_TARGET`, and `$GIT_CWD` for all git and platform operations below instead of `$REMOTE` and `$TARGET_BRANCH`.
@@ -80,7 +78,7 @@ Parse flags:
 
 ```bash
 # Flag parsing
-PR_DRAFT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" pr_draft --raw 2>/dev/null)
+PR_DRAFT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" pr_draft 2>/dev/null)
 
 if [[ "$ARGUMENTS" == *"--draft"* ]] && [[ "$ARGUMENTS" != *"--no-draft"* ]]; then
   PR_DRAFT="true"
@@ -169,7 +167,7 @@ Load type aliases from config:
 ```bash
 # Map the short type to its branch prefix alias using resolve-type-alias
 # e.g., TYPE=feat -> TYPE_ALIAS=feature
-TYPE_ALIAS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-type-alias "${TYPE:-feat}" --raw 2>/dev/null || echo "${TYPE:-feature}")
+TYPE_ALIAS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-type-alias "${TYPE:-feat}")
 ```
 
 Map the type to its alias for the branch name.
@@ -211,7 +209,7 @@ git -C "$GIT_CWD" merge --squash "$CURRENT_BRANCH" 2>&1
 # Build squash commit message from plan summaries
 SQUASH_MSG=""
 for summary in $(ls .planning/phases/${PHASE_DIR_NAME}/*-SUMMARY.md 2>/dev/null | sort); do
-  ONE_LINER=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" summary-extract "$summary" --fields one_liner --raw 2>/dev/null || echo "")
+  ONE_LINER=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" summary-extract "$summary" --fields one_liner --default "")
   if [ -n "$ONE_LINER" ]; then
     PLAN_ID=$(basename "$summary" | sed 's/-SUMMARY.md//')
     SQUASH_MSG="${SQUASH_MSG}- ${PLAN_ID}: ${ONE_LINER}\n"
@@ -275,7 +273,7 @@ Build PR description following template precedence: user config > repo template 
 PR_BODY_FILE=$(mktemp)
 
 # 1. Check user config template
-PR_TEMPLATE_PATH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" pr_template --raw 2>/dev/null)
+PR_TEMPLATE_PATH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" pr_template 2>/dev/null)
 
 if [ -n "$PR_TEMPLATE_PATH" ] && [ -f "$PR_TEMPLATE_PATH" ]; then
   # User config template — copy and apply variable substitution below
@@ -296,13 +294,13 @@ elif [ -d ".gitlab/merge_request_templates" ]; then
 
 else
   # GSD default professional template
-  # Extract phase goal using --pick (handles @file: dereferencing internally)
-  PHASE_OBJECTIVE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE_NUMBER}" --pick goal --raw 2>/dev/null || echo "")
+  # Extract phase goal using --pick
+  PHASE_OBJECTIVE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE_NUMBER}" --pick goal --default "")
 
   # Extract plan summaries
   PLAN_SUMMARIES=""
   for summary in $(ls .planning/phases/${PHASE_DIR_NAME}/*-SUMMARY.md 2>/dev/null | sort); do
-    ONE_LINER=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" summary-extract "$summary" --fields one_liner --raw 2>/dev/null || echo "")
+    ONE_LINER=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" summary-extract "$summary" --fields one_liner --default "")
     if [ -n "$ONE_LINER" ]; then
       PLAN_ID=$(basename "$summary" | sed 's/-SUMMARY.md//')
       PLAN_SUMMARIES="${PLAN_SUMMARIES}\n- **${PLAN_ID}**: ${ONE_LINER}"

--- a/gsd-ng/workflows/discuss-phase.md
+++ b/gsd-ng/workflows/discuss-phase.md
@@ -123,10 +123,8 @@ Phase number from argument (required).
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -203,11 +201,7 @@ If "Cancel": Exit workflow.
 
 Read the phase goal from ROADMAP.md for this phase:
 ```bash
-PHASE_GOAL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --raw 2>/dev/null | node -e "
-  process.stdin.on('data', d => {
-    try { const r = JSON.parse(d); console.log(r.goal || r.name || ''); } catch { console.log(''); }
-  });
-")
+PHASE_GOAL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --pick goal --default "" 2>/dev/null)
 ```
 
 If `$PHASE_GOAL` is empty, skip silently and continue to load_prior_context.
@@ -268,17 +262,13 @@ In **interactive mode**:
 
 1. Find the source todo for this phase by checking ROADMAP.md:
 ```bash
-SOURCE_TODO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --raw 2>/dev/null | node -e "
-  process.stdin.on('data', d => {
-    try { const r = JSON.parse(d); console.log(r.source_todos || ''); } catch { console.log(''); }
-  });
-")
+SOURCE_TODO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --pick source_todos --default "" 2>/dev/null)
 ```
 
 2. If `$SOURCE_TODO` is non-empty, read its existing `related:` field:
 ```bash
 EXISTING_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
-  ".planning/todos/pending/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+  ".planning/todos/pending/$SOURCE_TODO" --field related --default "")
 ```
 
 3. From the phase: linking candidates above (1-3 todos that were evaluated), filter for any that:
@@ -303,7 +293,7 @@ AskUserQuestion(
 ```bash
 # Append selected todo filename to source todo's related: field
 SOURCE_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
-  ".planning/todos/pending/$SOURCE_TODO" --field related --raw 2>/dev/null || echo "")
+  ".planning/todos/pending/$SOURCE_TODO" --field related --default "")
 UPDATED_SOURCE=$(echo "$SOURCE_RELATED_RAW" | node -e "
   const newFile = process.argv[1];
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
@@ -320,7 +310,7 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter set \
 
 # Append source todo filename to selected todo's related: field (backlink)
 SELECTED_RELATED_RAW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get \
-  ".planning/todos/pending/$SELECTED_FILE" --field related --raw 2>/dev/null || echo "")
+  ".planning/todos/pending/$SELECTED_FILE" --field related --default "")
 UPDATED_SELECTED=$(echo "$SELECTED_RELATED_RAW" | node -e "
   const newFile = process.argv[1];
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
@@ -458,7 +448,8 @@ Analyze the phase to identify gray areas worth discussing. **Use both `prior_dec
 Extract the `Requirements:` field from the phase's ROADMAP.md section (available in the `section` field from `roadmap get-phase`):
 
 ```bash
-# Extract Requirements field from the section text already loaded
+# Fetch phase data once for requirements and lineage analysis
+PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --json 2>/dev/null)
 REQUIREMENTS=$(echo "$PHASE_DATA" | node -e "
   let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
     try {
@@ -481,11 +472,7 @@ This is NOT a hard block — the workflow continues to lineage analysis and gray
 
 ```bash
 # Get depends_on from current phase (requires Plan 01's roadmap.cjs changes)
-DEPENDS_ON=$(echo "$PHASE_DATA" | node -e "
-  let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-    try { const r=JSON.parse(d); console.log(r.depends_on||''); } catch { console.log(''); }
-  });
-")
+DEPENDS_ON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --pick depends_on --default "" 2>/dev/null)
 
 # If empty: skip silently (no message, no note in CONTEXT.md)
 if [ -n "$DEPENDS_ON" ]; then
@@ -499,12 +486,7 @@ if [ -n "$DEPENDS_ON" ]; then
 
   # For each parent: fetch goal + success_criteria
   for PARENT_PHASE in $PARENT_PHASES; do
-    PARENT_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PARENT_PHASE" 2>/dev/null)
-    PARENT_FOUND=$(echo "$PARENT_DATA" | node -e "
-      let d=''; process.stdin.on('data',c=>d+=c); process.stdin.on('end',()=>{
-        try { console.log(JSON.parse(d).found ? 'true' : 'false'); } catch { console.log('false'); }
-      });
-    ")
+    PARENT_FOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "$PARENT_PHASE" --pick found --default "false" 2>/dev/null)
     # Skip silently if parent not found (common for prior milestones)
     if [ "$PARENT_FOUND" = "true" ]; then
       # Extract parent goal and success_criteria
@@ -931,8 +913,8 @@ Check for auto-advance trigger:
    ```
 3. Read both the chain flag and user preference:
    ```bash
-   AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active 2>/dev/null || echo "false")
-   AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
+   AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default "false")
+   AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance --default "false")
    ```
 
 **If `--auto` flag present AND `AUTO_CHAIN` is not true:** Persist chain flag to config (handles direct `--auto` usage without new-project):

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -17,10 +17,8 @@ Load all context in one call:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE_ARG}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -52,17 +50,17 @@ Check `branching_strategy` from init:
 **Submodule-aware routing:** Before performing any git branch operations, extract submodule context from `$INIT` (already loaded in the initialize step):
 
 ```bash
-SUBMODULE_IS_ACTIVE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_is_active --raw 2>/dev/null)
-SUBMODULE_GIT_CWD=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_git_cwd --raw 2>/dev/null)
-SUBMODULE_TARGET_BRANCH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_target_branch --raw 2>/dev/null)
-SUBMODULE_AMBIGUOUS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_ambiguous --raw 2>/dev/null)
+SUBMODULE_IS_ACTIVE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_is_active 2>/dev/null)
+SUBMODULE_GIT_CWD=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_git_cwd 2>/dev/null)
+SUBMODULE_TARGET_BRANCH=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_target_branch 2>/dev/null)
+SUBMODULE_AMBIGUOUS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_ambiguous 2>/dev/null)
 ```
 
 **Ambiguity guard:** If `$SUBMODULE_AMBIGUOUS` is `"true"`, multiple submodules have changes and branching cannot be reliably routed. Ask the user to select which submodule(s) to branch:
 
 ```bash
 if [ "$SUBMODULE_AMBIGUOUS" = "true" ]; then
-  AMBIGUOUS_PATHS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" ambiguous_paths --raw 2>/dev/null)
+  AMBIGUOUS_PATHS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" ambiguous_paths 2>/dev/null)
   AMBIGUOUS_COUNT=$(echo "$AMBIGUOUS_PATHS" | node -e "try{const a=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(a.length)}catch{console.log(0)}" 2>/dev/null)
   if [ "$AMBIGUOUS_COUNT" -le 2 ] && [ "$AMBIGUOUS_COUNT" -gt 0 ]; then
     PATH1=$(echo "$AMBIGUOUS_PATHS" | node -e "const a=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(a[0]||'')" 2>/dev/null)
@@ -139,11 +137,7 @@ Discover test commands via CLI and capture per-directory baselines. Supports sta
 
 ```bash
 # Discover test commands (config override or workspace-aware auto-detect)
-DISCOVERED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" discover-test-command 2>/dev/null || echo "[]")
-# Resolve @file: pattern if present
-if [[ "$DISCOVERED" == @file:* ]]; then
-  DISCOVERED=$(cat "${DISCOVERED#@file:}")
-fi
+DISCOVERED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" discover-test-command)
 
 ENTRY_COUNT=$(node -e "console.log(JSON.parse(process.argv[1]).length)" "$DISCOVERED")
 if [[ "$ENTRY_COUNT" -eq 0 ]]; then
@@ -223,8 +217,8 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
    Resolve workspace topology for agent context injection:
    ```bash
-   WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type --raw 2>/dev/null || echo "standalone")
-   WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
+   WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type)
+   WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace)
    SUBMODULE_PATHS=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p.join(', ')||'none')}catch{process.stdout.write('none')}" "$WORKSPACE_JSON")
    PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
    ```
@@ -287,10 +281,10 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
    - **Breakout check** — compare committed files against plan's `files_modified`:
      ```bash
      PLAN_FILE="{phase_dir}/{plan_file}"
-     FILES_MODIFIED=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$PLAN_FILE" --field files_modified --raw 2>/dev/null)
+     FILES_MODIFIED=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$PLAN_FILE" --field files_modified 2>/dev/null)
 
      if [[ -n "$FILES_MODIFIED" ]]; then
-       BREAKOUT_RESULT=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" breakout-check --plan "{phase}-{plan}" --declared-files "$FILES_MODIFIED" --raw 2>/dev/null)
+       BREAKOUT_RESULT=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" breakout-check --plan "{phase}-{plan}" --declared-files "$FILES_MODIFIED" 2>/dev/null)
      fi
      ```
      - If `BREAKOUT_RESULT` is `warning`: log in wave completion output — "Note: executor modified files outside declared scope: {list}". Continue execution.
@@ -335,8 +329,8 @@ Plans with `autonomous: false` require user interaction.
 
 Read auto-advance config (chain flag + user preference):
 ```bash
-AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active 2>/dev/null || echo "false")
-AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
+AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default "false")
+AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance --default "false")
 ```
 
 When executor returns a checkpoint AND (`AUTO_CHAIN` is `"true"` OR `AUTO_CFG` is `"true"`):
@@ -406,11 +400,11 @@ if [ "$AUTO_PUSH" = "true" ] && [ "$BRANCHING_STRATEGY" != "none" ] && [ -n "$BR
   # Route push to correct repository
   if [ "$SUBMODULE_IS_ACTIVE" = "true" ] && [ "$SUBMODULE_AMBIGUOUS" != "true" ] && [ -n "$SUBMODULE_GIT_CWD" ]; then
     GIT_CWD="${SUBMODULE_GIT_CWD}"
-    PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_remote --raw 2>/dev/null)
-    SUBMODULE_REMOTE_URL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_remote_url --raw 2>/dev/null)
+    PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_remote 2>/dev/null)
+    SUBMODULE_REMOTE_URL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" submodule_remote_url 2>/dev/null)
   else
     GIT_CWD="."
-    PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" remote --raw 2>/dev/null)
+    PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" remote 2>/dev/null)
     SUBMODULE_REMOTE_URL=""
   fi
   AMBIGUOUS="${SUBMODULE_AMBIGUOUS}"
@@ -421,11 +415,11 @@ if [ "$AUTO_PUSH" = "true" ] && [ "$BRANCHING_STRATEGY" != "none" ] && [ -n "$BR
 **SSH pre-push check:**
 
 ```bash
-  SSH_CHECK=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.ssh_check --raw 2>/dev/null || echo "true")
+  SSH_CHECK=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get git.ssh_check --default true)
   if [ "$SSH_CHECK" = "true" ] && [ -n "$SUBMODULE_REMOTE_URL" ]; then
-    SSH_STATUS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" ssh-check "$SUBMODULE_REMOTE_URL" --field status --raw)
+    SSH_STATUS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" ssh-check "$SUBMODULE_REMOTE_URL" --field status)
     if [ "$SSH_STATUS" != "ok" ] && [ "$SSH_STATUS" != "not_required" ]; then
-      SSH_MSG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" ssh-check "$SUBMODULE_REMOTE_URL" --field message --raw)
+      SSH_MSG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" ssh-check "$SUBMODULE_REMOTE_URL" --field message)
       echo "WARNING: SSH check failed — $SSH_MSG"
       # Also check for SSH signing
       GPG_FORMAT=$(git -C "$GIT_CWD" config gpg.format 2>/dev/null || echo "")
@@ -468,7 +462,7 @@ fi
 
 **2. Find parent UAT file:**
 ```bash
-PARENT_INFO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" find-phase "${PARENT_PHASE}" --raw)
+PARENT_INFO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" find-phase "${PARENT_PHASE}")
 # Extract directory from PARENT_INFO JSON, then find UAT file in that directory
 ```
 
@@ -628,13 +622,13 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs(phase-{X}): complete 
 After phase completion is committed, check for external issue auto-sync:
 
 ```bash
-AUTO_SYNC=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get issue_tracker.auto_sync --raw 2>/dev/null || echo "true")
+AUTO_SYNC=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get issue_tracker.auto_sync --default true)
 ```
 
 If `AUTO_SYNC` is `"true"` (string comparison — config-get returns raw string):
 
 ```bash
-SYNC_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" issue-sync "${PHASE_NUMBER}" --auto --raw 2>/dev/null)
+SYNC_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" issue-sync "${PHASE_NUMBER}" --auto 2>/dev/null)
 ```
 
 Parse SYNC_RESULT JSON. If `synced` array has entries, display:
@@ -657,9 +651,7 @@ If `AUTO_SYNC` is `"false"`: skip entirely, no output.
 After phase completion is committed, trigger incremental codebase re-mapping if codebase docs exist:
 
 ```bash
-STALE_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" staleness-check 2>/dev/null || echo '{"stale":[]}')
-if [[ "$STALE_JSON" == @file:* ]]; then STALE_JSON=$(cat "${STALE_JSON#@file:}"); fi
-STALE_COUNT=$(node -e "process.stdin.on('data',d=>{try{console.log(JSON.parse(d).stale.length)}catch{console.log(0)}})" <<< "$STALE_JSON")
+STALE_COUNT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" staleness-check --count)
 ```
 
 If STALE_COUNT is 0: skip silently (no stale docs, nothing to update).
@@ -668,6 +660,11 @@ If STALE_COUNT > 0:
 
 ```
 {STALE_COUNT} codebase doc(s) have changes since last mapping. Running incremental update...
+```
+
+Fetch the full stale doc list:
+```bash
+STALE_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" staleness-check)
 ```
 
 For each stale doc in the `stale` array from STALE_JSON, spawn a `gsd-incremental-mapper` agent:
@@ -743,8 +740,8 @@ If `branching_strategy` is not `"none"` AND push succeeded (or `auto_push` is en
 1. Parse `--auto` flag from $ARGUMENTS
 2. Read both the chain flag and user preference (chain flag already synced in init step):
    ```bash
-   AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active 2>/dev/null || echo "false")
-   AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
+   AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default "false")
+   AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance --default "false")
    ```
 
 **If `--auto` flag present OR `AUTO_CHAIN` is true OR `AUTO_CFG` is true (AND verification passed with no gaps):**
@@ -814,7 +811,7 @@ If `$VERIFY_STATUS` is `passed` AND `$ORIGIN_TODO_FILE` is set:
 
 **Auto mode:**
 ```bash
-AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --raw 2>/dev/null || echo "false")
+AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default false)
 ```
 
 If auto: close todo, log `[auto] Closed todo: $ORIGIN_TODO_TITLE`.
@@ -853,7 +850,7 @@ if [[ "$VERIFY_STATUS" == "passed" ]]; then
   if [[ -d "$PENDING_DIR" ]]; then
     for TODO_FILE in "$PENDING_DIR"/*.md; do
       [[ -f "$TODO_FILE" ]] || continue
-      TODO_PHASE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field phase --raw 2>/dev/null || echo "")
+      TODO_PHASE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field phase --default "")
       if [[ "$(echo "$TODO_PHASE" | tr -d '[:space:]')" == "${PHASE_NUMBER}" ]]; then
         TODO_BASENAME=$(basename "$TODO_FILE")
         TODO_TITLE=$(grep '^title:' "$TODO_FILE" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
@@ -868,7 +865,7 @@ If `$PHASE_LINKED` is non-empty (at least one phase-linked todo found):
 
 **Auto mode:**
 ```bash
-AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --raw 2>/dev/null || echo "false")
+AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default false)
 ```
 
 If auto: for each phase-linked todo, close it and commit:
@@ -914,7 +911,7 @@ if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS" == "passed" ]]; then
   if [[ ! -f "$ORIGIN_PATH" ]]; then
     ORIGIN_PATH=".planning/todos/completed/$ORIGIN_TODO_FILE"
   fi
-  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --raw 2>/dev/null || echo "")
+  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --default "")
   if [[ "$RELATED_OUTBOUND" == "null" ]]; then RELATED_OUTBOUND=""; fi
 fi
 ```
@@ -929,7 +926,7 @@ if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$VERIFY_STATUS
     TODO_BASENAME=$(basename "$TODO_FILE")
     # Skip the origin todo itself
     [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
-    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline --raw 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
+    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
       RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
     fi
   done
@@ -958,13 +955,13 @@ If `$RELATED_ALL` is non-empty:
 **Auto mode:**
 ```bash
 if [[ "$AUTO_CFG" == "true" ]]; then
-  while IFS= read -r REL_TODO; do
+  printf '%s\n' "$RELATED_ALL" | while IFS= read -r REL_TODO; do
     [[ -z "$REL_TODO" ]] && continue
     REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
     node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
     node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after phase completion" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
     echo "[auto] Closed related todo: $REL_TITLE"
-  done <<< "$RELATED_ALL"
+  done
 fi
 ```
 

--- a/gsd-ng/workflows/execute-plan.md
+++ b/gsd-ng/workflows/execute-plan.md
@@ -18,10 +18,8 @@ Load execution context (paths only to minimize orchestrator context):
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -135,7 +133,7 @@ This IS the execution instructions. Follow exactly. If plan references CONTEXT.m
 
 <step name="previous_phase_check">
 ```bash
-node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phases list --type summaries --raw
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phases list --type summaries
 # Extract the second-to-last summary from the JSON result
 ```
 If previous SUMMARY has unresolved "Issues Encountered" or "Next Phase Readiness" blockers: AskUserQuestion(header="Previous Issues", options: "Proceed anyway" | "Address first" | "Review previous").
@@ -331,7 +329,7 @@ If verification fails:
 
 **Check if node repair is enabled** (default: on):
 ```bash
-NODE_REPAIR=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.node_repair 2>/dev/null || echo "true")
+NODE_REPAIR=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.node_repair --default "true")
 ```
 
 If `NODE_REPAIR` is `true`: invoke `@./.claude/gsd-ng/workflows/node-repair.md` with:

--- a/gsd-ng/workflows/help.md
+++ b/gsd-ng/workflows/help.md
@@ -12,8 +12,7 @@ Read all files referenced by the invoking prompt's execution_context before star
 Retrieve the command list:
 
 ```bash
-HELP_OUTPUT=$(node "$GSD_TOOLS" help)
-if [[ "$HELP_OUTPUT" == @file:* ]]; then HELP_OUTPUT=$(cat "${HELP_OUTPUT#@file:}"); fi
+HELP_OUTPUT=$(node "$GSD_TOOLS" help --json)
 ```
 
 Parse the JSON output. The `commands` array contains objects with `name`, `description`, and `argument_hint` fields.

--- a/gsd-ng/workflows/import-issue.md
+++ b/gsd-ng/workflows/import-issue.md
@@ -15,7 +15,7 @@ Read all files referenced by the invoking prompt's execution_context before star
 Detect configured platform:
 
 ```bash
-PLATFORM=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --raw)
+PLATFORM=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform)
 ```
 
 Parse JSON. If platform unavailable or CLI not installed, display warning and exit (same as sync-issues):
@@ -46,7 +46,7 @@ Ask for issue number:
 - "Enter the issue number to import (e.g., 42):"
 
 ```bash
-RESULT=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-import {platform} {number} --raw)
+RESULT=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-import {platform} {number})
 IMPORT_EXIT=$?
 ```
 
@@ -113,7 +113,7 @@ Display matching issues as a numbered list. Use AskUserQuestion to confirm:
 
 For each selected issue, call:
 ```bash
-node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-import {platform} {number} --raw
+node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-import {platform} {number}
 ```
 
 If any import fails with `[SECURITY]`, pause bulk import and present the `security_gate` step for that issue. User may choose "Review and override" (re-run with `--force-unsafe`) or "Cancel import" to skip that issue and continue with the rest.

--- a/gsd-ng/workflows/insert-phase.md
+++ b/gsd-ng/workflows/insert-phase.md
@@ -35,10 +35,8 @@ Load phase operation context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${after_phase}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${after_phase}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/gsd-ng/workflows/map-codebase.md
+++ b/gsd-ng/workflows/map-codebase.md
@@ -29,10 +29,8 @@ Load codebase mapping context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init map-codebase)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init map-codebase)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -51,14 +49,12 @@ Parse `$ARGUMENTS` for `--incremental` or `incremental` keyword.
 If `--incremental` flag is present:
 
 ```bash
-STALE_JSON=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" staleness-check 2>/dev/null || echo '{"stale":[]}')
-if [[ "$STALE_JSON" == @file:* ]]; then STALE_JSON=$(cat "${STALE_JSON#@file:}"); fi
-STALE_COUNT=$(node -e "process.stdin.on('data',d=>{try{console.log(JSON.parse(d).stale.length)}catch{console.log(0)}})" <<< "$STALE_JSON")
+STALE_COUNT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" staleness-check --count)
 ```
 
 If STALE_COUNT is 0: output "All codebase docs are up-to-date. Nothing to update." and exit workflow.
 
-If STALE_COUNT > 0: output "{STALE_COUNT} codebase doc(s) need updating." and spawn one `gsd-incremental-mapper` agent per stale doc (use same pattern as execute-phase `incremental_remap` step). Wait for all agents to complete, then skip to `commit_codebase_map` step.
+If STALE_COUNT > 0: output "{STALE_COUNT} codebase doc(s) need updating." — fetch the full stale list with `staleness-check` (no `--count`) and spawn one `gsd-incremental-mapper` agent per stale doc (use same pattern as execute-phase `incremental_remap` step). Wait for all agents to complete, then skip to `commit_codebase_map` step.
 
 If NO `--incremental` flag (default behavior): continue to `check_existing` for full re-map.
 </step>

--- a/gsd-ng/workflows/new-milestone.md
+++ b/gsd-ng/workflows/new-milestone.md
@@ -101,10 +101,8 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: start milestone v[X.
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init new-milestone)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init new-milestone)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/gsd-ng/workflows/new-project.md
+++ b/gsd-ng/workflows/new-project.md
@@ -49,10 +49,8 @@ The document should describe what you want to build.
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init new-project)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init new-project)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -1030,7 +1028,7 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: create roadmap ([N] 
 **Detect workspace topology:**
 
 ```bash
-WS_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --raw)
+WS_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace)
 ```
 
 Parse JSON: `type` (submodule|monorepo|standalone), `signal` (detection method).

--- a/gsd-ng/workflows/pause-work.md
+++ b/gsd-ng/workflows/pause-work.md
@@ -86,7 +86,7 @@ Be specific enough for a fresh Claude to understand immediately.
 
 Use `current-timestamp` for last_updated field. You can use init todos (which provides timestamps) or call directly:
 ```bash
-timestamp=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" current-timestamp full --raw)
+timestamp=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" current-timestamp full)
 ```
 </step>
 

--- a/gsd-ng/workflows/plan-phase.md
+++ b/gsd-ng/workflows/plan-phase.md
@@ -18,10 +18,8 @@ Load all context in one call (paths only to minimize orchestrator context):
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init plan-phase "$PHASE")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init plan-phase "$PHASE")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -190,11 +188,7 @@ When discuss-phase is skipped, scan pending todos for keyword overlap with the p
 
 Read the phase goal:
 ```bash
-PHASE_GOAL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --raw 2>/dev/null | node -e "
-  process.stdin.on('data', d => {
-    try { const r = JSON.parse(d); console.log(r.goal || r.name || ''); } catch { console.log(''); }
-  });
-")
+PHASE_GOAL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --pick goal --default "" 2>/dev/null)
 ```
 
 If `$PHASE_GOAL` is empty or `ls .planning/todos/pending/*.md 2>/dev/null` returns no files, skip silently and continue to step 5.
@@ -255,7 +249,7 @@ Display banner:
 ```
 
 ```bash
-PHASE_DESC=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" | jq -r '.section')
+PHASE_DESC=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}")
 ```
 
 Gap research prompt:
@@ -342,7 +336,7 @@ Display banner:
 ### Spawn gsd-phase-researcher
 
 ```bash
-PHASE_DESC=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" | jq -r '.section')
+PHASE_DESC=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}")
 ```
 
 Research prompt:
@@ -421,8 +415,8 @@ test -f "${PHASE_DIR}/${PADDED_PHASE}-VALIDATION.md" && echo "VALIDATION_CREATED
 > Skip if `workflow.ui_phase` is explicitly `false` AND `workflow.ui_safety_gate` is explicitly `false` in `.planning/config.json`. If keys are absent, treat as enabled.
 
 ```bash
-UI_PHASE_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.ui_phase 2>/dev/null || echo "true")
-UI_GATE_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.ui_safety_gate 2>/dev/null || echo "true")
+UI_PHASE_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.ui_phase --default "true")
+UI_GATE_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.ui_safety_gate --default "true")
 ```
 
 **If both are `false`:** Skip to step 6.
@@ -717,8 +711,8 @@ Check for auto-advance trigger:
    ```
 3. Read both the chain flag and user preference:
    ```bash
-   AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active 2>/dev/null || echo "false")
-   AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
+   AUTO_CHAIN=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default "false")
+   AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.auto_advance --default "false")
    ```
 
 **If `--auto` flag present OR `AUTO_CHAIN` is true OR `AUTO_CFG` is true:**

--- a/gsd-ng/workflows/progress.md
+++ b/gsd-ng/workflows/progress.md
@@ -12,11 +12,9 @@ Read all files referenced by the invoking prompt's execution_context before star
 Gather all data from CLI in minimal calls:
 
 ```bash
-INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init progress --raw)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
+INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init progress)
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
-  INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init progress --raw)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
+  INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init progress)
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -30,11 +28,9 @@ If `project_exists` is false: "No planning structure found. Run /gsd:new-project
 If ROADMAP.md missing but PROJECT.md exists: Go to **Route F** (between milestones).
 
 ```bash
-ROADMAP=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap analyze --raw)
-if [[ "$ROADMAP" == @file:* ]]; then ROADMAP=$(cat "${ROADMAP#@file:}"); fi
+ROADMAP=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap analyze)
 
-STATE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state-snapshot --raw)
-if [[ "$STATE" == @file:* ]]; then STATE=$(cat "${STATE#@file:}"); fi
+STATE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state-snapshot)
 ```
 
 All structured data is now in INIT, ROADMAP, and STATE JSON variables. No manual file reading or parsing needed.
@@ -49,7 +45,7 @@ RECENT_SUMMARIES=$(ls -t .planning/phases/*/*-SUMMARY.md 2>/dev/null | head -3)
 
 For each summary file, extract the one-liner:
 ```bash
-node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" summary-extract <path> --fields one_liner --raw
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" summary-extract <path> --fields one_liner
 ```
 </step>
 
@@ -67,7 +63,7 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" summary-extract <path> --fields on
 
 ```bash
 # Get formatted progress bar
-PROGRESS_BAR=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" progress bar --raw)
+PROGRESS_BAR=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" progress bar)
 ```
 
 Present:

--- a/gsd-ng/workflows/quick.md
+++ b/gsd-ng/workflows/quick.md
@@ -145,10 +145,8 @@ If `$VERIFY_MODE` only:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init quick "$DESCRIPTION")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init quick "$DESCRIPTION")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -547,8 +545,8 @@ Offer: 1) Force proceed, 2) Abort
 Spawn gsd-executor with plan reference:
 
 ```bash
-WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type --raw 2>/dev/null || echo "standalone")
-WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
+WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type)
+WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace)
 SUBMODULE_PATHS=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p.join(', ')||'none')}catch{process.stdout.write('none')}" "$WORKSPACE_JSON")
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 ```
@@ -781,7 +779,7 @@ Read the SUMMARY.md one-liner and the todo title. If they share keywords or the 
 **In auto mode** (check `AUTO_CFG`):
 
 ```bash
-AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --raw 2>/dev/null || echo "false")
+AUTO_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow._auto_chain_active --default "false")
 ```
 
 If `$AUTO_CFG` is `"true"`:
@@ -832,7 +830,7 @@ if [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED" == "true" ]]; then
   if [[ ! -f "$ORIGIN_PATH" ]]; then
     ORIGIN_PATH=".planning/todos/pending/$ORIGIN_TODO_FILE"
   fi
-  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --raw 2>/dev/null || echo "")
+  RELATED_OUTBOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$ORIGIN_PATH" --field related --format newline --default "")
   if [[ "$RELATED_OUTBOUND" == "null" ]]; then RELATED_OUTBOUND=""; fi
 fi
 ```
@@ -846,7 +844,7 @@ if [[ -d "$PENDING_DIR" ]] && [[ -n "$ORIGIN_TODO_FILE" ]] && [[ "$ORIGIN_CLOSED
     [[ -f "$TODO_FILE" ]] || continue
     TODO_BASENAME=$(basename "$TODO_FILE")
     [[ "$TODO_BASENAME" == "$ORIGIN_TODO_FILE" ]] && continue
-    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline --raw 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
+    if node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter get "$TODO_FILE" --field related --format newline 2>/dev/null | grep -qFx "$ORIGIN_TODO_FILE"; then
       RELATED_INBOUND="${RELATED_INBOUND}${TODO_BASENAME}\n"
     fi
   done
@@ -874,13 +872,13 @@ If `$RELATED_ALL` is non-empty:
 **Auto mode:**
 ```bash
 if [[ "$AUTO_CFG" == "true" ]]; then
-  while IFS= read -r REL_TODO; do
+  printf '%s\n' "$RELATED_ALL" | while IFS= read -r REL_TODO; do
     [[ -z "$REL_TODO" ]] && continue
     REL_TITLE=$(grep '^title:' ".planning/todos/pending/$REL_TODO" 2>/dev/null | sed 's/^title:\s*//' | tr -d '"')
     node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo complete "$REL_TODO"
     node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: close related todo after quick task" --files ".planning/todos/completed/$REL_TODO" ".planning/todos/pending/$REL_TODO"
     echo "[auto] Closed related todo: $REL_TITLE"
-  done <<< "$RELATED_ALL"
+  done
 fi
 ```
 

--- a/gsd-ng/workflows/remove-phase.md
+++ b/gsd-ng/workflows/remove-phase.md
@@ -30,10 +30,8 @@ Load phase operation context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${target}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${target}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/gsd-ng/workflows/research-phase.md
+++ b/gsd-ng/workflows/research-phase.md
@@ -35,10 +35,8 @@ If exists: Offer update/view/skip options.
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/gsd-ng/workflows/resume-project.md
+++ b/gsd-ng/workflows/resume-project.md
@@ -21,10 +21,8 @@ Load all context in one call:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init resume)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init resume)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/gsd-ng/workflows/settings.md
+++ b/gsd-ng/workflows/settings.md
@@ -16,10 +16,8 @@ Ensure config exists and load current state:
 ```bash
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-ensure-section
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state load)
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" state load)
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -264,7 +262,7 @@ AskUserQuestion([
 
 If user selected "Auto-detect (Recommended)", run platform detection:
 ```bash
-PLATFORM_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --raw 2>/dev/null)
+PLATFORM_RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --json 2>/dev/null)
 ```
 Extract the `platform` field from the JSON result. Store it for display in the confirmation table as `"Auto-detect ({detected_platform})"` or `"Auto-detect (not detected)"` if null. Config stores `platform: null` (auto-detect uses runtime detection, config only stores manual overrides).
 

--- a/gsd-ng/workflows/squash.md
+++ b/gsd-ng/workflows/squash.md
@@ -35,10 +35,8 @@ Load phase context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init execute-phase "${PHASE}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -71,7 +69,6 @@ Always show dry run first:
 
 ```bash
 PREVIEW=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" squash ${PHASE} --strategy ${STRATEGY} --dry-run)
-if [[ "$PREVIEW" == @file:* ]]; then PREVIEW=$(cat "${PREVIEW#@file:}"); fi
 ```
 
 Display the preview showing which commits will be grouped and what messages will be used.
@@ -93,7 +90,6 @@ Execute the squash:
 
 ```bash
 RESULT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" squash ${PHASE} --strategy ${STRATEGY} ${ALLOW_STABLE_FLAG})
-if [[ "$RESULT" == @file:* ]]; then RESULT=$(cat "${RESULT#@file:}"); fi
 ```
 
 Display the result including backup tag name.
@@ -109,8 +105,8 @@ Push squashed branch with --force-with-lease?
 
 If yes:
 ```bash
-GIT_CWD=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context --field git_cwd --raw 2>/dev/null || echo ".")
-PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context --field remote --raw 2>/dev/null || echo "origin")
+GIT_CWD=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context --field git_cwd)
+PUSH_REMOTE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" git-context --field remote)
 BRANCH=$(git -C "$GIT_CWD" branch --show-current)
 git -C "$GIT_CWD" push --force-with-lease "$PUSH_REMOTE" "$BRANCH"
 ```

--- a/gsd-ng/workflows/stats.md
+++ b/gsd-ng/workflows/stats.md
@@ -13,7 +13,6 @@ Gather project statistics:
 
 ```bash
 STATS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" stats json)
-if [[ "$STATS" == @file:* ]]; then STATS=$(cat "${STATS#@file:}"); fi
 ```
 
 Extract fields from JSON: `milestone_version`, `milestone_name`, `phases`, `phases_completed`, `phases_total`, `total_plans`, `total_summaries`, `percent`, `plan_percent`, `requirements_total`, `requirements_complete`, `git_commits`, `git_first_commit_date`, `last_activity`.

--- a/gsd-ng/workflows/sync-issues.md
+++ b/gsd-ng/workflows/sync-issues.md
@@ -15,7 +15,7 @@ Read all files referenced by the invoking prompt's execution_context before star
 Detect configured platform:
 
 ```bash
-PLATFORM=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform --raw)
+PLATFORM=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-platform)
 ```
 
 Parse JSON for `platform`, `cli_installed`, `cli_install_url`.
@@ -37,7 +37,7 @@ Exit.
 Check issue tracker configuration:
 
 ```bash
-AUTO_SYNC=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" config-get issue_tracker.auto_sync --raw 2>/dev/null || echo "true")
+AUTO_SYNC=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" config-get issue_tracker.auto_sync --default "true")
 ```
 
 Read `issue_tracker.default_action` and `issue_tracker.comment_style` too. Display current config.
@@ -47,7 +47,7 @@ Read `issue_tracker.default_action` and `issue_tracker.comment_style` too. Displ
 Scan for external references:
 
 ```bash
-REFS=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-list-refs --raw)
+REFS=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-list-refs)
 ```
 
 If `count` is 0:
@@ -77,7 +77,7 @@ External Issue References:
 Execute sync:
 
 ```bash
-SYNC=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-sync --raw)
+SYNC=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" issue-sync)
 ```
 
 Parse JSON for `synced`, `conflicts`, `skipped`.

--- a/gsd-ng/workflows/transition.md
+++ b/gsd-ng/workflows/transition.md
@@ -243,7 +243,7 @@ After (Phase 2 shipped JWT auth, discovered rate limiting needed):
 Verify the updates are correct by reading STATE.md. If the progress bar needs updating, use:
 
 ```bash
-PROGRESS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" progress bar --raw)
+PROGRESS=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" progress bar)
 ```
 
 Update the progress bar line in STATE.md with the result.

--- a/gsd-ng/workflows/ui-phase.md
+++ b/gsd-ng/workflows/ui-phase.md
@@ -16,10 +16,8 @@ UI-SPEC.md locks spacing, typography, color, copywriting, and design system deci
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init plan-phase "$PHASE")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init plan-phase "$PHASE")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -34,14 +32,14 @@ Parse JSON for: `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded
 Resolve UI agent models:
 
 ```bash
-UI_RESEARCHER_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-ui-researcher --raw)
-UI_CHECKER_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-ui-checker --raw)
+UI_RESEARCHER_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-ui-researcher)
+UI_CHECKER_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-ui-checker)
 ```
 
 Check config:
 
 ```bash
-UI_ENABLED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.ui_phase 2>/dev/null || echo "true")
+UI_ENABLED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.ui_phase --default "true")
 ```
 
 **If `UI_ENABLED` is `false`:**

--- a/gsd-ng/workflows/ui-review.md
+++ b/gsd-ng/workflows/ui-review.md
@@ -14,10 +14,8 @@ Retroactive 6-pillar visual audit of implemented frontend code. Standalone comma
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -28,7 +26,7 @@ fi
 Parse: `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `commit_docs`.
 
 ```bash
-UI_AUDITOR_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-ui-auditor --raw)
+UI_AUDITOR_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-ui-auditor)
 ```
 
 Display banner:

--- a/gsd-ng/workflows/validate-phase.md
+++ b/gsd-ng/workflows/validate-phase.md
@@ -14,10 +14,8 @@ Audit Nyquist validation gaps for a completed phase. Generate missing tests. Upd
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -28,8 +26,8 @@ fi
 Parse: `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`.
 
 ```bash
-AUDITOR_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-nyquist-auditor --raw)
-NYQUIST_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.nyquist_validation --raw)
+AUDITOR_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-nyquist-auditor)
+NYQUIST_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.nyquist_validation)
 ```
 
 If `NYQUIST_CFG` is `false`: exit with "Nyquist validation is disabled. Enable via /gsd:settings."
@@ -95,8 +93,8 @@ Call AskUserQuestion with gap table and options:
 ## 5. Spawn gsd-nyquist-auditor
 
 ```bash
-WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type --raw 2>/dev/null || echo "standalone")
-WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace 2>/dev/null || echo '{"type":"standalone","signal":null,"submodule_paths":[]}')
+WORKSPACE_TYPE=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace --field type)
+WORKSPACE_JSON=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" detect-workspace)
 SUBMODULE_PATHS=$(node -e "try{const w=JSON.parse(process.argv[1]);const p=w.submodule_paths||[];process.stdout.write(p.join(', ')||'none')}catch{process.stdout.write('none')}" "$WORKSPACE_JSON")
 PROJECT_ROOT="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 ```

--- a/gsd-ng/workflows/verify-phase.md
+++ b/gsd-ng/workflows/verify-phase.md
@@ -29,10 +29,8 @@ Load phase operation context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init phase-op "${PHASE_ARG}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1
@@ -73,7 +71,7 @@ Aggregate all must_haves across plans for phase-level verification.
 If no must_haves in frontmatter (MUST_HAVES returns error or empty), check for Success Criteria:
 
 ```bash
-PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${phase_number}" --raw)
+PHASE_DATA=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${phase_number}" --json)
 ```
 
 Parse the `success_criteria` array from the JSON output. If non-empty:

--- a/gsd-ng/workflows/verify-work.md
+++ b/gsd-ng/workflows/verify-work.md
@@ -27,10 +27,8 @@ If $ARGUMENTS contains a phase number, load context:
 
 ```bash
 INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init verify-work "${PHASE_ARG}")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/dev/null; then
   INIT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" init verify-work "${PHASE_ARG}")
-  if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
   if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT"; then
     echo "Error: init failed twice. Check gsd-tools installation."
     exit 1

--- a/tests/arg-validation.test.cjs
+++ b/tests/arg-validation.test.cjs
@@ -1,7 +1,7 @@
 /**
  * GSD Tools Tests - Arg Validation
  *
- * Tests for ARG_SCHEMAS registry and validateSubcommandArgs() pre-dispatch validation.
+ * Tests for ARG_SCHEMAS registry and validateArgs() pre-dispatch validation.
  * Covers: flag in positional slot, equals syntax, count validation, unknown flags,
  * no-regression tests for valid commands, and schema coverage for all 14 namespaces.
  *
@@ -125,6 +125,15 @@ describe('arg validation - unknown flag', () => {
       `Expected "Unknown flag" in stderr, got: ${result.error}`
     );
   });
+
+  test('detect-workspace --bogus rejects with unknown flag error (top-level _self schema)', () => {
+    const result = runGsdTools('detect-workspace --bogus', tmpDir);
+    assert.strictEqual(result.success, false, 'Should exit non-zero');
+    assert.ok(
+      result.error.includes('Unknown flag'),
+      `Expected "Unknown flag" in stderr, got: ${result.error}`
+    );
+  });
 });
 
 // ─── No Regression ───────────────────────────────────────────────────────────
@@ -153,6 +162,12 @@ describe('arg validation - no regression', () => {
     );
     const result = runGsdTools('state load', tmpDir);
     assert.strictEqual(result.success, true, `Should succeed with state load, got error: ${result.error}`);
+  });
+
+  test('detect-workspace --field still succeeds (top-level with known flag)', () => {
+    const result = runGsdTools('detect-workspace --field type', tmpDir);
+    // detect-workspace should succeed (it detects current workspace)
+    assert.strictEqual(result.success, true, `Should succeed with valid flag, got error: ${result.error}`);
   });
 
   test('roadmap get-phase 44 still succeeds (one positional command)', () => {
@@ -187,11 +202,11 @@ describe('ARG_SCHEMAS coverage', () => {
       'todo', 'init', 'guard', 'test',
     ];
     // Check that each namespace appears in the ARG_SCHEMAS block
-    // (between 'const ARG_SCHEMAS' and 'function validateSubcommandArgs')
+    // (between 'const ARG_SCHEMAS' and 'function validateArgs')
     const schemasStart = source.indexOf('const ARG_SCHEMAS');
-    const schemasEnd = source.indexOf('function validateSubcommandArgs');
+    const schemasEnd = source.indexOf('function validateArgs');
     assert.ok(schemasStart !== -1, 'ARG_SCHEMAS should be defined');
-    assert.ok(schemasEnd !== -1, 'validateSubcommandArgs should be defined');
+    assert.ok(schemasEnd !== -1, 'validateArgs should be defined');
     const schemasBlock = source.slice(schemasStart, schemasEnd);
     for (const ns of expectedNamespaces) {
       assert.ok(
@@ -201,21 +216,46 @@ describe('ARG_SCHEMAS coverage', () => {
     }
   });
 
-  test('validateSubcommandArgs function exists in gsd-tools.cjs source', () => {
+  test('ARG_SCHEMAS contains _self entries for top-level commands', () => {
     const source = fs.readFileSync(TOOLS_PATH, 'utf-8');
+    const schemasStart = source.indexOf('const ARG_SCHEMAS');
+    const schemasEnd = source.indexOf('function validateArgs');
+    assert.ok(schemasStart !== -1 && schemasEnd !== -1, 'ARG_SCHEMAS and validateArgs should exist');
+    const schemasBlock = source.slice(schemasStart, schemasEnd);
+    // Verify _self entries exist for key top-level commands
+    const topLevelCommands = [
+      'commit', 'detect-workspace', 'git-context', 'squash',
+      'version-bump', 'divergence', 'cleanup', 'update',
+    ];
+    for (const cmd of topLevelCommands) {
+      assert.ok(
+        schemasBlock.includes(`'${cmd}'`),
+        `ARG_SCHEMAS should contain top-level command '${cmd}' with _self schema`
+      );
+    }
+    // Verify _self keys exist
+    const selfCount = (schemasBlock.match(/_self:/g) || []).length;
     assert.ok(
-      source.includes('function validateSubcommandArgs'),
-      'gsd-tools.cjs should define function validateSubcommandArgs'
+      selfCount >= 22,
+      `Expected at least 22 _self entries in ARG_SCHEMAS, got ${selfCount}`
     );
   });
 
-  test('validateSubcommandArgs called in all 14 compound command case blocks', () => {
+  test('validateArgs function exists in gsd-tools.cjs source', () => {
     const source = fs.readFileSync(TOOLS_PATH, 'utf-8');
-    // Count call sites: pattern is validateSubcommandArgs('commandname'
-    const callMatches = (source.match(/validateSubcommandArgs\('[a-z]/g) || []).length;
     assert.ok(
-      callMatches >= 14,
-      `Expected at least 14 validateSubcommandArgs call sites, got ${callMatches}`
+      source.includes('function validateArgs'),
+      'gsd-tools.cjs should define function validateArgs'
+    );
+  });
+
+  test('validateArgs called in all compound + top-level command case blocks', () => {
+    const source = fs.readFileSync(TOOLS_PATH, 'utf-8');
+    // Count call sites: pattern is validateArgs('commandname'
+    const callMatches = (source.match(/validateArgs\('[a-z]/g) || []).length;
+    assert.ok(
+      callMatches >= 36,
+      `Expected at least 36 validateArgs call sites (14 compound + 22 top-level), got ${callMatches}`
     );
   });
 });

--- a/tests/breakout.test.cjs
+++ b/tests/breakout.test.cjs
@@ -243,7 +243,7 @@ describe('cmdBreakoutCheck integration', () => {
     execSync('git add -A && git commit -m "feat(18-01): implement feature"', { cwd: tmpDir, stdio: 'pipe' });
 
     const result = runGsdTools(
-      ['breakout-check', '--plan', '18-01', '--declared-files', 'src/a.js,src/b.js'],
+      ['breakout-check', '--plan', '18-01', '--declared-files', 'src/a.js,src/b.js', '--json'],
       tmpDir
     );
 

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -21,7 +21,7 @@ describe('history-digest command', () => {
   });
 
   test('empty phases directory returns valid schema', () => {
-    const result = runGsdTools('history-digest', tmpDir);
+    const result = runGsdTools('history-digest --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const digest = JSON.parse(result.output);
@@ -62,7 +62,7 @@ key-decisions:
 
     fs.writeFileSync(path.join(phaseDir, '01-01-SUMMARY.md'), summaryContent);
 
-    const result = runGsdTools('history-digest', tmpDir);
+    const result = runGsdTools('history-digest --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const digest = JSON.parse(result.output);
@@ -144,7 +144,7 @@ tech-stack:
 `
     );
 
-    const result = runGsdTools('history-digest', tmpDir);
+    const result = runGsdTools('history-digest --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const digest = JSON.parse(result.output);
@@ -192,7 +192,7 @@ broken: [unclosed
 `
     );
 
-    const result = runGsdTools('history-digest', tmpDir);
+    const result = runGsdTools('history-digest --json', tmpDir);
     assert.ok(result.success, `Command should succeed despite malformed files: ${result.error}`);
 
     const digest = JSON.parse(result.output);
@@ -217,7 +217,7 @@ provides:
 `
     );
 
-    const result = runGsdTools('history-digest', tmpDir);
+    const result = runGsdTools('history-digest --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const digest = JSON.parse(result.output);
@@ -242,7 +242,7 @@ patterns-established: ["Pattern X", "Pattern Y"]
 `
     );
 
-    const result = runGsdTools('history-digest', tmpDir);
+    const result = runGsdTools('history-digest --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const digest = JSON.parse(result.output);
@@ -276,7 +276,7 @@ describe('summary-extract command', () => {
   });
 
   test('missing file returns error', () => {
-    const result = runGsdTools('summary-extract .planning/phases/01-test/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-test/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -315,7 +315,7 @@ Full summary content here.
 `
     );
 
-    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -351,7 +351,7 @@ requirements-completed:
 `
     );
 
-    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --fields one_liner,key_files,requirements_completed', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --fields one_liner,key_files,requirements_completed --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -386,7 +386,7 @@ key-files:
 `
     );
 
-    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -408,7 +408,7 @@ one-liner: Minimal summary
 `
     );
 
-    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -434,7 +434,7 @@ key-decisions:
 `
     );
 
-    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -472,7 +472,7 @@ describe('progress command', () => {
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Done');
     fs.writeFileSync(path.join(p1, '01-02-PLAN.md'), '# Plan 2');
 
-    const result = runGsdTools('progress json', tmpDir);
+    const result = runGsdTools('progress json --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -493,7 +493,7 @@ describe('progress command', () => {
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Done');
 
-    const result = runGsdTools('progress bar --raw', tmpDir);
+    const result = runGsdTools('progress bar', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.ok(result.output.includes('1/1'), 'should include count');
     assert.ok(result.output.includes('100%'), 'should include 100%');
@@ -508,7 +508,7 @@ describe('progress command', () => {
     fs.mkdirSync(p1, { recursive: true });
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
 
-    const result = runGsdTools('progress table --raw', tmpDir);
+    const result = runGsdTools('progress table', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.ok(result.output.includes('Phase'), 'should have table header');
     assert.ok(result.output.includes('foundation'), 'should include phase name');
@@ -527,16 +527,16 @@ describe('progress command', () => {
     fs.writeFileSync(path.join(p1, '01-02-SUMMARY.md'), '# Orphaned summary');
 
     // bar format - should not crash with RangeError
-    const barResult = runGsdTools('progress bar --raw', tmpDir);
+    const barResult = runGsdTools('progress bar', tmpDir);
     assert.ok(barResult.success, `Bar format crashed: ${barResult.error}`);
     assert.ok(barResult.output.includes('100%'), 'percent should be clamped to 100%');
 
     // table format - should not crash with RangeError
-    const tableResult = runGsdTools('progress table --raw', tmpDir);
+    const tableResult = runGsdTools('progress table', tmpDir);
     assert.ok(tableResult.success, `Table format crashed: ${tableResult.error}`);
 
     // json format - percent should be clamped
-    const jsonResult = runGsdTools('progress json', tmpDir);
+    const jsonResult = runGsdTools('progress json --json', tmpDir);
     assert.ok(jsonResult.success, `JSON format crashed: ${jsonResult.error}`);
     const output = JSON.parse(jsonResult.output);
     assert.ok(output.percent <= 100, `percent should be <= 100 but got ${output.percent}`);
@@ -567,7 +567,7 @@ describe('todo complete command', () => {
       `title: Add dark mode\narea: ui\ncreated: 2025-01-01\n`
     );
 
-    const result = runGsdTools('todo complete add-dark-mode.md', tmpDir);
+    const result = runGsdTools('todo complete add-dark-mode.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -617,7 +617,7 @@ describe('scaffold command', () => {
   test('scaffolds context file', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-api'), { recursive: true });
 
-    const result = runGsdTools('scaffold context --phase 3', tmpDir);
+    const result = runGsdTools('scaffold context --phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -636,7 +636,7 @@ describe('scaffold command', () => {
   test('scaffolds UAT file', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-api'), { recursive: true });
 
-    const result = runGsdTools('scaffold uat --phase 3', tmpDir);
+    const result = runGsdTools('scaffold uat --phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -653,7 +653,7 @@ describe('scaffold command', () => {
   test('scaffolds verification file', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-api'), { recursive: true });
 
-    const result = runGsdTools('scaffold verification --phase 3', tmpDir);
+    const result = runGsdTools('scaffold verification --phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -667,7 +667,7 @@ describe('scaffold command', () => {
   });
 
   test('scaffolds phase directory', () => {
-    const result = runGsdTools('scaffold phase-dir --phase 5 --name User Dashboard', tmpDir);
+    const result = runGsdTools('scaffold phase-dir --phase 5 --name User Dashboard --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -683,7 +683,7 @@ describe('scaffold command', () => {
     fs.mkdirSync(phaseDir, { recursive: true });
     fs.writeFileSync(path.join(phaseDir, '03-CONTEXT.md'), '# Existing content');
 
-    const result = runGsdTools('scaffold context --phase 3', tmpDir);
+    const result = runGsdTools('scaffold context --phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -708,7 +708,7 @@ describe('generate-slug command', () => {
   });
 
   test('converts normal text to slug', () => {
-    const result = runGsdTools('generate-slug "Hello World"', tmpDir);
+    const result = runGsdTools('generate-slug "Hello World" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -716,7 +716,7 @@ describe('generate-slug command', () => {
   });
 
   test('strips special characters', () => {
-    const result = runGsdTools('generate-slug "Test@#$%^Special!!!"', tmpDir);
+    const result = runGsdTools('generate-slug "Test@#$%^Special!!!" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -724,7 +724,7 @@ describe('generate-slug command', () => {
   });
 
   test('preserves numbers', () => {
-    const result = runGsdTools('generate-slug "Phase 3 Plan"', tmpDir);
+    const result = runGsdTools('generate-slug "Phase 3 Plan" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -732,7 +732,7 @@ describe('generate-slug command', () => {
   });
 
   test('strips leading and trailing hyphens', () => {
-    const result = runGsdTools('generate-slug "---leading-trailing---"', tmpDir);
+    const result = runGsdTools('generate-slug "---leading-trailing---" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -762,7 +762,7 @@ describe('current-timestamp command', () => {
   });
 
   test('date format returns YYYY-MM-DD', () => {
-    const result = runGsdTools('current-timestamp date', tmpDir);
+    const result = runGsdTools('current-timestamp date --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -770,7 +770,7 @@ describe('current-timestamp command', () => {
   });
 
   test('filename format returns ISO without colons or fractional seconds', () => {
-    const result = runGsdTools('current-timestamp filename', tmpDir);
+    const result = runGsdTools('current-timestamp filename --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -778,7 +778,7 @@ describe('current-timestamp command', () => {
   });
 
   test('full format returns full ISO string', () => {
-    const result = runGsdTools('current-timestamp full', tmpDir);
+    const result = runGsdTools('current-timestamp full --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -786,7 +786,7 @@ describe('current-timestamp command', () => {
   });
 
   test('default (no format) returns full ISO string', () => {
-    const result = runGsdTools('current-timestamp', tmpDir);
+    const result = runGsdTools('current-timestamp --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -810,7 +810,7 @@ describe('list-todos command', () => {
   });
 
   test('empty directory returns zero count', () => {
-    const result = runGsdTools('list-todos', tmpDir);
+    const result = runGsdTools('list-todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -825,7 +825,7 @@ describe('list-todos command', () => {
     fs.writeFileSync(path.join(pendingDir, 'add-tests.md'), 'title: Add unit tests\narea: testing\ncreated: 2026-01-15\n');
     fs.writeFileSync(path.join(pendingDir, 'fix-bug.md'), 'title: Fix login bug\narea: auth\ncreated: 2026-01-20\n');
 
-    const result = runGsdTools('list-todos', tmpDir);
+    const result = runGsdTools('list-todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -846,7 +846,7 @@ describe('list-todos command', () => {
     fs.writeFileSync(path.join(pendingDir, 'ui-task.md'), 'title: UI task\narea: ui\ncreated: 2026-01-01\n');
     fs.writeFileSync(path.join(pendingDir, 'api-task.md'), 'title: API task\narea: api\ncreated: 2026-01-01\n');
 
-    const result = runGsdTools('list-todos ui', tmpDir);
+    const result = runGsdTools('list-todos ui --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -860,7 +860,7 @@ describe('list-todos command', () => {
 
     fs.writeFileSync(path.join(pendingDir, 'task.md'), 'title: Some task\narea: backend\ncreated: 2026-01-01\n');
 
-    const result = runGsdTools('list-todos nonexistent-area', tmpDir);
+    const result = runGsdTools('list-todos nonexistent-area --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -874,7 +874,7 @@ describe('list-todos command', () => {
     // File with no title or area fields
     fs.writeFileSync(path.join(pendingDir, 'malformed.md'), 'some random content\nno fields here\n');
 
-    const result = runGsdTools('list-todos', tmpDir);
+    const result = runGsdTools('list-todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -903,7 +903,7 @@ describe('verify-path-exists command', () => {
   test('existing file returns exists=true with type=file', () => {
     fs.writeFileSync(path.join(tmpDir, 'test-file.txt'), 'hello');
 
-    const result = runGsdTools('verify-path-exists test-file.txt', tmpDir);
+    const result = runGsdTools('verify-path-exists test-file.txt --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -914,7 +914,7 @@ describe('verify-path-exists command', () => {
   test('existing directory returns exists=true with type=directory', () => {
     fs.mkdirSync(path.join(tmpDir, 'test-dir'), { recursive: true });
 
-    const result = runGsdTools('verify-path-exists test-dir', tmpDir);
+    const result = runGsdTools('verify-path-exists test-dir --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -923,7 +923,7 @@ describe('verify-path-exists command', () => {
   });
 
   test('missing path returns exists=false', () => {
-    const result = runGsdTools('verify-path-exists nonexistent/path', tmpDir);
+    const result = runGsdTools('verify-path-exists nonexistent/path --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -935,7 +935,7 @@ describe('verify-path-exists command', () => {
     const absFile = path.join(tmpDir, 'abs-test.txt');
     fs.writeFileSync(absFile, 'content');
 
-    const result = runGsdTools(`verify-path-exists ${absFile}`, tmpDir);
+    const result = runGsdTools(`verify-path-exists ${absFile} --json`, tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -966,7 +966,7 @@ describe('resolve-model command', () => {
   });
 
   test('known agent returns model and profile without unknown_agent', () => {
-    const result = runGsdTools('resolve-model gsd-planner', tmpDir);
+    const result = runGsdTools('resolve-model gsd-planner --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -976,7 +976,7 @@ describe('resolve-model command', () => {
   });
 
   test('unknown agent returns unknown_agent=true', () => {
-    const result = runGsdTools('resolve-model fake-nonexistent-agent', tmpDir);
+    const result = runGsdTools('resolve-model fake-nonexistent-agent --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -985,7 +985,7 @@ describe('resolve-model command', () => {
 
   test('default profile fallback when no config exists', () => {
     // tmpDir has no config.json, so defaults to balanced profile
-    const result = runGsdTools('resolve-model gsd-executor', tmpDir);
+    const result = runGsdTools('resolve-model gsd-executor --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1024,7 +1024,7 @@ describe('commit command', () => {
       JSON.stringify({ commit_docs: false })
     );
 
-    const result = runGsdTools('commit "test message"', tmpDir);
+    const result = runGsdTools('commit "test message" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1038,7 +1038,7 @@ describe('commit command', () => {
     execSync('git add .gitignore', { cwd: tmpDir, stdio: 'pipe' });
     execSync('git commit -m "add gitignore"', { cwd: tmpDir, stdio: 'pipe' });
 
-    const result = runGsdTools('commit "test message"', tmpDir);
+    const result = runGsdTools('commit "test message" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1048,7 +1048,7 @@ describe('commit command', () => {
 
   test('handles nothing to commit', () => {
     // Don't modify any files after initial commit
-    const result = runGsdTools('commit "test message"', tmpDir);
+    const result = runGsdTools('commit "test message" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1060,7 +1060,7 @@ describe('commit command', () => {
     // Create a new file in .planning/
     fs.writeFileSync(path.join(tmpDir, '.planning', 'test-file.md'), '# Test\n');
 
-    const result = runGsdTools('commit "test: add test file" --files .planning/test-file.md', tmpDir);
+    const result = runGsdTools('commit "test: add test file" --files .planning/test-file.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1083,7 +1083,7 @@ describe('commit command', () => {
     // Modify the file and amend
     fs.writeFileSync(path.join(tmpDir, '.planning', 'amend-file.md'), '# Amended\n');
 
-    const result = runGsdTools('commit "ignored" --files .planning/amend-file.md --amend', tmpDir);
+    const result = runGsdTools('commit "ignored" --files .planning/amend-file.md --amend --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1101,6 +1101,7 @@ describe('commit command', () => {
 
 describe('websearch command', () => {
   const { cmdWebsearch } = require('../gsd-ng/bin/lib/commands.cjs');
+  const { setJsonMode } = require('../gsd-ng/bin/lib/core.cjs');
   let origFetch;
   let origApiKey;
   let origFsWriteSync;
@@ -1113,6 +1114,7 @@ describe('websearch command', () => {
     origFsWriteSync = fs.writeSync.bind(fs);
     origStdoutWrite = process.stdout.write.bind(process.stdout);
     captured = '';
+    setJsonMode(true);  // websearch tests expect JSON output
     // Intercept both fs.writeSync(1,...) and process.stdout.write to capture output()
     fs.writeSync = (fd, data, ...rest) => {
       if (fd === 1) { captured += String(data); return data.length; }
@@ -1130,12 +1132,13 @@ describe('websearch command', () => {
     }
     fs.writeSync = origFsWriteSync;
     process.stdout.write = origStdoutWrite;
+    setJsonMode(false);
   });
 
   test('returns available=false when BRAVE_API_KEY is unset', async () => {
     delete process.env.BRAVE_API_KEY;
 
-    await cmdWebsearch('test query', {}, false);
+    await cmdWebsearch('test query', {});
 
     const output = JSON.parse(captured);
     assert.strictEqual(output.available, false);
@@ -1145,7 +1148,7 @@ describe('websearch command', () => {
   test('returns error when no query provided', async () => {
     process.env.BRAVE_API_KEY = 'test-key';
 
-    await cmdWebsearch(null, {}, false);
+    await cmdWebsearch(null, {});
 
     const output = JSON.parse(captured);
     assert.strictEqual(output.available, false);
@@ -1166,7 +1169,7 @@ describe('websearch command', () => {
       }),
     });
 
-    await cmdWebsearch('test query', { limit: 5, freshness: 'pd' }, false);
+    await cmdWebsearch('test query', { limit: 5, freshness: 'pd' });
 
     const output = JSON.parse(captured);
     assert.strictEqual(output.available, true);
@@ -1189,7 +1192,7 @@ describe('websearch command', () => {
       };
     };
 
-    await cmdWebsearch('node.js testing', { limit: 5, freshness: 'pd' }, false);
+    await cmdWebsearch('node.js testing', { limit: 5, freshness: 'pd' });
 
     const parsed = new URL(capturedUrl);
     assert.strictEqual(parsed.searchParams.get('q'), 'node.js testing', 'query param should decode to original string');
@@ -1205,7 +1208,7 @@ describe('websearch command', () => {
       status: 429,
     });
 
-    await cmdWebsearch('test query', {}, false);
+    await cmdWebsearch('test query', {});
 
     const output = JSON.parse(captured);
     assert.strictEqual(output.available, false);
@@ -1219,7 +1222,7 @@ describe('websearch command', () => {
       throw new Error('Network timeout');
     };
 
-    await cmdWebsearch('test query', {}, false);
+    await cmdWebsearch('test query', {});
 
     const output = JSON.parse(captured);
     assert.strictEqual(output.available, false);
@@ -1239,7 +1242,7 @@ describe('stats command', () => {
   });
 
   test('returns valid JSON with empty project', () => {
-    const result = runGsdTools('stats', tmpDir);
+    const result = runGsdTools('stats --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const stats = JSON.parse(result.output);
@@ -1268,7 +1271,7 @@ describe('stats command', () => {
     // Phase 2: 1 plan, 0 summaries (planned)
     fs.writeFileSync(path.join(p2, '02-01-PLAN.md'), '# Plan');
 
-    const result = runGsdTools('stats', tmpDir);
+    const result = runGsdTools('stats --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const stats = JSON.parse(result.output);
@@ -1294,7 +1297,7 @@ describe('stats command', () => {
 `
     );
 
-    const result = runGsdTools('stats', tmpDir);
+    const result = runGsdTools('stats --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const stats = JSON.parse(result.output);
@@ -1308,7 +1311,7 @@ describe('stats command', () => {
       `# State\n\n**Current Phase:** 01\n**Status:** In progress\n**Last Activity:** 2025-06-15\n**Last Activity Description:** Working\n`
     );
 
-    const result = runGsdTools('stats', tmpDir);
+    const result = runGsdTools('stats --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const stats = JSON.parse(result.output);
@@ -1321,7 +1324,7 @@ describe('stats command', () => {
       `# Project State\n\n## Current Position\n\nPhase: 1 of 2 (Foundation)\nPlan: 1 of 1 in current phase\nStatus: In progress\nLast activity: 2025-06-16 — Finished plan 01-01\n`
     );
 
-    const result = runGsdTools('stats', tmpDir);
+    const result = runGsdTools('stats --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const stats = JSON.parse(result.output);
@@ -1359,7 +1362,7 @@ describe('stats command', () => {
 `
     );
 
-    const result = runGsdTools('stats', tmpDir);
+    const result = runGsdTools('stats --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const stats = JSON.parse(result.output);
@@ -1406,7 +1409,7 @@ describe('stats command', () => {
       },
     });
 
-    const result = runGsdTools('stats', tmpDir);
+    const result = runGsdTools('stats --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const stats = JSON.parse(result.output);
@@ -1420,7 +1423,7 @@ describe('stats command', () => {
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
 
-    const result = runGsdTools('stats table', tmpDir);
+    const result = runGsdTools('stats table --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const parsed = JSON.parse(result.output);
@@ -1462,7 +1465,7 @@ describe('cmdSquash command', () => {
   afterEach(() => { cleanup(tmpDir); });
 
   test('--dry-run single strategy returns plan without executing', () => {
-    const result = runGsdTools(['squash', '14', '--strategy', 'single', '--dry-run'], tmpDir);
+    const result = runGsdTools(['squash', '14', '--strategy', 'single', '--dry-run', '--json'], tmpDir);
     assert.ok(result.success, `Failed: ${result.error}`);
     const out = JSON.parse(result.output);
     assert.strictEqual(out.dry_run, true);
@@ -1490,7 +1493,7 @@ describe('cmdSquash command', () => {
   test('list-backup-tags returns gsd backup tags', () => {
     // Create a tag first
     execSync('git tag gsd/backup/2026-03-16/main', { cwd: tmpDir, stdio: 'pipe' });
-    const result = runGsdTools(['squash', '--list-backup-tags'], tmpDir);
+    const result = runGsdTools(['squash', '--list-backup-tags', '--json'], tmpDir);
     assert.ok(result.success, `Failed: ${result.error}`);
     const out = JSON.parse(result.output);
     assert.ok(out.tags.length > 0, 'should list at least one tag');
@@ -1770,7 +1773,7 @@ describe('divergence command', () => {
 
   test('returns no_upstream when no upstream remote exists', () => {
     // createTempProject() creates a non-git project, so no upstream remote
-    const result = runGsdTools('divergence', tmpDir);
+    const result = runGsdTools('divergence --json', tmpDir);
     assert.ok(result.success, `Command should not crash: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1782,13 +1785,13 @@ describe('divergence command', () => {
     const { cmdDivergence } = require('../gsd-ng/bin/lib/commands.cjs');
     const { stdout, stderr, exited } = callExpectingError(() => {
       // Use a temp dir that has no upstream — if no upstream, early exit before validation
-      cmdDivergence(tmpDir, { triage: 'abc1234', status: 'skipped', reason: '' }, false);
+      cmdDivergence(tmpDir, { triage: 'abc1234', status: 'skipped', reason: '' });
     });
 
     // Should either: produce an error about reason (if upstream exists), OR exit early with
     // no_upstream (which is valid when no upstream is configured in the test environment)
     assert.ok(
-      exited || stderr.includes('Reason required') || stderr.includes('skipped') || stdout.includes('no_upstream'),
+      exited || stderr.includes('Reason required') || stderr.includes('skipped') || stdout.includes('no_upstream') || stdout.includes('No') ,
       `Expected error about reason or no_upstream exit, got stdout: ${stdout}, stderr: ${stderr}`
     );
   });
@@ -1836,7 +1839,7 @@ describe('divergence command', () => {
 
   test('--init exits 0 in non-git project (no upstream/main ref)', () => {
     // Non-git project with upstream remote set but no git history — should handle gracefully
-    const result = runGsdTools('divergence --init', tmpDir);
+    const result = runGsdTools('divergence --init --json', tmpDir);
     // Either no_upstream (no git repo) or initialized (0 commits) — either is acceptable
     assert.ok(result.success, `Should exit 0: ${result.error}`);
     const output = JSON.parse(result.output);
@@ -1848,7 +1851,7 @@ describe('divergence command', () => {
     // Non-git project: git rev-parse fails, so branch not found error returned
     const { cmdDivergence } = require('../gsd-ng/bin/lib/commands.cjs');
     const { stderr, exited } = callExpectingError(() => {
-      cmdDivergence(tmpDir, { branch: 'feature/nonexistent' }, false);
+      cmdDivergence(tmpDir, { branch: 'feature/nonexistent' });
     });
     // Either exited (process.exit called) or wrote error about branch not found
     assert.ok(exited || stderr.includes('not found') || stderr.includes('nonexistent'),
@@ -1879,7 +1882,7 @@ describe('divergence command', () => {
     const { cmdDivergence } = require('../gsd-ng/bin/lib/commands.cjs');
     const { stderr, exited } = callExpectingError(() => {
       // branch mode with triage but invalid status
-      cmdDivergence(tmpDir, { branch: 'feature/test', base: 'main', triage: 'abc1234', status: 'invalid-status', reason: '' }, false);
+      cmdDivergence(tmpDir, { branch: 'feature/test', base: 'main', triage: 'abc1234', status: 'invalid-status', reason: '' });
     });
     // Should error about branch not found (before reaching triage validation)
     // OR error about invalid status if branch check is bypassed in tests
@@ -1904,12 +1907,12 @@ describe('divergence command', () => {
   test('upstream triage: adapted status without reason produces error', () => {
     const { cmdDivergence } = require('../gsd-ng/bin/lib/commands.cjs');
     const { stdout, stderr, exited } = callExpectingError(() => {
-      cmdDivergence(tmpDir, { triage: 'abc1234', status: 'adapted', reason: '' }, false);
+      cmdDivergence(tmpDir, { triage: 'abc1234', status: 'adapted', reason: '' });
     });
 
     // Either produces an error (validation reached) or exits early with no_upstream
     assert.ok(
-      exited || stderr.includes('Reason required') || stderr.includes('adapted') || stdout.includes('no_upstream'),
+      exited || stderr.includes('Reason required') || stderr.includes('adapted') || stdout.includes('no_upstream') || stdout.includes('No'),
       `Expected error requiring reason or no_upstream exit, got stdout: ${stdout}, stderr: ${stderr}`
     );
   });
@@ -1918,7 +1921,7 @@ describe('divergence command', () => {
     const { cmdDivergence } = require('../gsd-ng/bin/lib/commands.cjs');
     const { stderr, exited } = callExpectingError(() => {
       // Branch mode: pass branch + base + triage + status=adapted with no reason
-      cmdDivergence(tmpDir, { branch: 'feature/test', base: 'main', triage: 'abc1234', status: 'adapted', reason: '' }, false);
+      cmdDivergence(tmpDir, { branch: 'feature/test', base: 'main', triage: 'abc1234', status: 'adapted', reason: '' });
     });
 
     // Either exited (branch not found) or errors about reason requirement
@@ -1929,7 +1932,7 @@ describe('divergence command', () => {
 
 describe('help command', () => {
   test('returns a commands array with 10+ entries', () => {
-    const result = runGsdTools('help', process.cwd());
+    const result = runGsdTools('help --json', process.cwd());
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1938,7 +1941,7 @@ describe('help command', () => {
   });
 
   test('each entry has name and description fields', () => {
-    const result = runGsdTools('help', process.cwd());
+    const result = runGsdTools('help --json', process.cwd());
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1949,7 +1952,7 @@ describe('help command', () => {
   });
 
   test('known commands are discoverable', () => {
-    const result = runGsdTools('help', process.cwd());
+    const result = runGsdTools('help --json', process.cwd());
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1960,7 +1963,7 @@ describe('help command', () => {
   });
 
   test('commands are sorted alphabetically by name', () => {
-    const result = runGsdTools('help', process.cwd());
+    const result = runGsdTools('help --json', process.cwd());
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -2178,7 +2181,7 @@ describe('discoverTestCommand', () => {
           path.join(projDir, 'package.json'),
           JSON.stringify({ scripts: { test: 'node --test' } })
         );
-        const result = runGsdTools(['discover-test-command'], projDir);
+        const result = runGsdTools(['discover-test-command', '--json'], projDir);
         assert.ok(result.success, `CLI failed: ${result.error}`);
         const parsed = JSON.parse(result.output);
         assert.deepStrictEqual(parsed, [{ dir: '.', command: 'npm test' }]);
@@ -2195,7 +2198,7 @@ describe('discoverTestCommand', () => {
       const setResult = runGsdTools(['config-set', 'verification.test_command', 'make test'], projDir);
       assert.ok(setResult.success, `config-set failed: ${setResult.error}`);
 
-      const getResult = runGsdTools(['config-get', 'verification.test_command', '--raw'], projDir);
+      const getResult = runGsdTools(['config-get', 'verification.test_command'], projDir);
       assert.ok(getResult.success, `config-get failed: ${getResult.error}`);
       assert.strictEqual(getResult.output, 'make test');
     } finally {
@@ -2360,10 +2363,10 @@ describe('divergence helpers', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// detect-platform --field --raw
+// detect-platform --field
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('detect-platform --field --raw', () => {
+describe('detect-platform --field', () => {
   let tmpDir;
 
   beforeEach(() => {
@@ -2386,12 +2389,12 @@ describe('detect-platform --field --raw', () => {
     cleanup(tmpDir);
   });
 
-  test('detect-platform --field platform --raw returns plain string', () => {
+  test('detect-platform --field platform returns plain string', () => {
     const { execFileSync } = require('child_process');
     const TOOLS_PATH = path.join(__dirname, '..', 'gsd-ng', 'bin', 'gsd-tools.cjs');
     let out;
     try {
-      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'platform', '--raw'], {
+      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'platform'], {
         cwd: tmpDir,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -2403,12 +2406,12 @@ describe('detect-platform --field --raw', () => {
     assert.ok(!out.startsWith('{'), 'output must not be JSON');
   });
 
-  test('detect-platform --field source --raw returns plain string', () => {
+  test('detect-platform --field source returns plain string', () => {
     const { execFileSync } = require('child_process');
     const TOOLS_PATH = path.join(__dirname, '..', 'gsd-ng', 'bin', 'gsd-tools.cjs');
     let out;
     try {
-      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'source', '--raw'], {
+      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'source'], {
         cwd: tmpDir,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -2420,12 +2423,12 @@ describe('detect-platform --field --raw', () => {
     assert.ok(!out.startsWith('{'), 'output must not be JSON');
   });
 
-  test('detect-platform --field cli_installed --raw returns true or false string', () => {
+  test('detect-platform --field cli_installed returns true or false string', () => {
     const { execFileSync } = require('child_process');
     const TOOLS_PATH = path.join(__dirname, '..', 'gsd-ng', 'bin', 'gsd-tools.cjs');
     let out;
     try {
-      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'cli_installed', '--raw'], {
+      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'cli_installed'], {
         cwd: tmpDir,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -2436,12 +2439,12 @@ describe('detect-platform --field --raw', () => {
     assert.ok(out === 'true' || out === 'false', `cli_installed must be "true" or "false", got: ${out}`);
   });
 
-  test('detect-platform --field cli --raw returns CLI name string', () => {
+  test('detect-platform --field cli returns CLI name string', () => {
     const { execFileSync } = require('child_process');
     const TOOLS_PATH = path.join(__dirname, '..', 'gsd-ng', 'bin', 'gsd-tools.cjs');
     let out;
     try {
-      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'cli', '--raw'], {
+      out = execFileSync(process.execPath, [TOOLS_PATH, 'detect-platform', '--field', 'cli'], {
         cwd: tmpDir,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
@@ -2456,10 +2459,10 @@ describe('detect-platform --field --raw', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// version-bump --field --raw
+// version-bump --field
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('version-bump --field --raw', () => {
+describe('version-bump --field', () => {
   let tmpDir;
 
   beforeEach(() => {
@@ -2481,8 +2484,8 @@ describe('version-bump --field --raw', () => {
     cleanup(tmpDir);
   });
 
-  test('version-bump --level patch --field version --raw returns plain version string', () => {
-    const result = runGsdTools(['version-bump', '--level', 'patch', '--field', 'version', '--raw'], tmpDir);
+  test('version-bump --level patch --field version returns plain version string', () => {
+    const result = runGsdTools(['version-bump', '--level', 'patch', '--field', 'version'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, '1.0.1', 'should return plain version string for patch bump');
     assert.ok(!result.output.startsWith('{'), 'output must not be JSON');
@@ -2504,14 +2507,14 @@ describe('resolve-type-alias command', () => {
     cleanup(tmpDir);
   });
 
-  test('resolve-type-alias feat --raw returns default alias (feature)', () => {
-    const result = runGsdTools(['resolve-type-alias', 'feat', '--raw'], tmpDir);
+  test('resolve-type-alias feat returns default alias (feature)', () => {
+    const result = runGsdTools(['resolve-type-alias', 'feat'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'feature', 'feat should resolve to feature by default');
   });
 
-  test('resolve-type-alias fix --raw returns default alias (bugfix)', () => {
-    const result = runGsdTools(['resolve-type-alias', 'fix', '--raw'], tmpDir);
+  test('resolve-type-alias fix returns default alias (bugfix)', () => {
+    const result = runGsdTools(['resolve-type-alias', 'fix'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'bugfix', 'fix should resolve to bugfix by default');
   });
@@ -2526,23 +2529,23 @@ describe('resolve-type-alias command', () => {
       path.join(tmpDir, '.planning', 'config.json'),
       JSON.stringify(config, null, 2)
     );
-    const result = runGsdTools(['resolve-type-alias', 'feat', '--raw'], tmpDir);
+    const result = runGsdTools(['resolve-type-alias', 'feat'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'new-feature', 'should use config alias');
   });
 
   test('resolve-type-alias unknown type returns type itself', () => {
-    const result = runGsdTools(['resolve-type-alias', 'docs', '--raw'], tmpDir);
+    const result = runGsdTools(['resolve-type-alias', 'docs'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'docs', 'unknown type should return itself');
   });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// config-get --raw (regression check for scalar extraction)
+// config-get (regression check for scalar extraction)
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('config-get --raw scalar extraction', () => {
+describe('config-get scalar extraction', () => {
   let tmpDir;
 
   beforeEach(() => {
@@ -2558,8 +2561,8 @@ describe('config-get --raw scalar extraction', () => {
     cleanup(tmpDir);
   });
 
-  test('config-get git.remote --raw returns plain string "origin"', () => {
-    const result = runGsdTools(['config-get', 'git.remote', '--raw'], tmpDir);
+  test('config-get git.remote returns plain string "origin"', () => {
+    const result = runGsdTools(['config-get', 'git.remote'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'origin', 'git.remote should return "origin"');
     assert.ok(!result.output.startsWith('{'), 'output must not be JSON');
@@ -2729,7 +2732,7 @@ describe('cleanup command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-foundation'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-auth'), { recursive: true });
 
-    const result = runGsdTools(['cleanup', '--dry-run'], tmpDir);
+    const result = runGsdTools(['cleanup', '--dry-run', '--json'], tmpDir);
     assert.ok(result.success, 'cleanup dry-run should succeed: ' + result.error);
 
     const parsed = JSON.parse(result.output);
@@ -2753,7 +2756,7 @@ describe('cleanup command', () => {
       '# Roadmap v1.0\n\n## Phase 1: Foundation\n'
     );
 
-    const result = runGsdTools(['cleanup', '--dry-run'], tmpDir);
+    const result = runGsdTools(['cleanup', '--dry-run', '--json'], tmpDir);
     assert.ok(result.success, 'cleanup dry-run should succeed: ' + result.error);
 
     const parsed = JSON.parse(result.output);
@@ -2773,7 +2776,7 @@ describe('cleanup command', () => {
     );
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-foundation'), { recursive: true });
 
-    const result = runGsdTools(['cleanup'], tmpDir);
+    const result = runGsdTools(['cleanup', '--json'], tmpDir);
     assert.ok(result.success, 'cleanup execute should succeed: ' + result.error);
 
     const destDir = path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases');
@@ -2789,7 +2792,7 @@ describe('cleanup command', () => {
   // Test 4: missing MILESTONES.md returns error-shaped result, not throw
   test('missing MILESTONES.md returns error-shaped JSON result without crashing', () => {
     // No MILESTONES.md created
-    const result = runGsdTools(['cleanup', '--dry-run'], tmpDir);
+    const result = runGsdTools(['cleanup', '--dry-run', '--json'], tmpDir);
     assert.ok(result.success, 'cleanup should exit 0 even with missing MILESTONES.md: ' + result.error);
 
     const parsed = JSON.parse(result.output);
@@ -2804,7 +2807,7 @@ describe('cleanup command', () => {
     );
     // No v1.0-ROADMAP.md created — missing snapshot
 
-    const result = runGsdTools(['cleanup', '--dry-run'], tmpDir);
+    const result = runGsdTools(['cleanup', '--dry-run', '--json'], tmpDir);
     assert.ok(result.success, 'cleanup should succeed even with missing ROADMAP snapshot: ' + result.error);
 
     const parsed = JSON.parse(result.output);
@@ -2830,7 +2833,7 @@ describe('cleanup command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-foundation'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-auth'), { recursive: true });
 
-    const result = runGsdTools(['cleanup', '--dry-run'], tmpDir);
+    const result = runGsdTools(['cleanup', '--dry-run', '--json'], tmpDir);
     assert.ok(result.success, 'cleanup should succeed: ' + result.error);
 
     const parsed = JSON.parse(result.output);
@@ -2967,5 +2970,273 @@ describe('update command', () => {
     assert.strictEqual(parsed.status, 'updated');
     assert.ok(parsed.install_command, 'should record install_command for test verification');
     assert.ok(parsed.install_command.includes('gsd-ng'), 'install_command should reference package');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// staleness-check --count flag
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('staleness-check --count flag', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('staleness-check --count returns "0" when no codebase docs exist', () => {
+    // No .planning/codebase directory — should return 0 stale
+    const result = runGsdTools(['staleness-check', '--count'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output, '0', 'should return integer 0 as string');
+  });
+
+  test('staleness-check --count returns integer N when N docs are stale', () => {
+    // Create a codebase doc with a commit hash that won't exist in the repo
+    const codebaseDir = path.join(tmpDir, '.planning', 'codebase');
+    fs.mkdirSync(codebaseDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(codebaseDir, 'overview.md'),
+      '---\nlast_mapped_commit: deadbeef1234567890abcdef1234567890abcdef\n---\n\n# Overview\n'
+    );
+
+    const result = runGsdTools(['staleness-check', '--count'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    // The doc has a non-existent hash, so it should be stale (count = 1)
+    assert.strictEqual(result.output, '1', 'should return integer 1 as string');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// config-get --default flag
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('config-get --default flag', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('config-get --default returns default string when key not found', () => {
+    // Write a config without the key we are querying
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ git: { remote: 'origin' } }, null, 2)
+    );
+    const result = runGsdTools(['config-get', 'nonexistent.key', '--default', 'mydefault'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output.trim(), 'mydefault', `Expected scalar "mydefault", got: ${result.output}`);
+  });
+
+  test('config-get --default false without returns JSON string "false"', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ git: { remote: 'origin' } }, null, 2)
+    );
+    const result = runGsdTools(['config-get', 'nonexistent.key', '--default', 'false'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output.trim(), 'false', `Expected scalar "false", got: ${result.output}`);
+  });
+
+  test('config-get --default returns actual value when key exists', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ workflow: { auto_advance: true } }, null, 2)
+    );
+    const result = runGsdTools(['config-get', 'workflow.auto_advance', '--default', 'false'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.ok(result.output.includes('true'), `Expected "true" in output, got: ${result.output}`);
+  });
+
+  test('config-get --default false returns "false" when key not found', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ git: { remote: 'origin' } }, null, 2)
+    );
+    const result = runGsdTools(['config-get', 'nonexistent.key', '--default', 'false'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output, 'false', `Expected exactly "false", got: ${result.output}`);
+  });
+});
+
+describe('todo list-by-phase command', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    // Create todos/pending directory
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'todos', 'pending'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('list-by-phase returns filenames matching the given phase', () => {
+    // Create three todos: one matching phase 5, one with phase 10, one with no phase
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'todos', 'pending', '2026-01-01-todo-phase5.md'),
+      '---\nphase: 5\ntitle: Phase 5 todo\n---\n\nDo something in phase 5.\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'todos', 'pending', '2026-01-02-todo-phase10.md'),
+      '---\nphase: 10\ntitle: Phase 10 todo\n---\n\nDo something in phase 10.\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'todos', 'pending', '2026-01-03-todo-nophase.md'),
+      '---\ntitle: No phase todo\n---\n\nDo something unrelated.\n'
+    );
+
+    const result = runGsdTools(['todo', 'list-by-phase', '5', '--json'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(Array.isArray(output), 'Output should be an array');
+    assert.ok(output.includes('2026-01-01-todo-phase5.md'), 'Should include the phase-5 todo');
+    assert.ok(!output.includes('2026-01-02-todo-phase10.md'), 'Should not include phase-10 todo');
+    assert.ok(!output.includes('2026-01-03-todo-nophase.md'), 'Should not include no-phase todo');
+  });
+
+  test('list-by-phase returns empty array when no todos match', () => {
+    // Create todos with different phases
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'todos', 'pending', '2026-01-01-todo-phase3.md'),
+      '---\nphase: 3\ntitle: Phase 3 todo\n---\n\nDo something.\n'
+    );
+
+    const result = runGsdTools(['todo', 'list-by-phase', '99', '--json'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(Array.isArray(output), 'Output should be an array');
+    assert.strictEqual(output.length, 0, 'Should return empty array when no phase matches');
+  });
+
+  test('list-by-phase returns empty array when pending dir is empty', () => {
+    // No todos created
+    const result = runGsdTools(['todo', 'list-by-phase', '5', '--json'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(Array.isArray(output), 'Output should be an array');
+    assert.strictEqual(output.length, 0, 'Should return empty array when dir is empty');
+  });
+});
+
+describe('todo scan-phase-linked command', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'todos', 'pending'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('scan-phase-linked returns source todos listed in ROADMAP.md for the given phase', () => {
+    // Create ROADMAP.md with a phase containing Source Todos
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase Details\n\n### Phase 5: Test Phase\n**Goal:** Do things\n**Source Todos**: `todo-a.md`, `todo-b.md`\n\n'
+    );
+
+    // Create the todo files in pending
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'todos', 'pending', 'todo-a.md'),
+      '---\nphase: 5\ntitle: Todo A\n---\n\nContent A.\n'
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'todos', 'pending', 'todo-b.md'),
+      '---\nphase: 5\ntitle: Todo B\n---\n\nContent B.\n'
+    );
+
+    const result = runGsdTools(['todo', 'scan-phase-linked', '5', '--json'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(Array.isArray(output), 'Output should be an array');
+    assert.ok(output.includes('todo-a.md'), 'Should include todo-a.md');
+    assert.ok(output.includes('todo-b.md'), 'Should include todo-b.md');
+  });
+
+  test('scan-phase-linked returns empty array when phase has no source todos', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase Details\n\n### Phase 5: Test Phase\n**Goal:** Do things\n\n'
+    );
+
+    const result = runGsdTools(['todo', 'scan-phase-linked', '5', '--json'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(Array.isArray(output), 'Output should be an array');
+    assert.strictEqual(output.length, 0, 'Should return empty when no source todos');
+  });
+
+  test('scan-phase-linked only returns todos that exist in pending dir', () => {
+    // ROADMAP lists two todos but only one exists in pending
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase Details\n\n### Phase 7: Another Phase\n**Goal:** Do things\n**Source Todos**: `exists.md`, `missing.md`\n\n'
+    );
+
+    // Only create exists.md
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'todos', 'pending', 'exists.md'),
+      '---\nphase: 7\ntitle: Exists\n---\n\nContent.\n'
+    );
+
+    const result = runGsdTools(['todo', 'scan-phase-linked', '7', '--json'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(Array.isArray(output), 'Output should be an array');
+    assert.ok(output.includes('exists.md'), 'Should include the existing todo');
+    assert.ok(!output.includes('missing.md'), 'Should not include missing todo');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// summary-extract --default flag
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('summary-extract --default flag', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('returns default value when summary file not found', () => {
+    const result = runGsdTools(['summary-extract', '.planning/phases/nonexistent/01-01-SUMMARY.md', '--fields', 'one_liner', '--default', ''], tmpDir);
+    assert.ok(result.success, `Command should exit 0 with --default, got: ${result.error}`);
+    assert.strictEqual(result.output, '', `Expected empty string, got: "${result.output}"`);
+  });
+
+  test('returns actual value when file found (default unused)', () => {
+    const summaryDir = path.join(tmpDir, '.planning', 'phases', '01-test');
+    fs.mkdirSync(summaryDir, { recursive: true });
+    // one-liner uses hyphen key in frontmatter (matching cmdSummaryExtract's fm['one-liner'])
+    const summaryContent = `---\nphase: "01"\nplan: "01"\nsubsystem: test\ntags: []\nduration: 5m\ncompleted: "2026-01-01"\none-liner: "Built the thing"\n---\n\n# Summary\n`;
+    fs.writeFileSync(path.join(summaryDir, '01-01-SUMMARY.md'), summaryContent);
+    const result = runGsdTools(['summary-extract', '.planning/phases/01-test/01-01-SUMMARY.md', '--fields', 'one_liner', '--default', '', '--json'], tmpDir);
+    assert.ok(result.success, `Command should succeed`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.one_liner, 'Built the thing', 'Should return actual value');
   });
 });

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -40,7 +40,7 @@ describe('config-ensure-section command', () => {
   });
 
   test('creates config.json with expected structure and types', () => {
-    const result = runGsdTools('config-ensure-section', tmpDir);
+    const result = runGsdTools('config-ensure-section --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -63,12 +63,12 @@ describe('config-ensure-section command', () => {
   });
 
   test('is idempotent — returns already_exists on second call', () => {
-    const first = runGsdTools('config-ensure-section', tmpDir);
+    const first = runGsdTools('config-ensure-section --json', tmpDir);
     assert.ok(first.success, `First call failed: ${first.error}`);
     const firstOutput = JSON.parse(first.output);
     assert.strictEqual(firstOutput.created, true);
 
-    const second = runGsdTools('config-ensure-section', tmpDir);
+    const second = runGsdTools('config-ensure-section --json', tmpDir);
     assert.ok(second.success, `Second call failed: ${second.error}`);
     const secondOutput = JSON.parse(second.output);
     assert.strictEqual(secondOutput.created, false);
@@ -135,7 +135,7 @@ describe('config-set command', () => {
   });
 
   test('sets a top-level string value', () => {
-    const result = runGsdTools('config-set model_profile quality', tmpDir);
+    const result = runGsdTools('config-set model_profile quality --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -315,7 +315,7 @@ describe('Phase 13 git config keys (GIT-01)', () => {
       'utf-8'
     );
 
-    const result = runGsdTools('init execute-phase 13', tmpDir);
+    const result = runGsdTools('init execute-phase 13 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -341,7 +341,7 @@ describe('Phase 13 git config keys (GIT-01)', () => {
       'utf-8'
     );
 
-    const result = runGsdTools('init execute-phase 13', tmpDir);
+    const result = runGsdTools('init execute-phase 13 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -362,7 +362,7 @@ describe('Phase 13 git config keys (GIT-01)', () => {
       'utf-8'
     );
 
-    const result = runGsdTools('init execute-phase 13', tmpDir);
+    const result = runGsdTools('init execute-phase 13 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -388,7 +388,7 @@ describe('Phase 13 git config keys (GIT-01)', () => {
     assert.ok(setResult.success, `config-set failed: ${setResult.error}`);
 
     // Then verify init execute-phase returns the updated value
-    const initResult = runGsdTools('init execute-phase 13', tmpDir);
+    const initResult = runGsdTools('init execute-phase 13 --json', tmpDir);
     assert.ok(initResult.success, `init failed: ${initResult.error}`);
 
     const output = JSON.parse(initResult.output);
@@ -412,7 +412,7 @@ describe('config-get command', () => {
   });
 
   test('gets a top-level value', () => {
-    const result = runGsdTools('config-get model_profile', tmpDir);
+    const result = runGsdTools('config-get model_profile --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -420,7 +420,7 @@ describe('config-get command', () => {
   });
 
   test('gets a nested value via dot-notation', () => {
-    const result = runGsdTools('config-get workflow.research', tmpDir);
+    const result = runGsdTools('config-get workflow.research --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -502,7 +502,7 @@ describe('git commit and versioning config keys', () => {
 
   test('config-get git.commit_format returns set value', () => {
     writeConfig(tmpDir, { git: { commit_format: 'issue-first' } });
-    const result = runGsdTools('config-get git.commit_format', tmpDir);
+    const result = runGsdTools('config-get git.commit_format --json', tmpDir);
     assert.ok(result.success, `Failed: ${result.error}`);
     assert.strictEqual(JSON.parse(result.output), 'issue-first');
   });
@@ -576,7 +576,7 @@ describe('Per-submodule config keys (SUBMOD-01)', () => {
     existing.git.submodule = { workspace_branch: 'develop' };
     fs.writeFileSync(configPath, JSON.stringify(existing, null, 2));
 
-    const result = runGsdTools('config-get git.submodule.workspace_branch --raw', tmpDir);
+    const result = runGsdTools('config-get git.submodule.workspace_branch', tmpDir);
     // Should succeed (returns value for migration) but stderr has warning
     assert.match(result.stderr || result.output || result.error || '', /deprecated/i);
   });

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -991,3 +991,67 @@ describe('output EPIPE handling', () => {
     );
   });
 });
+
+// ─── output() inline default and --file flag ─────────────────────────────────
+
+describe('output() inline default and --file flag', () => {
+  const { setFileOutput, output } = require('../gsd-ng/bin/lib/core.cjs');
+
+  // Intercept fs.writeSync to capture what output() writes to stdout (fd 1).
+  let capturedOutput;
+  let origWriteSync;
+
+  beforeEach(() => {
+    capturedOutput = '';
+    origWriteSync = fs.writeSync;
+    fs.writeSync = (fd, data) => {
+      if (fd === 1) { capturedOutput += data; return data.length; }
+      return origWriteSync(fd, data);
+    };
+    // Ensure file output flag is off before each test
+    setFileOutput(false);
+  });
+
+  afterEach(() => {
+    fs.writeSync = origWriteSync;
+    setFileOutput(false);
+  });
+
+  test('small payload writes inline JSON to stdout', () => {
+    output({ hello: 'world' });
+    assert.ok(!capturedOutput.startsWith('@file:'), `Expected inline JSON, got: ${capturedOutput.slice(0, 50)}`);
+    const parsed = JSON.parse(capturedOutput);
+    assert.strictEqual(parsed.hello, 'world');
+  });
+
+  test('large payload (>50KB) writes inline JSON by default', () => {
+    const bigObj = { data: 'x'.repeat(51000) };
+    output(bigObj);
+    assert.ok(!capturedOutput.startsWith('@file:'), `Expected inline JSON, got @file: path`);
+    const parsed = JSON.parse(capturedOutput);
+    assert.ok(parsed.data.length === 51000, 'Large payload data should be preserved');
+  });
+
+  test('--file flag triggers @file: temp file output', () => {
+    setFileOutput(true);
+    output({ test: true });
+    assert.ok(capturedOutput.startsWith('@file:'), `Expected @file: prefix, got: ${capturedOutput.slice(0, 50)}`);
+    const tmpPath = capturedOutput.slice(6);
+    const contents = fs.readFileSync(tmpPath, 'utf-8');
+    const parsed = JSON.parse(contents);
+    assert.strictEqual(parsed.test, true);
+    // Clean up temp file
+    try { fs.unlinkSync(tmpPath); } catch {}
+  });
+
+  test('displayValue mode writes string directly', () => {
+    output(null, 'display-string');
+    assert.strictEqual(capturedOutput, 'display-string');
+  });
+
+  test('setFileOutput exists and is exported (setResolveOutput does NOT exist)', () => {
+    const coreExports = require('../gsd-ng/bin/lib/core.cjs');
+    assert.strictEqual(typeof coreExports.setFileOutput, 'function', 'setFileOutput should be exported');
+    assert.strictEqual(typeof coreExports.setResolveOutput, 'undefined', 'setResolveOutput should NOT be exported');
+  });
+});

--- a/tests/frontmatter-cli.test.cjs
+++ b/tests/frontmatter-cli.test.cjs
@@ -37,7 +37,7 @@ afterEach(() => {
 describe('frontmatter get', () => {
   test('returns all fields as JSON', () => {
     const file = writeTempFile('---\nphase: 01\nplan: 01\ntype: execute\n---\nbody text');
-    const result = runGsdTools(`frontmatter get ${file}`);
+    const result = runGsdTools(`frontmatter get ${file} --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.phase, '01');
@@ -47,7 +47,7 @@ describe('frontmatter get', () => {
 
   test('returns specific field with --field', () => {
     const file = writeTempFile('---\nphase: 01\nplan: 02\ntype: tdd\n---\nbody');
-    const result = runGsdTools(`frontmatter get ${file} --field phase`);
+    const result = runGsdTools(`frontmatter get ${file} --field phase --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.phase, '01');
@@ -55,7 +55,7 @@ describe('frontmatter get', () => {
 
   test('returns error for missing field', () => {
     const file = writeTempFile('---\nphase: 01\n---\n');
-    const result = runGsdTools(`frontmatter get ${file} --field nonexistent`);
+    const result = runGsdTools(`frontmatter get ${file} --field nonexistent --json`);
     // The command succeeds (exit 0) but returns an error object in JSON
     assert.ok(result.success, 'Command should exit 0');
     const parsed = JSON.parse(result.output);
@@ -64,7 +64,7 @@ describe('frontmatter get', () => {
   });
 
   test('returns error for missing file', () => {
-    const result = runGsdTools('frontmatter get /nonexistent/path/file.md');
+    const result = runGsdTools('frontmatter get /nonexistent/path/file.md --json');
     assert.ok(result.success, 'Command should exit 0 with error JSON');
     const parsed = JSON.parse(result.output);
     assert.ok(parsed.error, 'Should have error field');
@@ -72,7 +72,7 @@ describe('frontmatter get', () => {
 
   test('handles file with no frontmatter', () => {
     const file = writeTempFile('Plain text with no frontmatter delimiters.');
-    const result = runGsdTools(`frontmatter get ${file}`);
+    const result = runGsdTools(`frontmatter get ${file} --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.deepStrictEqual(parsed, {}, 'Should return empty object for no frontmatter');
@@ -118,7 +118,7 @@ describe('frontmatter set', () => {
   });
 
   test('returns error for missing file', () => {
-    const result = runGsdTools('frontmatter set /nonexistent/file.md --field phase --value "01"');
+    const result = runGsdTools('frontmatter set /nonexistent/file.md --field phase --value "01" --json');
     assert.ok(result.success, 'Command should exit 0 with error JSON');
     const parsed = JSON.parse(result.output);
     assert.ok(parsed.error, 'Should have error field');
@@ -164,7 +164,7 @@ describe('frontmatter merge', () => {
   });
 
   test('returns error for missing file', () => {
-    const result = runGsdTools(`frontmatter merge /nonexistent/file.md --data '{"phase":"01"}'`);
+    const result = runGsdTools(`frontmatter merge /nonexistent/file.md --data '{"phase":"01"}' --json`);
     assert.ok(result.success, 'Command should exit 0 with error JSON');
     const parsed = JSON.parse(result.output);
     assert.ok(parsed.error, 'Should have error field');
@@ -197,7 +197,7 @@ must_haves:
 ---
 body`;
     const file = writeTempFile(content);
-    const result = runGsdTools(`frontmatter validate ${file} --schema plan`);
+    const result = runGsdTools(`frontmatter validate ${file} --schema plan --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.valid, true, 'Should be valid');
@@ -207,7 +207,7 @@ body`;
 
   test('reports invalid with missing fields', () => {
     const file = writeTempFile('---\nphase: 01\n---\nbody');
-    const result = runGsdTools(`frontmatter validate ${file} --schema plan`);
+    const result = runGsdTools(`frontmatter validate ${file} --schema plan --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.valid, false, 'Should be invalid');
@@ -231,7 +231,7 @@ completed: 2026-02-25
 ---
 body`;
     const file = writeTempFile(content);
-    const result = runGsdTools(`frontmatter validate ${file} --schema summary`);
+    const result = runGsdTools(`frontmatter validate ${file} --schema summary --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.valid, true, 'Should be valid for summary schema');
@@ -247,7 +247,7 @@ score: 5/5
 ---
 body`;
     const file = writeTempFile(content);
-    const result = runGsdTools(`frontmatter validate ${file} --schema verification`);
+    const result = runGsdTools(`frontmatter validate ${file} --schema verification --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.valid, true, 'Should be valid for verification schema');
@@ -263,7 +263,7 @@ body`;
   });
 
   test('returns error for missing file', () => {
-    const result = runGsdTools('frontmatter validate /nonexistent/file.md --schema plan');
+    const result = runGsdTools('frontmatter validate /nonexistent/file.md --schema plan --json');
     assert.ok(result.success, 'Command should exit 0 with error JSON');
     const parsed = JSON.parse(result.output);
     assert.ok(parsed.error, 'Should have error field');
@@ -273,30 +273,30 @@ body`;
 // ─── frontmatter get --format newline ───────────────────────────────────────
 
 describe('frontmatter get --format newline', () => {
-  test('outputs array values one per line with --format newline --raw', () => {
+  test('outputs array values one per line with --format newline', () => {
     const file = writeTempFile('---\ntags:\n  - alpha\n  - beta\n  - gamma\n---\nbody');
-    const result = runGsdTools(`frontmatter get ${file} --field tags --format newline --raw`);
+    const result = runGsdTools(`frontmatter get ${file} --field tags --format newline`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'alpha\nbeta\ngamma');
   });
 
-  test('passes scalar through unchanged with --format newline --raw', () => {
+  test('passes scalar through unchanged with --format newline', () => {
     const file = writeTempFile('---\ntitle: My Title\n---\nbody');
-    const result = runGsdTools(`frontmatter get ${file} --field title --format newline --raw`);
+    const result = runGsdTools(`frontmatter get ${file} --field title --format newline`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'My Title');
   });
 
   test('comma-separated output without --format flag is backward compatible', () => {
     const file = writeTempFile('---\ntags:\n  - alpha\n  - beta\n  - gamma\n---\nbody');
-    const result = runGsdTools(`frontmatter get ${file} --field tags --raw`);
+    const result = runGsdTools(`frontmatter get ${file} --field tags`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'alpha, beta, gamma');
   });
 
-  test('returns JSON object with --format newline but no --raw', () => {
+  test('returns JSON object with --format newline and --json', () => {
     const file = writeTempFile('---\ntags:\n  - alpha\n  - beta\n  - gamma\n---\nbody');
-    const result = runGsdTools(`frontmatter get ${file} --field tags --format newline`);
+    const result = runGsdTools(`frontmatter get ${file} --field tags --format newline --json`);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.deepStrictEqual(parsed, { tags: ['alpha', 'beta', 'gamma'] });
@@ -311,5 +311,44 @@ describe('frontmatter set validates field name (SEC-02)', () => {
     const result = runGsdTools(['frontmatter', 'set', testFile, '--field', 'bad:field', '--value', 'value']);
     assert.ok(!result.success || result.output.includes('Invalid field name'),
       'should reject field name containing colon');
+  });
+});
+
+// ─── frontmatter get --default flag ─────────────────────────────────────────
+
+describe('frontmatter get --default flag', () => {
+  test('returns default value (raw) when file not found', () => {
+    const result = runGsdTools('frontmatter get /nonexistent/path/missing.md --field phase --default "notfound"');
+    assert.ok(result.success, 'Command should exit 0 with --default');
+    assert.strictEqual(result.output, 'notfound', `Expected "notfound", got: ${result.output}`);
+  });
+
+  test('returns default value (raw) when field not found', () => {
+    const file = writeTempFile('---\nphase: 01\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field nonexistent --default "fallback"`);
+    assert.ok(result.success, 'Command should exit 0 with --default');
+    assert.strictEqual(result.output, 'fallback', `Expected "fallback", got: ${result.output}`);
+  });
+
+  test('returns actual field value when field exists (default unused)', () => {
+    const file = writeTempFile('---\nphase: 42\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field phase --default "notused"`);
+    assert.ok(result.success, 'Command should succeed');
+    assert.strictEqual(result.output, '42', `Expected "42", got: ${result.output}`);
+  });
+
+  test('returns default empty string when field not found', () => {
+    const file = writeTempFile('---\nphase: 01\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field related --format newline --default ""`);
+    assert.ok(result.success, 'Command should exit 0 with empty default');
+    assert.strictEqual(result.output, '', `Expected empty string, got: ${result.output}`);
+  });
+
+  test('preserves error JSON when no --default flag and field not found', () => {
+    const file = writeTempFile('---\nphase: 01\n---\nbody');
+    const result = runGsdTools(`frontmatter get ${file} --field nonexistent --json`);
+    assert.ok(result.success, 'Command should exit 0');
+    const parsed = JSON.parse(result.output);
+    assert.ok(parsed.error, 'Should return error object without --default');
   });
 });

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -24,7 +24,7 @@ describe('init commands', () => {
     fs.mkdirSync(phaseDir, { recursive: true });
     fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '# Plan');
 
-    const result = runGsdTools('init execute-phase 03', tmpDir);
+    const result = runGsdTools('init execute-phase 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -41,7 +41,7 @@ describe('init commands', () => {
     fs.writeFileSync(path.join(phaseDir, '03-VERIFICATION.md'), '# Verification');
     fs.writeFileSync(path.join(phaseDir, '03-UAT.md'), '# UAT');
 
-    const result = runGsdTools('init plan-phase 03', tmpDir);
+    const result = runGsdTools('init plan-phase 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -55,7 +55,7 @@ describe('init commands', () => {
   });
 
   test('init progress returns file paths', () => {
-    const result = runGsdTools('init progress', tmpDir);
+    const result = runGsdTools('init progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -73,7 +73,7 @@ describe('init commands', () => {
     fs.writeFileSync(path.join(phaseDir, '03-VERIFICATION.md'), '# Verification');
     fs.writeFileSync(path.join(phaseDir, '03-UAT.md'), '# UAT');
 
-    const result = runGsdTools('init phase-op 03', tmpDir);
+    const result = runGsdTools('init phase-op 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -90,7 +90,7 @@ describe('init commands', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
     fs.mkdirSync(phaseDir, { recursive: true });
 
-    const result = runGsdTools('init plan-phase 03', tmpDir);
+    const result = runGsdTools('init plan-phase 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -107,7 +107,7 @@ describe('init commands', () => {
       `# Roadmap\n\n### Phase 3: API\n**Goal:** Build API\n**Requirements**: CP-01, CP-02, CP-03\n**Plans:** 0 plans\n`
     );
 
-    const result = runGsdTools('init plan-phase 3', tmpDir);
+    const result = runGsdTools('init plan-phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -121,7 +121,7 @@ describe('init commands', () => {
       `# Roadmap\n\n### Phase 3: API\n**Goal:** Build API\n**Requirements**: [CP-01, CP-02]\n**Plans:** 0 plans\n`
     );
 
-    const result = runGsdTools('init plan-phase 3', tmpDir);
+    const result = runGsdTools('init plan-phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -135,7 +135,7 @@ describe('init commands', () => {
       `# Roadmap\n\n### Phase 3: API\n**Goal:** Build API\n**Plans:** 0 plans\n`
     );
 
-    const result = runGsdTools('init plan-phase 3', tmpDir);
+    const result = runGsdTools('init plan-phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -145,7 +145,7 @@ describe('init commands', () => {
   test('init plan-phase returns null phase_req_ids when ROADMAP is absent', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-api'), { recursive: true });
 
-    const result = runGsdTools('init plan-phase 3', tmpDir);
+    const result = runGsdTools('init plan-phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -161,7 +161,7 @@ describe('init commands', () => {
       `# Roadmap\n\n### Phase 3: API\n**Goal:** Build API\n**Requirements**: EX-01, EX-02\n**Plans:** 1 plans\n`
     );
 
-    const result = runGsdTools('init execute-phase 3', tmpDir);
+    const result = runGsdTools('init execute-phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -175,7 +175,7 @@ describe('init commands', () => {
       `# Roadmap\n\n### Phase 3: API\n**Goal:** Build API\n**Requirements**: TBD\n**Plans:** 0 plans\n`
     );
 
-    const result = runGsdTools('init plan-phase 3', tmpDir);
+    const result = runGsdTools('init plan-phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -191,7 +191,7 @@ describe('init commands', () => {
       `# Roadmap\n\n### Phase 3: API\n**Goal:** Build API\n**Plans:** 1 plans\n`
     );
 
-    const result = runGsdTools('init execute-phase 3', tmpDir);
+    const result = runGsdTools('init execute-phase 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -217,7 +217,7 @@ describe('cmdInitTodos', () => {
   test('empty pending dir returns zero count', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'todos', 'pending'), { recursive: true });
 
-    const result = runGsdTools('init todos', tmpDir);
+    const result = runGsdTools('init todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -227,7 +227,7 @@ describe('cmdInitTodos', () => {
   });
 
   test('missing pending dir returns zero count', () => {
-    const result = runGsdTools('init todos', tmpDir);
+    const result = runGsdTools('init todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -244,7 +244,7 @@ describe('cmdInitTodos', () => {
     fs.writeFileSync(path.join(pendingDir, 'task-2.md'), 'title: Add feature\narea: frontend\ncreated: 2026-02-24');
     fs.writeFileSync(path.join(pendingDir, 'task-3.md'), 'title: Write docs\narea: backend\ncreated: 2026-02-23');
 
-    const result = runGsdTools('init todos', tmpDir);
+    const result = runGsdTools('init todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -267,7 +267,7 @@ describe('cmdInitTodos', () => {
     fs.writeFileSync(path.join(pendingDir, 'task-2.md'), 'title: Add feature\narea: frontend\ncreated: 2026-02-24');
     fs.writeFileSync(path.join(pendingDir, 'task-3.md'), 'title: Write docs\narea: backend\ncreated: 2026-02-23');
 
-    const result = runGsdTools('init todos backend', tmpDir);
+    const result = runGsdTools('init todos backend --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -284,7 +284,7 @@ describe('cmdInitTodos', () => {
 
     fs.writeFileSync(path.join(pendingDir, 'task-1.md'), 'title: Fix bug\narea: backend\ncreated: 2026-02-25');
 
-    const result = runGsdTools('init todos nonexistent', tmpDir);
+    const result = runGsdTools('init todos nonexistent --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -298,7 +298,7 @@ describe('cmdInitTodos', () => {
 
     fs.writeFileSync(path.join(pendingDir, 'broken.md'), 'some random content without fields');
 
-    const result = runGsdTools('init todos', tmpDir);
+    const result = runGsdTools('init todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -316,7 +316,7 @@ describe('cmdInitTodos', () => {
     fs.writeFileSync(path.join(pendingDir, 'task.md'), 'title: Real task\narea: dev\ncreated: 2026-01-01');
     fs.writeFileSync(path.join(pendingDir, 'notes.txt'), 'title: Not a task\narea: dev\ncreated: 2026-01-01');
 
-    const result = runGsdTools('init todos', tmpDir);
+    const result = runGsdTools('init todos --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -341,7 +341,7 @@ describe('cmdInitMilestoneOp', () => {
   });
 
   test('no phase directories returns zero counts', () => {
-    const result = runGsdTools('init milestone-op', tmpDir);
+    const result = runGsdTools('init milestone-op --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -358,7 +358,7 @@ describe('cmdInitMilestoneOp', () => {
     fs.writeFileSync(path.join(phase1, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(phase2, '02-01-PLAN.md'), '# Plan');
 
-    const result = runGsdTools('init milestone-op', tmpDir);
+    const result = runGsdTools('init milestone-op --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -376,7 +376,7 @@ describe('cmdInitMilestoneOp', () => {
     fs.writeFileSync(path.join(phase1, '01-01-SUMMARY.md'), '# Summary');
     fs.writeFileSync(path.join(phase2, '02-01-PLAN.md'), '# Plan');
 
-    const result = runGsdTools('init milestone-op', tmpDir);
+    const result = runGsdTools('init milestone-op --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -391,7 +391,7 @@ describe('cmdInitMilestoneOp', () => {
     fs.writeFileSync(path.join(phase1, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(phase1, '01-01-SUMMARY.md'), '# Summary');
 
-    const result = runGsdTools('init milestone-op', tmpDir);
+    const result = runGsdTools('init milestone-op --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -404,7 +404,7 @@ describe('cmdInitMilestoneOp', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'archive', 'v1.0'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'archive', 'v0.9'), { recursive: true });
 
-    const result = runGsdTools('init milestone-op', tmpDir);
+    const result = runGsdTools('init milestone-op --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -413,7 +413,7 @@ describe('cmdInitMilestoneOp', () => {
   });
 
   test('no archive directory returns empty', () => {
-    const result = runGsdTools('init milestone-op', tmpDir);
+    const result = runGsdTools('init milestone-op --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -447,7 +447,7 @@ describe('cmdInitPhaseOp fallback', () => {
       '# Roadmap\n\n### Phase 3: API\n**Goal:** Build API\n**Plans:** 1 plans\n'
     );
 
-    const result = runGsdTools('init phase-op 3', tmpDir);
+    const result = runGsdTools('init phase-op 3 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -463,7 +463,7 @@ describe('cmdInitPhaseOp fallback', () => {
       '# Roadmap\n\n### Phase 5: Widget Builder\n**Goal:** Build widgets\n**Plans:** TBD\n'
     );
 
-    const result = runGsdTools('init phase-op 5', tmpDir);
+    const result = runGsdTools('init phase-op 5 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -507,7 +507,7 @@ describe('cmdInitPhaseOp fallback', () => {
 `
     );
 
-    const result = runGsdTools('init phase-op 2', tmpDir);
+    const result = runGsdTools('init phase-op 2 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -526,7 +526,7 @@ describe('cmdInitPhaseOp fallback', () => {
       '# Roadmap\n\n### Phase 1: Setup\n**Goal:** Setup project\n**Plans:** TBD\n'
     );
 
-    const result = runGsdTools('init phase-op 99', tmpDir);
+    const result = runGsdTools('init phase-op 99 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -540,7 +540,7 @@ describe('cmdInitPhaseOp fallback', () => {
       '# Roadmap\n\n### Phase 15: Base\n**Goal:** Base work\n**Plans:** TBD\n\n### Phase 15.1: Hotfix\n**Goal:** Emergency fix\n**Plans:** TBD\n\n### Phase 16: Next\n**Goal:** Next work\n**Plans:** TBD\n'
     );
 
-    const result = runGsdTools('init phase-op 15.1', tmpDir);
+    const result = runGsdTools('init phase-op 15.1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -557,7 +557,7 @@ describe('cmdInitPhaseOp fallback', () => {
       '# Roadmap\n\n### Phase 15: Base\n**Goal:** Base work\n**Plans:** TBD\n\n### Phase 15.1: Hotfix\n**Goal:** Emergency fix\n**Plans:** TBD\n\n### Phase 16: Next\n**Goal:** Next work\n**Plans:** TBD\n'
     );
 
-    const result = runGsdTools('init plan-phase 15.1', tmpDir);
+    const result = runGsdTools('init plan-phase 15.1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -583,7 +583,7 @@ describe('cmdInitProgress', () => {
   });
 
   test('no phases returns empty state', () => {
-    const result = runGsdTools('init progress', tmpDir);
+    const result = runGsdTools('init progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -611,7 +611,7 @@ describe('cmdInitProgress', () => {
     fs.mkdirSync(phase3, { recursive: true });
     fs.writeFileSync(path.join(phase3, '03-CONTEXT.md'), '# Context');
 
-    const result = runGsdTools('init progress', tmpDir);
+    const result = runGsdTools('init progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -638,7 +638,7 @@ describe('cmdInitProgress', () => {
     fs.mkdirSync(phase1, { recursive: true });
     fs.writeFileSync(path.join(phase1, '01-RESEARCH.md'), '# Research');
 
-    const result = runGsdTools('init progress', tmpDir);
+    const result = runGsdTools('init progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -654,7 +654,7 @@ describe('cmdInitProgress', () => {
     fs.writeFileSync(path.join(phase1, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(phase1, '01-01-SUMMARY.md'), '# Summary');
 
-    const result = runGsdTools('init progress', tmpDir);
+    const result = runGsdTools('init progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -669,7 +669,7 @@ describe('cmdInitProgress', () => {
       '# Project State\n\n**Paused At:** Phase 2, Task 3 — implementing auth\n'
     );
 
-    const result = runGsdTools('init progress', tmpDir);
+    const result = runGsdTools('init progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -683,7 +683,7 @@ describe('cmdInitProgress', () => {
       '# Project State\n\nSome content without pause.\n'
     );
 
-    const result = runGsdTools('init progress', tmpDir);
+    const result = runGsdTools('init progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -707,7 +707,7 @@ describe('cmdInitQuick', () => {
   });
 
   test('with description generates slug and task_dir with YYMMDD-xxx format', () => {
-    const result = runGsdTools('init quick "Fix login bug"', tmpDir);
+    const result = runGsdTools('init quick "Fix login bug" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -731,7 +731,7 @@ describe('cmdInitQuick', () => {
   });
 
   test('without description returns null slug and task_dir', () => {
-    const result = runGsdTools('init quick', tmpDir);
+    const result = runGsdTools('init quick --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -748,7 +748,7 @@ describe('cmdInitQuick', () => {
     // Both calls happen within the same test, which is sub-second.
     // They may or may not land in the same 2-second block. We just verify format.
     const r1 = runGsdTools('init quick "Task one"', tmpDir);
-    const r2 = runGsdTools('init quick "Task two"', tmpDir);
+    const r2 = runGsdTools('init quick "Task two" --json', tmpDir);
     assert.ok(r1.success && r2.success);
 
     const o1 = JSON.parse(r1.output);
@@ -762,7 +762,7 @@ describe('cmdInitQuick', () => {
   });
 
   test('long description truncates slug to 40 chars', () => {
-    const result = runGsdTools('init quick "This is a very long description that should get truncated to forty characters maximum"', tmpDir);
+    const result = runGsdTools('init quick "This is a very long description that should get truncated to forty characters maximum" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -786,7 +786,7 @@ describe('cmdInitMapCodebase', () => {
   });
 
   test('no codebase dir returns empty', () => {
-    const result = runGsdTools('init map-codebase', tmpDir);
+    const result = runGsdTools('init map-codebase --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -802,7 +802,7 @@ describe('cmdInitMapCodebase', () => {
     fs.writeFileSync(path.join(codebaseDir, 'ARCHITECTURE.md'), '# Architecture');
     fs.writeFileSync(path.join(codebaseDir, 'notes.txt'), 'not a markdown file');
 
-    const result = runGsdTools('init map-codebase', tmpDir);
+    const result = runGsdTools('init map-codebase --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -816,7 +816,7 @@ describe('cmdInitMapCodebase', () => {
     const codebaseDir = path.join(tmpDir, '.planning', 'codebase');
     fs.mkdirSync(codebaseDir, { recursive: true });
 
-    const result = runGsdTools('init map-codebase', tmpDir);
+    const result = runGsdTools('init map-codebase --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -842,7 +842,7 @@ describe('cmdInitNewProject', () => {
   });
 
   test('greenfield project with no code', () => {
-    const result = runGsdTools('init new-project', tmpDir);
+    const result = runGsdTools('init new-project --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -855,7 +855,7 @@ describe('cmdInitNewProject', () => {
   test('brownfield with package.json detected', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}');
 
-    const result = runGsdTools('init new-project', tmpDir);
+    const result = runGsdTools('init new-project --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -868,7 +868,7 @@ describe('cmdInitNewProject', () => {
     fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"test"}');
     fs.mkdirSync(path.join(tmpDir, '.planning', 'codebase'), { recursive: true });
 
-    const result = runGsdTools('init new-project', tmpDir);
+    const result = runGsdTools('init new-project --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -877,7 +877,7 @@ describe('cmdInitNewProject', () => {
   });
 
   test('planning_exists flag is correct', () => {
-    const result = runGsdTools('init new-project', tmpDir);
+    const result = runGsdTools('init new-project --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -901,7 +901,7 @@ describe('cmdInitNewMilestone', () => {
   });
 
   test('returns expected fields', () => {
-    const result = runGsdTools('init new-milestone', tmpDir);
+    const result = runGsdTools('init new-milestone --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -918,7 +918,7 @@ describe('cmdInitNewMilestone', () => {
 
   test('file existence flags reflect actual state', () => {
     // Default: no STATE.md, ROADMAP.md, or PROJECT.md
-    const result1 = runGsdTools('init new-milestone', tmpDir);
+    const result1 = runGsdTools('init new-milestone --json', tmpDir);
     assert.ok(result1.success, `Command failed: ${result1.error}`);
 
     const output1 = JSON.parse(result1.output);
@@ -931,7 +931,7 @@ describe('cmdInitNewMilestone', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), '# Roadmap');
     fs.writeFileSync(path.join(tmpDir, '.planning', 'PROJECT.md'), '# Project');
 
-    const result2 = runGsdTools('init new-milestone', tmpDir);
+    const result2 = runGsdTools('init new-milestone --json', tmpDir);
     assert.ok(result2.success, `Command failed: ${result2.error}`);
 
     const output2 = JSON.parse(result2.output);
@@ -961,7 +961,7 @@ describe('decimal phase not-found suggests parent', () => {
   afterEach(() => { cleanup(tmpDir); });
 
   test('phase-op suggests parent when decimal phase not found', () => {
-    const result = runGsdTools('init phase-op 15.1', tmpDir);
+    const result = runGsdTools('init phase-op 15.1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -971,7 +971,7 @@ describe('decimal phase not-found suggests parent', () => {
   });
 
   test('plan-phase suggests parent when decimal phase not found', () => {
-    const result = runGsdTools('init plan-phase 15.1', tmpDir);
+    const result = runGsdTools('init plan-phase 15.1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -981,7 +981,7 @@ describe('decimal phase not-found suggests parent', () => {
   });
 
   test('integer phase not found has no suggestion', () => {
-    const result = runGsdTools('init phase-op 99', tmpDir);
+    const result = runGsdTools('init phase-op 99 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1011,7 +1011,7 @@ describe('cmdInitPlanPhase gap research detection', () => {
 
   test('has_gap_research is true when GAP-RESEARCH.md exists', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'phases', '03-api', '03-GAP-RESEARCH.md'), '# Gap Research');
-    const result = runGsdTools('init plan-phase 03', tmpDir);
+    const result = runGsdTools('init plan-phase 03 --json', tmpDir);
     assert.ok(result.success);
     const output = JSON.parse(result.output);
     assert.strictEqual(output.has_gap_research, true);
@@ -1020,7 +1020,7 @@ describe('cmdInitPlanPhase gap research detection', () => {
 
   test('has_research is false when only GAP-RESEARCH.md exists', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'phases', '03-api', '03-GAP-RESEARCH.md'), '# Gap Research');
-    const result = runGsdTools('init plan-phase 03', tmpDir);
+    const result = runGsdTools('init plan-phase 03 --json', tmpDir);
     assert.ok(result.success);
     const output = JSON.parse(result.output);
     assert.strictEqual(output.has_research, false);
@@ -1029,7 +1029,7 @@ describe('cmdInitPlanPhase gap research detection', () => {
   test('has_research true when both RESEARCH.md and GAP-RESEARCH.md exist', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'phases', '03-api', '03-RESEARCH.md'), '# Research');
     fs.writeFileSync(path.join(tmpDir, '.planning', 'phases', '03-api', '03-GAP-RESEARCH.md'), '# Gap Research');
-    const result = runGsdTools('init plan-phase 03', tmpDir);
+    const result = runGsdTools('init plan-phase 03 --json', tmpDir);
     assert.ok(result.success);
     const output = JSON.parse(result.output);
     assert.strictEqual(output.has_research, true);
@@ -1037,7 +1037,7 @@ describe('cmdInitPlanPhase gap research detection', () => {
   });
 
   test('gap_research_path absent when no GAP-RESEARCH.md', () => {
-    const result = runGsdTools('init plan-phase 03', tmpDir);
+    const result = runGsdTools('init plan-phase 03 --json', tmpDir);
     assert.ok(result.success);
     const output = JSON.parse(result.output);
     assert.strictEqual(output.has_gap_research, false);
@@ -1088,7 +1088,7 @@ describe('init execute-phase submodule fields', () => {
       { name: 'mylib', path: 'mylib', remoteUrl: 'https://github.com/user/mylib.git' },
     ], { roadmap: true, state: true, phaseDir: '01-test' });
     try {
-      const result = runGsdTools(['init', 'execute-phase', '1'], workspaceDir);
+      const result = runGsdTools(['init', 'execute-phase', '1', '--json'], workspaceDir);
       assert.ok(result.success, `init should succeed: ${result.error}`);
       const parsed = JSON.parse(result.output);
 
@@ -1133,7 +1133,7 @@ describe('init execute-phase submodule fields', () => {
           },
         }, null, 2)
       );
-      const result = runGsdTools(['init', 'execute-phase', '1'], workspaceDir);
+      const result = runGsdTools(['init', 'execute-phase', '1', '--json'], workspaceDir);
       assert.ok(result.success, `init should succeed: ${result.error}`);
       const parsed = JSON.parse(result.output);
 
@@ -1164,26 +1164,26 @@ describe('init-get command', () => {
     cleanup(tmpDir);
   });
 
-  test('returns boolean field as plain string when --raw', () => {
-    const result = runGsdTools(['init-get', '{"submodule_is_active":true}', 'submodule_is_active', '--raw'], tmpDir);
+  test('returns boolean field as plain string when', () => {
+    const result = runGsdTools(['init-get', '{"submodule_is_active":true}', 'submodule_is_active'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'true');
   });
 
-  test('returns string field as plain string when --raw', () => {
-    const result = runGsdTools(['init-get', '{"submodule_git_cwd":"/path/to/repo"}', 'submodule_git_cwd', '--raw'], tmpDir);
+  test('returns string field as plain string when', () => {
+    const result = runGsdTools(['init-get', '{"submodule_git_cwd":"/path/to/repo"}', 'submodule_git_cwd'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, '/path/to/repo');
   });
 
   test('returns empty string for missing field without error exit', () => {
-    const result = runGsdTools(['init-get', '{"foo":"bar"}', 'missing_field', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', '{"foo":"bar"}', 'missing_field'], tmpDir);
     assert.ok(result.success, `Command should not fail for missing field: ${result.error}`);
     assert.strictEqual(result.output, '');
   });
 
-  test('coerces number to string when --raw', () => {
-    const result = runGsdTools(['init-get', '{"count":42}', 'count', '--raw'], tmpDir);
+  test('coerces number to string when', () => {
+    const result = runGsdTools(['init-get', '{"count":42}', 'count'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, '42');
   });
@@ -1195,55 +1195,55 @@ describe('init-get command', () => {
   });
 
   test('exits nonzero for invalid JSON', () => {
-    const result = runGsdTools(['init-get', 'not-json', 'branching_strategy', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', 'not-json', 'branching_strategy'], tmpDir);
     assert.ok(!result.success, 'Command should fail for invalid JSON');
     assert.ok(result.error.includes('init-get') || result.error.includes('invalid JSON'), `Expected error message, got: ${result.error}`);
   });
 
-  test('array field returns JSON string when --raw', () => {
-    const result = runGsdTools(['init-get', '{"ambiguous_paths":["a","b"]}', 'ambiguous_paths', '--raw'], tmpDir);
+  test('array field returns JSON string when', () => {
+    const result = runGsdTools(['init-get', '{"ambiguous_paths":["a","b"]}', 'ambiguous_paths'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, '["a","b"]');
   });
 
-  test('null field in JSON returns empty string when --raw', () => {
-    const result = runGsdTools(['init-get', '{"platform":null}', 'platform', '--raw'], tmpDir);
+  test('null field in JSON returns empty string when', () => {
+    const result = runGsdTools(['init-get', '{"platform":null}', 'platform'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, '');
   });
 
   test('known boolean field missing from JSON returns typed default', () => {
-    const result = runGsdTools(['init-get', '{}', 'submodule_is_active', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', '{}', 'submodule_is_active'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'false');
   });
 
   test('known array field missing from JSON returns empty JSON array', () => {
-    const result = runGsdTools(['init-get', '{}', 'ambiguous_paths', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', '{}', 'ambiguous_paths'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, '[]');
   });
 
   test('known string field missing from JSON returns non-empty default', () => {
-    const result = runGsdTools(['init-get', '{}', 'branching_strategy', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', '{}', 'branching_strategy'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     assert.strictEqual(result.output, 'none');
   });
 
   test('exits nonzero for empty string $INIT', () => {
-    const result = runGsdTools(['init-get', '', 'target_branch', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', '', 'target_branch'], tmpDir);
     assert.ok(!result.success, 'Command should fail for empty string $INIT');
     assert.ok(result.error.includes('init-get') || result.error.includes('invalid JSON'), `Expected error message, got: ${result.error}`);
   });
 
   test('exits nonzero for malformed JSON $INIT', () => {
-    const result = runGsdTools(['init-get', 'NOTJSON', 'commit_docs', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', 'NOTJSON', 'commit_docs'], tmpDir);
     assert.ok(!result.success, 'Command should fail for malformed JSON $INIT');
     assert.ok(result.error.includes('init-get') || result.error.includes('invalid JSON'), `Expected error message, got: ${result.error}`);
   });
 
   test('unknown field not in registry returns empty string and exits 0', () => {
-    const result = runGsdTools(['init-get', '{}', 'completely_unknown_field', '--raw'], tmpDir);
+    const result = runGsdTools(['init-get', '{}', 'completely_unknown_field'], tmpDir);
     assert.ok(result.success, `Command should succeed for unknown field: ${result.error}`);
     assert.strictEqual(result.output, '');
   });

--- a/tests/install-js.test.cjs
+++ b/tests/install-js.test.cjs
@@ -898,6 +898,103 @@ test('COPILOT-09: --local --runtime copilot writes hooks/gsd-hooks.json with ses
   }
 });
 
+// ── AST-SAFETY-01: claude local install creates CLAUDE.md with AST safety block ──
+
+test('AST-SAFETY-01: claude local install creates CLAUDE.md with AST safety block', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-ast-01-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      { encoding: 'utf8', timeout: 15000, cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }) }
+    );
+    assert.strictEqual(result.status, 0,
+      'install.js --runtime claude --local must exit 0 (AST-SAFETY-01)\nstderr: ' + (result.stderr || ''));
+    const claudeMdPath = path.join(tmpDir, 'CLAUDE.md');
+    assert.ok(fs.existsSync(claudeMdPath),
+      'CLAUDE.md must exist after claude local install (AST-SAFETY-01)');
+    const content = fs.readFileSync(claudeMdPath, 'utf8');
+    assert.ok(content.includes('GSD — AST Safety Rules'),
+      'CLAUDE.md must contain AST safety block heading (AST-SAFETY-01).\nActual content: ' + content.slice(0, 500));
+    assert.ok(content.includes('30435'),
+      'CLAUDE.md must reference issue #30435 (AST-SAFETY-01)');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── AST-SAFETY-02: claude local install appends to existing CLAUDE.md ──────────
+
+test('AST-SAFETY-02: claude local install appends AST safety block to existing CLAUDE.md', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-ast-02-'));
+  try {
+    const existingContent = '# My Project\n\nExisting project instructions.\n';
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), existingContent);
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      { encoding: 'utf8', timeout: 15000, cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }) }
+    );
+    assert.strictEqual(result.status, 0,
+      'install.js --runtime claude --local must exit 0 (AST-SAFETY-02)\nstderr: ' + (result.stderr || ''));
+    const content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    assert.ok(content.includes('Existing project instructions.'),
+      'Existing CLAUDE.md content must be preserved (AST-SAFETY-02)');
+    assert.ok(content.includes('GSD — AST Safety Rules'),
+      'AST safety block must be appended (AST-SAFETY-02)');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── AST-SAFETY-03: idempotent — re-running does not duplicate block ───────────
+
+test('AST-SAFETY-03: claude local install is idempotent — re-running does not duplicate AST block', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-ast-03-'));
+  try {
+    const runInstall = () => spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      { encoding: 'utf8', timeout: 15000, cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }) }
+    );
+    const r1 = runInstall();
+    assert.strictEqual(r1.status, 0, 'First install must exit 0 (AST-SAFETY-03)');
+    const r2 = runInstall();
+    assert.strictEqual(r2.status, 0, 'Second install must exit 0 (AST-SAFETY-03)');
+    const content = fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf8');
+    const occurrences = (content.match(/^## GSD — AST Safety Rules$/gm) || []).length;
+    assert.strictEqual(occurrences, 1,
+      'AST safety block heading (## GSD — AST Safety Rules) must appear exactly once after two installs (AST-SAFETY-03).\n' +
+      'Found: ' + occurrences + ' occurrences');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+// ── AST-SAFETY-04: copilot install does NOT touch CLAUDE.md ──────────────────
+
+test('AST-SAFETY-04: copilot local install does not create or modify CLAUDE.md', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-ast-04-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'copilot', '--local'],
+      { encoding: 'utf8', timeout: 15000, cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }) }
+    );
+    assert.strictEqual(result.status, 0,
+      'install.js --runtime copilot --local must exit 0 (AST-SAFETY-04)\nstderr: ' + (result.stderr || ''));
+    const claudeMdPath = path.join(tmpDir, 'CLAUDE.md');
+    assert.ok(!fs.existsSync(claudeMdPath),
+      'CLAUDE.md must NOT be created by copilot install (AST-SAFETY-04)');
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
 // ── COPILOT-10: SKILL.md name: fields must not contain colon character ────────
 
 test('COPILOT-10: all SKILL.md name: fields must use gsd- prefix, not gsd: (no colons)', () => {

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -40,7 +40,7 @@ describe('milestone complete command', () => {
       `---\none-liner: Set up project infrastructure\n---\n# Summary\n`
     );
 
-    const result = runGsdTools('milestone complete v1.0 --name MVP Foundation', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name MVP Foundation --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -152,7 +152,7 @@ describe('milestone complete command', () => {
       `---\none-liner: Set up project infrastructure\n---\n# Summary\n`
     );
 
-    const result = runGsdTools('milestone complete v1.0 --name MVP --archive-phases', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name MVP --archive-phases --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -209,7 +209,7 @@ describe('milestone complete command', () => {
       `# State\n\n**Status:** In progress\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`
     );
 
-    const result = runGsdTools('milestone complete v1.0 --name Test', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name Test --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -230,7 +230,7 @@ describe('milestone complete command', () => {
       `# State\n\n**Status:** In progress\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`
     );
 
-    const result = runGsdTools('milestone complete v1.0 --name NoRoadmap', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name NoRoadmap --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -276,7 +276,7 @@ describe('milestone complete command', () => {
     fs.writeFileSync(path.join(p4, '04-02-PLAN.md'), '# Plan 2\n');
     fs.writeFileSync(path.join(p4, '04-01-SUMMARY.md'), '---\none-liner: Polished UI\n---\n# Summary\n');
 
-    const result = runGsdTools('milestone complete v1.1 --name "Second Release"', tmpDir);
+    const result = runGsdTools('milestone complete v1.1 --name "Second Release" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -351,7 +351,7 @@ describe('milestone complete command', () => {
       '---\none-liner: Scaling work\n---\n'
     );
 
-    const result = runGsdTools('milestone complete v1.0 --name MVP', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name MVP --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -386,7 +386,7 @@ describe('milestone complete command', () => {
     fs.mkdirSync(misc, { recursive: true });
     fs.writeFileSync(path.join(misc, 'PLAN.md'), '# Not a phase\n');
 
-    const result = runGsdTools('milestone complete v1.0 --name Test', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name Test --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -417,7 +417,7 @@ describe('milestone complete command', () => {
     fs.mkdirSync(p45, { recursive: true });
     fs.writeFileSync(path.join(p45, 'PLAN.md'), '# Plan\n');
 
-    const result = runGsdTools('milestone complete v1.49 --name DACP', tmpDir);
+    const result = runGsdTools('milestone complete v1.49 --name DACP --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -441,7 +441,7 @@ describe('milestone complete command', () => {
       `---\none-liner: Built the foundation\n---\n\n# Phase 1: Foundation Summary\n\n**Built the foundation**\n\n## Performance\n\n- **Duration:** 28 min\n- **Tasks:** 7\n- **Files modified:** 12\n`
     );
 
-    const result = runGsdTools('milestone complete v1.0 --name MVP', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name MVP --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -466,7 +466,7 @@ describe('milestone complete command', () => {
       `---\nphase: "01"\n---\n\n# Phase 1: Foundation Summary\n\n**JWT auth with refresh rotation using jose library**\n\n## Performance\n`
     );
 
-    const result = runGsdTools('milestone complete v1.0 --name MVP', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name MVP --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -487,7 +487,7 @@ describe('milestone complete command', () => {
     );
     // phases directory exists but is empty (from createTempProject)
 
-    const result = runGsdTools('milestone complete v1.0 --name EmptyPhases', tmpDir);
+    const result = runGsdTools('milestone complete v1.0 --name EmptyPhases --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -551,7 +551,7 @@ describe('requirements mark-complete command', () => {
   test('marks single requirement complete (checkbox + table)', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
-    const result = runGsdTools('requirements mark-complete TEST-01', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-01 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -568,7 +568,7 @@ describe('requirements mark-complete command', () => {
   test('handles mixed prefixes in single call (TEST-XX, REG-XX, INFRA-XX)', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
-    const result = runGsdTools('requirements mark-complete TEST-01,REG-01,INFRA-01', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-01,REG-01,INFRA-01 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -589,7 +589,7 @@ describe('requirements mark-complete command', () => {
   test('accepts space-separated IDs', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
-    const result = runGsdTools('requirements mark-complete TEST-01 TEST-02', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-01 TEST-02 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -603,7 +603,7 @@ describe('requirements mark-complete command', () => {
   test('accepts bracket-wrapped IDs [REQ-01, REQ-02]', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
-    const result = runGsdTools('requirements mark-complete [TEST-01,TEST-02]', tmpDir);
+    const result = runGsdTools('requirements mark-complete [TEST-01,TEST-02] --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -617,7 +617,7 @@ describe('requirements mark-complete command', () => {
   test('returns not_found for invalid IDs while updating valid ones', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
-    const result = runGsdTools('requirements mark-complete TEST-01,FAKE-99', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-01,FAKE-99 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -631,7 +631,7 @@ describe('requirements mark-complete command', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
     // TEST-03 already has [x] and Complete in the fixture
-    const result = runGsdTools('requirements mark-complete TEST-03', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -649,7 +649,7 @@ describe('requirements mark-complete command', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
     // TEST-03 already has [x] and Complete in the fixture
-    const result = runGsdTools('requirements mark-complete TEST-03', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -661,7 +661,7 @@ describe('requirements mark-complete command', () => {
     writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
 
     // TEST-01: pending (will be marked), TEST-03: already complete, FAKE-99: not found
-    const result = runGsdTools('requirements mark-complete TEST-01,TEST-03,FAKE-99', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-01,TEST-03,FAKE-99 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -673,7 +673,7 @@ describe('requirements mark-complete command', () => {
   test('missing REQUIREMENTS.md returns expected error structure', () => {
     // createTempProject does not create REQUIREMENTS.md — so it's already missing
 
-    const result = runGsdTools('requirements mark-complete TEST-01', tmpDir);
+    const result = runGsdTools('requirements mark-complete TEST-01 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -20,7 +20,7 @@ describe('phases list command', () => {
   });
 
   test('empty phases directory returns empty array', () => {
-    const result = runGsdTools('phases list', tmpDir);
+    const result = runGsdTools('phases list --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -34,7 +34,7 @@ describe('phases list command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-api'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-foundation'), { recursive: true });
 
-    const result = runGsdTools('phases list', tmpDir);
+    const result = runGsdTools('phases list --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -52,7 +52,7 @@ describe('phases list command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02.2-patch'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-ui'), { recursive: true });
 
-    const result = runGsdTools('phases list', tmpDir);
+    const result = runGsdTools('phases list --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -71,7 +71,7 @@ describe('phases list command', () => {
     fs.writeFileSync(path.join(phaseDir, '01-01-SUMMARY.md'), '# Summary');
     fs.writeFileSync(path.join(phaseDir, 'RESEARCH.md'), '# Research');
 
-    const result = runGsdTools('phases list --type plans', tmpDir);
+    const result = runGsdTools('phases list --type plans --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -89,7 +89,7 @@ describe('phases list command', () => {
     fs.writeFileSync(path.join(phaseDir, '01-01-SUMMARY.md'), '# Summary 1');
     fs.writeFileSync(path.join(phaseDir, '01-02-SUMMARY.md'), '# Summary 2');
 
-    const result = runGsdTools('phases list --type summaries', tmpDir);
+    const result = runGsdTools('phases list --type summaries --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -108,7 +108,7 @@ describe('phases list command', () => {
     fs.writeFileSync(path.join(phase01, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(phase02, '02-01-PLAN.md'), '# Plan');
 
-    const result = runGsdTools('phases list --type plans --phase 01', tmpDir);
+    const result = runGsdTools('phases list --type plans --phase 01 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -137,7 +137,7 @@ describe('phase next-decimal command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '06-feature'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '07-next'), { recursive: true });
 
-    const result = runGsdTools('phase next-decimal 06', tmpDir);
+    const result = runGsdTools('phase next-decimal 06 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -150,7 +150,7 @@ describe('phase next-decimal command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '06.1-hotfix'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '06.2-patch'), { recursive: true });
 
-    const result = runGsdTools('phase next-decimal 06', tmpDir);
+    const result = runGsdTools('phase next-decimal 06 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -163,7 +163,7 @@ describe('phase next-decimal command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '06.1-first'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '06.3-third'), { recursive: true });
 
-    const result = runGsdTools('phase next-decimal 06', tmpDir);
+    const result = runGsdTools('phase next-decimal 06 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -174,7 +174,7 @@ describe('phase next-decimal command', () => {
   test('handles single-digit phase input', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '06-feature'), { recursive: true });
 
-    const result = runGsdTools('phase next-decimal 6', tmpDir);
+    const result = runGsdTools('phase next-decimal 6 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -185,7 +185,7 @@ describe('phase next-decimal command', () => {
   test('returns error if base phase does not exist', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-start'), { recursive: true });
 
-    const result = runGsdTools('phase next-decimal 06', tmpDir);
+    const result = runGsdTools('phase next-decimal 06 --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -213,7 +213,7 @@ describe('phase-plan-index command', () => {
   test('empty phase directory returns empty plans array', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-api'), { recursive: true });
 
-    const result = runGsdTools('phase-plan-index 03', tmpDir);
+    const result = runGsdTools('phase-plan-index 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -242,7 +242,7 @@ files-modified: [prisma/schema.prisma, src/lib/db.ts]
 `
     );
 
-    const result = runGsdTools('phase-plan-index 03', tmpDir);
+    const result = runGsdTools('phase-plan-index 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -296,7 +296,7 @@ objective: API routes
 `
     );
 
-    const result = runGsdTools('phase-plan-index 03', tmpDir);
+    const result = runGsdTools('phase-plan-index 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -316,7 +316,7 @@ objective: API routes
     // Plan without summary
     fs.writeFileSync(path.join(phaseDir, '03-02-PLAN.md'), `---\nwave: 2\n---\n## Task 1`);
 
-    const result = runGsdTools('phase-plan-index 03', tmpDir);
+    const result = runGsdTools('phase-plan-index 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -341,7 +341,7 @@ objective: Manual review needed
 `
     );
 
-    const result = runGsdTools('phase-plan-index 03', tmpDir);
+    const result = runGsdTools('phase-plan-index 03 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -350,7 +350,7 @@ objective: Manual review needed
   });
 
   test('phase not found returns error', () => {
-    const result = runGsdTools('phase-plan-index 99', tmpDir);
+    const result = runGsdTools('phase-plan-index 99 --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -405,7 +405,7 @@ Output: App component
 `
     );
 
-    const result = runGsdTools('phase-plan-index 04', tmpDir);
+    const result = runGsdTools('phase-plan-index 04 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -447,7 +447,7 @@ Output: App.tsx with routing
 `
     );
 
-    const result = runGsdTools('phase-plan-index 04', tmpDir);
+    const result = runGsdTools('phase-plan-index 04 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -500,7 +500,7 @@ Create UI components
 `
     );
 
-    const result = runGsdTools('phase-plan-index 04', tmpDir);
+    const result = runGsdTools('phase-plan-index 04 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -569,7 +569,7 @@ Output: Chat component, API endpoints.
 `
     );
 
-    const result = runGsdTools('phase-plan-index 04', tmpDir);
+    const result = runGsdTools('phase-plan-index 04 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -611,7 +611,7 @@ describe('phase add command', () => {
 `
     );
 
-    const result = runGsdTools('phase add User Dashboard', tmpDir);
+    const result = runGsdTools('phase add User Dashboard --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -636,7 +636,7 @@ describe('phase add command', () => {
       `# Roadmap v1.0\n`
     );
 
-    const result = runGsdTools('phase add Initial Setup', tmpDir);
+    const result = runGsdTools('phase add Initial Setup --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -687,7 +687,7 @@ describe('phase insert command', () => {
     );
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-foundation'), { recursive: true });
 
-    const result = runGsdTools('phase insert 1 Fix Critical Bug', tmpDir);
+    const result = runGsdTools('phase insert 1 Fix Critical Bug --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -720,7 +720,7 @@ describe('phase insert command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-foundation'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01.1-hotfix'), { recursive: true });
 
-    const result = runGsdTools('phase insert 1 Another Fix', tmpDir);
+    const result = runGsdTools('phase insert 1 Another Fix --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -753,7 +753,7 @@ describe('phase insert command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '09.05-existing'), { recursive: true });
 
     // Pass unpadded "9.05" but roadmap has "09.05"
-    const result = runGsdTools('phase insert 9.05 Padding Test', tmpDir);
+    const result = runGsdTools('phase insert 9.05 Padding Test --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -793,7 +793,7 @@ describe('phase insert command', () => {
     );
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '05-feature-work'), { recursive: true });
 
-    const result = runGsdTools('phase insert 5 Hotfix', tmpDir);
+    const result = runGsdTools('phase insert 5 Hotfix --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -850,7 +850,7 @@ describe('phase remove command', () => {
     fs.writeFileSync(path.join(p3, '03-02-PLAN.md'), '# Plan 2');
 
     // Remove phase 2
-    const result = runGsdTools('phase remove 2', tmpDir);
+    const result = runGsdTools('phase remove 2 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -990,7 +990,7 @@ describe('phase complete command', () => {
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-api'), { recursive: true });
 
-    const result = runGsdTools('phase complete 1', tmpDir);
+    const result = runGsdTools('phase complete 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1027,7 +1027,7 @@ describe('phase complete command', () => {
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
 
-    const result = runGsdTools('phase complete 1', tmpDir);
+    const result = runGsdTools('phase complete 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1294,7 +1294,7 @@ describe('phase complete command', () => {
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
 
-    const result = runGsdTools('phase complete 1', tmpDir);
+    const result = runGsdTools('phase complete 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.requirements_updated, true, 'requirements_updated should be true');
@@ -1631,7 +1631,7 @@ describe('letter-suffix phase sorting', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '12B-hotfix'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '13-deploy'), { recursive: true });
 
-    const result = runGsdTools('phases list', tmpDir);
+    const result = runGsdTools('phases list --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1700,7 +1700,7 @@ describe('phase complete milestone-scoped next-phase', () => {
     // Phase 6 — next phase in milestone
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '06-dashboard'), { recursive: true });
 
-    const result = runGsdTools('phase complete 5', tmpDir);
+    const result = runGsdTools('phase complete 5 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1736,7 +1736,7 @@ describe('phase complete milestone-scoped next-phase', () => {
       fs.writeFileSync(path.join(phaseDir, `${padded}-01-SUMMARY.md`), '# Summary');
     }
 
-    const result = runGsdTools('phase complete 5', tmpDir);
+    const result = runGsdTools('phase complete 5 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1776,7 +1776,7 @@ describe('phase-plan-index file overlap detection', () => {
       `---\nwave: 1\nautonomous: true\nfiles_modified: [src/b.cjs, src/shared.cjs]\n---\n<objective>\nPlan B\n</objective>\n`
     );
 
-    const result = runGsdTools('phase-plan-index 25', tmpDir);
+    const result = runGsdTools('phase-plan-index 25 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1799,7 +1799,7 @@ describe('phase-plan-index file overlap detection', () => {
       `---\nwave: 1\nautonomous: true\nfiles_modified: [src/b.cjs]\n---\n<objective>\nPlan B\n</objective>\n`
     );
 
-    const result = runGsdTools('phase-plan-index 25', tmpDir);
+    const result = runGsdTools('phase-plan-index 25 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1820,7 +1820,7 @@ describe('phase-plan-index file overlap detection', () => {
       `---\nwave: 2\nautonomous: true\nfiles_modified: [src/shared.cjs]\n---\n<objective>\nPlan B\n</objective>\n`
     );
 
-    const result = runGsdTools('phase-plan-index 25', tmpDir);
+    const result = runGsdTools('phase-plan-index 25 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1846,7 +1846,7 @@ describe('phase-plan-index file overlap detection', () => {
       `---\nwave: 1\nautonomous: true\nfiles_modified: [x.cjs, z.cjs]\n---\n<objective>\nPlan C\n</objective>\n`
     );
 
-    const result = runGsdTools('phase-plan-index 25', tmpDir);
+    const result = runGsdTools('phase-plan-index 25 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1879,7 +1879,7 @@ describe('phase-plan-index file overlap detection', () => {
       `---\nwave: 1\nautonomous: true\nfiles_modified: []\n---\n<objective>\nPlan B\n</objective>\n`
     );
 
-    const result = runGsdTools('phase-plan-index 25', tmpDir);
+    const result = runGsdTools('phase-plan-index 25 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);

--- a/tests/pick-flag.test.cjs
+++ b/tests/pick-flag.test.cjs
@@ -7,6 +7,7 @@
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert');
+const fs = require('node:fs');
 const { runGsdTools } = require('./helpers.cjs');
 
 // ─── --pick flag ─────────────────────────────────────────────────────────────
@@ -37,7 +38,7 @@ describe('--pick flag', () => {
   });
 
   test('errors when --pick value starts with --', () => {
-    const result = runGsdTools(['generate-slug', 'test', '--pick', '--raw']);
+    const result = runGsdTools(['generate-slug', 'test', '--pick']);
     assert.strictEqual(result.success, false);
     assert.match(result.error, /Missing value for --pick/);
   });
@@ -54,5 +55,43 @@ describe('--pick flag', () => {
     assert.strictEqual(result.success, true);
     assert.ok(result.output.length > 0, 'timestamp should not be empty');
     assert.match(result.output, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ─── --file flag ────────────────────────────────────────────────────────────
+
+describe('--file flag (CLI integration)', () => {
+  test('--file outputs @file: prefixed path with valid JSON in temp file', () => {
+    const result = runGsdTools(['generate-slug', 'hello world', '--file', '--json']);
+    assert.strictEqual(result.success, true);
+    assert.ok(result.output.startsWith('@file:'), `Expected @file: prefix, got: ${result.output.slice(0, 50)}`);
+    const tmpPath = result.output.slice(6);
+    const contents = fs.readFileSync(tmpPath, 'utf-8');
+    const parsed = JSON.parse(contents);
+    assert.strictEqual(parsed.slug, 'hello-world');
+    try { fs.unlinkSync(tmpPath); } catch {}
+  });
+
+  test('--file with still writes raw value to stdout (not @file:)', () => {
+    const result = runGsdTools(['generate-slug', 'hello world', '--file']);
+    assert.strictEqual(result.success, true);
+    assert.ok(!result.output.startsWith('@file:'), 'Raw mode should not produce @file: output');
+    assert.strictEqual(result.output, 'hello-world');
+  });
+
+  test('--file --pick extracts field from temp file correctly', () => {
+    const result = runGsdTools(['generate-slug', 'hello world', '--file', '--pick', 'slug']);
+    assert.strictEqual(result.success, true);
+    assert.strictEqual(result.output, 'hello-world');
+    // --pick should NOT leave @file: in output
+    assert.ok(!result.output.startsWith('@file:'), '--pick should resolve @file: and extract field');
+  });
+
+  test('without --file, output is inline JSON (not @file:)', () => {
+    const result = runGsdTools(['generate-slug', 'hello world', '--json']);
+    assert.strictEqual(result.success, true);
+    assert.ok(!result.output.startsWith('@file:'), 'Default should be inline JSON');
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.slug, 'hello-world');
   });
 });

--- a/tests/pingpong.test.cjs
+++ b/tests/pingpong.test.cjs
@@ -174,7 +174,7 @@ describe('cmdPingpongCheck integration', () => {
     fs.writeFileSync(path.join(tmpDir, 'src', 'feature.js'), 'v2');
     execSync('git add -A && git commit -m "feat: update feature"', { cwd: tmpDir, stdio: 'pipe' });
 
-    const result = runGsdTools(['pingpong-check'], tmpDir);
+    const result = runGsdTools(['pingpong-check', '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.status, 'ok');
@@ -192,7 +192,7 @@ describe('cmdPingpongCheck integration', () => {
       { cwd: tmpDir, stdio: 'pipe' }
     );
 
-    const result = runGsdTools(['pingpong-check'], tmpDir);
+    const result = runGsdTools(['pingpong-check', '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.status, 'warning', `Expected warning, got: ${JSON.stringify(parsed)}`);
@@ -216,7 +216,7 @@ describe('cmdPingpongCheck integration', () => {
       { cwd: tmpDir, stdio: 'pipe' }
     );
 
-    const result = runGsdTools(['pingpong-check'], tmpDir);
+    const result = runGsdTools(['pingpong-check', '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.status, 'halt', `Expected halt, got: ${JSON.stringify(parsed)}`);
@@ -231,7 +231,7 @@ describe('cmdPingpongCheck integration', () => {
       );
     }
 
-    const result = runGsdTools(['pingpong-check'], tmpDir);
+    const result = runGsdTools(['pingpong-check', '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.status, 'ok', 'Single-author iteration should not trigger warning');
@@ -239,14 +239,14 @@ describe('cmdPingpongCheck integration', () => {
 
   test('Test 5: returns ok when no additional git history (fresh repo with initial commit only)', () => {
     // createTempGitProject already made initial commit, but no multi-author oscillation
-    const result = runGsdTools(['pingpong-check'], tmpDir);
+    const result = runGsdTools(['pingpong-check', '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.status, 'ok');
   });
 
   test('CLI integration: gsd-tools pingpong-check runs and returns valid JSON', () => {
-    const result = runGsdTools(['pingpong-check'], tmpDir);
+    const result = runGsdTools(['pingpong-check', '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     // Must be valid JSON
     let parsed;

--- a/tests/quick-research.test.cjs
+++ b/tests/quick-research.test.cjs
@@ -172,7 +172,7 @@ describe('quick task: research file in task directory', () => {
   });
 
   test('init quick returns valid task_dir for research file placement', () => {
-    const result = runGsdTools('init quick "Add caching layer"', tmpDir);
+    const result = runGsdTools('init quick "Add caching layer" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -201,7 +201,7 @@ describe('quick task: research file in task directory', () => {
     );
 
     const result = runGsdTools(
-      'verify-path-exists .planning/quick/1-test-task/1-RESEARCH.md',
+      'verify-path-exists .planning/quick/1-test-task/1-RESEARCH.md --json',
       tmpDir
     );
     assert.ok(result.success, `Command failed: ${result.error}`);
@@ -216,7 +216,7 @@ describe('quick task: research file in task directory', () => {
     fs.mkdirSync(quickTaskDir, { recursive: true });
 
     const result = runGsdTools(
-      'verify-path-exists .planning/quick/1-test-task/1-RESEARCH.md',
+      'verify-path-exists .planning/quick/1-test-task/1-RESEARCH.md --json',
       tmpDir
     );
     assert.ok(result.success, `Command failed: ${result.error}`);
@@ -243,7 +243,7 @@ describe('quick task: research file in task directory', () => {
 
     for (const artifact of artifacts) {
       const result = runGsdTools(
-        `verify-path-exists .planning/quick/1-add-caching/${artifact}`,
+        `verify-path-exists .planning/quick/1-add-caching/${artifact} --json`,
         tmpDir
       );
       assert.ok(result.success, `Command failed for ${artifact}: ${result.error}`);

--- a/tests/recurring-todos.test.cjs
+++ b/tests/recurring-todos.test.cjs
@@ -14,6 +14,12 @@ const os = require('os');
 const { resolveTmpDir } = require('./helpers.cjs');
 
 const { parseDuration, isRecurringDue, cmdTodoComplete, cmdRecurringDue, syncSingleRef } = require('../gsd-ng/bin/lib/commands.cjs');
+const { setJsonMode } = require('../gsd-ng/bin/lib/core.cjs');
+
+function withJsonMode(fn) {
+  setJsonMode(true);
+  try { return fn(); } finally { setJsonMode(false); }
+}
 
 /**
  * Capture stdout output from a function that uses fs.writeSync(1, ...) or process.stdout.write.
@@ -158,7 +164,7 @@ describe('cmdTodoComplete - recurring', () => {
 
     fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), todoContent, 'utf-8');
 
-    cmdTodoComplete(tmpDir, filename, true);
+    cmdTodoComplete(tmpDir, filename);
 
     // File should still be in pending/
     assert.ok(
@@ -192,7 +198,7 @@ describe('cmdTodoComplete - recurring', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), todoContent, 'utf-8');
 
     const beforeComplete = Date.now();
-    cmdTodoComplete(tmpDir, filename, true);
+    cmdTodoComplete(tmpDir, filename);
 
     const updatedContent = fs.readFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), 'utf-8');
     assert.ok(updatedContent.includes('last_completed:'), 'last_completed should be added to frontmatter');
@@ -220,7 +226,7 @@ describe('cmdTodoComplete - recurring', () => {
 
     fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), todoContent, 'utf-8');
 
-    cmdTodoComplete(tmpDir, filename, true);
+    cmdTodoComplete(tmpDir, filename);
 
     // File should be in done/ (original behavior uses 'completed' dir actually... let's check)
     // The existing code uses 'completed' dir name, not 'done'
@@ -259,7 +265,7 @@ describe('cmdRecurringDue', () => {
 
     fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'normal.md'), todoContent, 'utf-8');
 
-    const result = JSON.parse(captureOutput(() => cmdRecurringDue(tmpDir, false)));
+    const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdRecurringDue(tmpDir))));
     assert.strictEqual(result.count, 0);
     assert.deepStrictEqual(result.todos, []);
   });
@@ -284,7 +290,7 @@ describe('cmdRecurringDue', () => {
 
     fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'monthly-sync.md'), todoContent, 'utf-8');
 
-    const result = JSON.parse(captureOutput(() => cmdRecurringDue(tmpDir, false)));
+    const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdRecurringDue(tmpDir))));
     assert.strictEqual(result.count, 1);
     assert.strictEqual(result.todos[0].file, 'monthly-sync.md');
     assert.strictEqual(result.todos[0].title, 'Monthly sync check');
@@ -311,7 +317,7 @@ describe('cmdRecurringDue', () => {
 
     fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'recent.md'), todoContent, 'utf-8');
 
-    const result = JSON.parse(captureOutput(() => cmdRecurringDue(tmpDir, false)));
+    const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdRecurringDue(tmpDir))));
     assert.strictEqual(result.count, 0);
   });
 
@@ -332,7 +338,7 @@ describe('cmdRecurringDue', () => {
 
     fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', 'new-recurring.md'), todoContent, 'utf-8');
 
-    const result = JSON.parse(captureOutput(() => cmdRecurringDue(tmpDir, false)));
+    const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdRecurringDue(tmpDir))));
     assert.strictEqual(result.count, 1);
     assert.strictEqual(result.todos[0].last_completed, 'never');
   });
@@ -392,7 +398,7 @@ describe('cmdTodoComplete - inline issue sync', () => {
 
       fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), todoContent, 'utf-8');
 
-      const result = JSON.parse(captureOutput(() => cmdTodoComplete(tmpDir, filename, false)));
+      const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdTodoComplete(tmpDir, filename))));
       assert.strictEqual(result.completed, true, 'completion should succeed');
       assert.ok(result.synced !== undefined, 'result should include synced field when external_ref present');
       assert.ok(Array.isArray(result.synced), 'synced should be an array');
@@ -421,7 +427,7 @@ describe('cmdTodoComplete - inline issue sync', () => {
 
       fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), todoContent, 'utf-8');
 
-      const result = JSON.parse(captureOutput(() => cmdTodoComplete(tmpDir, filename, false)));
+      const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdTodoComplete(tmpDir, filename))));
       assert.strictEqual(result.recurring, true, 'should be marked as recurring');
       assert.strictEqual(result.synced, undefined, 'recurring completion should NOT include synced field');
     } finally {
@@ -446,7 +452,7 @@ describe('cmdTodoComplete - inline issue sync', () => {
 
       fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), todoContent, 'utf-8');
 
-      const result = JSON.parse(captureOutput(() => cmdTodoComplete(tmpDir, filename, false)));
+      const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdTodoComplete(tmpDir, filename))));
       assert.strictEqual(result.completed, true, 'completion should succeed');
       assert.strictEqual(result.synced, undefined, 'no external_ref means no sync field');
     } finally {
@@ -479,7 +485,7 @@ describe('cmdTodoComplete - inline issue sync', () => {
 
       fs.writeFileSync(path.join(tmpDir, '.planning', 'todos', 'pending', filename), todoContent, 'utf-8');
 
-      const result = JSON.parse(captureOutput(() => cmdTodoComplete(tmpDir, filename, false)));
+      const result = JSON.parse(captureOutput(() => withJsonMode(() => cmdTodoComplete(tmpDir, filename))));
       assert.strictEqual(result.completed, true, 'completion should succeed');
       assert.strictEqual(result.synced, undefined, 'auto_sync=false means no sync');
     } finally {

--- a/tests/roadmap.test.cjs
+++ b/tests/roadmap.test.cjs
@@ -38,7 +38,7 @@ Some description here.
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -58,7 +58,7 @@ Some description here.
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 5', tmpDir);
+    const result = runGsdTools('roadmap get-phase 5 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -78,7 +78,7 @@ Some description here.
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 2.1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 2.1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -105,7 +105,7 @@ This phase covers:
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -115,7 +115,7 @@ This phase covers:
   });
 
   test('handles missing ROADMAP.md gracefully', () => {
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -137,7 +137,7 @@ This phase covers:
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -158,7 +158,7 @@ This phase covers:
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -197,7 +197,7 @@ describe('roadmap get-phase depends_on and source_todos', () => {
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -218,7 +218,7 @@ describe('roadmap get-phase depends_on and source_todos', () => {
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -240,7 +240,7 @@ describe('roadmap get-phase depends_on and source_todos', () => {
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -265,7 +265,7 @@ describe('roadmap get-phase depends_on and source_todos', () => {
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -291,7 +291,7 @@ describe('roadmap analyze command', () => {
   });
 
   test('missing ROADMAP.md returns error', () => {
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -324,7 +324,7 @@ describe('roadmap analyze command', () => {
     fs.mkdirSync(p2, { recursive: true });
     fs.writeFileSync(path.join(p2, '02-01-PLAN.md'), '# Plan');
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -354,7 +354,7 @@ describe('roadmap analyze command', () => {
 `
     );
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -387,7 +387,7 @@ describe('roadmap analyze command', () => {
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan 1');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary 1');
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -427,7 +427,7 @@ describe('roadmap analyze disk status variants', () => {
     fs.mkdirSync(p1, { recursive: true });
     fs.writeFileSync(path.join(p1, '01-RESEARCH.md'), '# Research notes');
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -449,7 +449,7 @@ describe('roadmap analyze disk status variants', () => {
     fs.mkdirSync(p1, { recursive: true });
     fs.writeFileSync(path.join(p1, '01-CONTEXT.md'), '# Context notes');
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -470,7 +470,7 @@ describe('roadmap analyze disk status variants', () => {
     const p1 = path.join(tmpDir, '.planning', 'phases', '01-empty');
     fs.mkdirSync(p1, { recursive: true });
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -510,7 +510,7 @@ describe('roadmap analyze milestone extraction', () => {
 `
     );
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -551,7 +551,7 @@ describe('roadmap analyze missing phase details', () => {
 `
     );
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -576,7 +576,7 @@ describe('roadmap analyze missing phase details', () => {
 `
     );
 
-    const result = runGsdTools('roadmap analyze', tmpDir);
+    const result = runGsdTools('roadmap analyze --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -616,7 +616,7 @@ describe('roadmap get-phase success criteria', () => {
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -638,7 +638,7 @@ describe('roadmap get-phase success criteria', () => {
 `
     );
 
-    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const result = runGsdTools('roadmap get-phase 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -701,7 +701,7 @@ describe('roadmap update-plan-progress command', () => {
     fs.mkdirSync(p1, { recursive: true });
     fs.writeFileSync(path.join(p1, '01-CONTEXT.md'), '# Context');
 
-    const result = runGsdTools('roadmap update-plan-progress 1', tmpDir);
+    const result = runGsdTools('roadmap update-plan-progress 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -734,7 +734,7 @@ describe('roadmap update-plan-progress command', () => {
     fs.writeFileSync(path.join(p1, '01-02-PLAN.md'), '# Plan 2');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary 1');
 
-    const result = runGsdTools('roadmap update-plan-progress 1', tmpDir);
+    const result = runGsdTools('roadmap update-plan-progress 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -774,7 +774,7 @@ describe('roadmap update-plan-progress command', () => {
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan 1');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary 1');
 
-    const result = runGsdTools('roadmap update-plan-progress 1', tmpDir);
+    const result = runGsdTools('roadmap update-plan-progress 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -796,7 +796,7 @@ describe('roadmap update-plan-progress command', () => {
     fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan 1');
     fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary 1');
 
-    const result = runGsdTools('roadmap update-plan-progress 1', tmpDir);
+    const result = runGsdTools('roadmap update-plan-progress 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -938,7 +938,7 @@ status: testing
     const p2 = path.join(tmpDir, '.planning', 'phases', '02-features');
     fs.mkdirSync(p2, { recursive: true });
 
-    const result = runGsdTools(['roadmap', 'analyze', '--current'], tmpDir);
+    const result = runGsdTools(['roadmap', 'analyze', '--current', '--json'], tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -979,7 +979,7 @@ status: testing
 `
     );
 
-    const result = runGsdTools(['roadmap', 'analyze', '--current'], tmpDir);
+    const result = runGsdTools(['roadmap', 'analyze', '--current', '--json'], tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1086,6 +1086,58 @@ describe('format contract tests — lineage and D10/D11 chain', () => {
     } finally {
       cleanup(tmpDir);
     }
+  });
+});
+
+// ─── roadmap get-phase --default flag ───────────────────────────────────────
+
+describe('roadmap get-phase --default flag', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('returns default value when ROADMAP.md not found', () => {
+    const result = runGsdTools(['roadmap', 'get-phase', '1', '--default', '{}'], tmpDir);
+    assert.ok(result.success, `Command should exit 0 with --default, got: ${result.error}`);
+    assert.strictEqual(result.output, '{}', `Expected "{}", got: ${result.output}`);
+  });
+
+  test('returns default value when phase not found', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n### Phase 1: Test\n**Goal:** Test goal\n`
+    );
+    const result = runGsdTools(['roadmap', 'get-phase', '99', '--default', '{}'], tmpDir);
+    assert.ok(result.success, `Command should exit 0 with --default`);
+    assert.strictEqual(result.output, '{}', `Expected "{}", got: ${result.output}`);
+  });
+
+  test('returns actual phase data when phase found (default unused)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n### Phase 1: Auth\n**Goal:** Build auth\n`
+    );
+    const result = runGsdTools(['roadmap', 'get-phase', '1', '--default', '{}', '--json'], tmpDir);
+    assert.ok(result.success, 'Command should succeed');
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.found, true, 'Should find phase 1');
+  });
+
+  test('preserves found:false when no --default and phase not found', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n### Phase 1: Test\n**Goal:** Test goal\n`
+    );
+    const result = runGsdTools(['roadmap', 'get-phase', '99', '--json'], tmpDir);
+    assert.ok(result.success, 'Command should exit 0');
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.found, false, 'Should return found:false without --default');
   });
 });
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -38,7 +38,7 @@ describe('state-snapshot command', () => {
   });
 
   test('missing STATE.md returns error', () => {
-    const result = runGsdTools('state-snapshot', tmpDir);
+    const result = runGsdTools('state-snapshot --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -62,7 +62,7 @@ describe('state-snapshot command', () => {
 `
     );
 
-    const result = runGsdTools('state-snapshot', tmpDir);
+    const result = runGsdTools('state-snapshot --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -92,7 +92,7 @@ describe('state-snapshot command', () => {
 `
     );
 
-    const result = runGsdTools('state-snapshot', tmpDir);
+    const result = runGsdTools('state-snapshot --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -116,7 +116,7 @@ describe('state-snapshot command', () => {
 `
     );
 
-    const result = runGsdTools('state-snapshot', tmpDir);
+    const result = runGsdTools('state-snapshot --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -141,7 +141,7 @@ describe('state-snapshot command', () => {
 `
     );
 
-    const result = runGsdTools('state-snapshot', tmpDir);
+    const result = runGsdTools('state-snapshot --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -160,7 +160,7 @@ describe('state-snapshot command', () => {
 `
     );
 
-    const result = runGsdTools('state-snapshot', tmpDir);
+    const result = runGsdTools('state-snapshot --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -179,7 +179,7 @@ describe('state-snapshot command', () => {
     const outsideDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-test-outside-'));
 
     try {
-      const result = runGsdTools(`state-snapshot --cwd "${tmpDir}"`, outsideDir);
+      const result = runGsdTools(`state-snapshot --cwd "${tmpDir}"` + ` --json`, outsideDir);
       assert.ok(result.success, `Command failed: ${result.error}`);
 
       const output = JSON.parse(result.output);
@@ -331,7 +331,7 @@ describe('state json command', () => {
   });
 
   test('missing STATE.md returns error', () => {
-    const result = runGsdTools('state json', tmpDir);
+    const result = runGsdTools('state json --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -354,7 +354,7 @@ describe('state json command', () => {
 `
     );
 
-    const result = runGsdTools('state json', tmpDir);
+    const result = runGsdTools('state json --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -386,7 +386,7 @@ stopped_at: Plan 2 of Phase 3
 `
     );
 
-    const result = runGsdTools('state json', tmpDir);
+    const result = runGsdTools('state json --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -412,7 +412,7 @@ stopped_at: Plan 2 of Phase 3
         `# State\n\n**Current Phase:** 01\n**Status:** ${input}\n`
       );
 
-      const result = runGsdTools('state json', tmpDir);
+      const result = runGsdTools('state json --json', tmpDir);
       assert.ok(result.success, `Command failed for status "${input}": ${result.error}`);
       const output = JSON.parse(result.output);
       assert.strictEqual(output.status, expected, `"${input}" should normalize to "${expected}"`);
@@ -531,9 +531,9 @@ milestone: v1.0
 `
     );
 
-    runGsdTools('state update Status "Executing Plan 5"', tmpDir);
+    runGsdTools('state update Status "Executing Plan 5" --json', tmpDir);
 
-    const result = runGsdTools('state json', tmpDir);
+    const result = runGsdTools('state json --json', tmpDir);
     assert.ok(result.success, `state json failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -656,7 +656,7 @@ describe('cmdStateLoad (state load)', () => {
       '# Roadmap\n'
     );
 
-    const result = runGsdTools('state load', tmpDir);
+    const result = runGsdTools('state load --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -667,7 +667,7 @@ describe('cmdStateLoad (state load)', () => {
   });
 
   test('returns state_exists false when STATE.md missing', () => {
-    const result = runGsdTools('state load', tmpDir);
+    const result = runGsdTools('state load --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -675,7 +675,7 @@ describe('cmdStateLoad (state load)', () => {
     assert.strictEqual(output.state_raw, '', 'state_raw should be empty string');
   });
 
-  test('returns raw key=value format with --raw flag', () => {
+  test('returns JSON with state_exists and config_exists fields', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
       '# Project State\n\n**Status:** Active\n'
@@ -685,11 +685,12 @@ describe('cmdStateLoad (state load)', () => {
       JSON.stringify({ mode: 'yolo' })
     );
 
-    const result = runGsdTools('state load --raw', tmpDir);
+    const result = runGsdTools('state load --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
-    assert.ok(result.output.includes('state_exists=true'), 'raw output should include state_exists=true');
-    assert.ok(result.output.includes('config_exists=true'), 'raw output should include config_exists=true');
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.state_exists, true, 'state_exists should be true');
+    assert.strictEqual(output.config_exists, true, 'config_exists should be true');
   });
 });
 
@@ -708,7 +709,7 @@ describe('cmdStateGet (state get)', () => {
     const stateContent = '---\nstatus: completed\n---\n# Project State\n\n**Status:** Active\n**Current Phase:** 03\n';
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
 
-    const result = runGsdTools('state get', tmpDir);
+    const result = runGsdTools('state get --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -724,7 +725,7 @@ describe('cmdStateGet (state get)', () => {
       '# Project State\n\n**Status:** Active\n'
     );
 
-    const result = runGsdTools('state get Status', tmpDir);
+    const result = runGsdTools('state get Status --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -737,7 +738,7 @@ describe('cmdStateGet (state get)', () => {
       '# Project State\n\n**Status:** Active\n\n## Blockers\n\n- item1\n- item2\n'
     );
 
-    const result = runGsdTools('state get Blockers', tmpDir);
+    const result = runGsdTools('state get Blockers --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -754,7 +755,7 @@ describe('cmdStateGet (state get)', () => {
       '# Project State\n\n**Status:** Active\n'
     );
 
-    const result = runGsdTools('state get Missing', tmpDir);
+    const result = runGsdTools('state get Missing --json', tmpDir);
     assert.ok(result.success, `Command should exit 0 even for missing field: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -858,7 +859,7 @@ describe('cmdStatePatch and cmdStateUpdate (state patch, state update)', () => {
   test('state patch reports failed fields that do not exist', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
 
-    const result = runGsdTools('state patch --Status Done --Missing value', tmpDir);
+    const result = runGsdTools('state patch --Status Done --Missing value --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -871,7 +872,7 @@ describe('cmdStatePatch and cmdStateUpdate (state patch, state update)', () => {
   test('state update changes a single field', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
 
-    const result = runGsdTools('state update Status "Phase complete"', tmpDir);
+    const result = runGsdTools('state update Status "Phase complete" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -886,7 +887,7 @@ describe('cmdStatePatch and cmdStateUpdate (state patch, state update)', () => {
   test('state update reports field not found', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
 
-    const result = runGsdTools('state update Missing value', tmpDir);
+    const result = runGsdTools('state update Missing value --json', tmpDir);
     assert.ok(result.success, `Command should exit 0 for not-found field: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -895,7 +896,7 @@ describe('cmdStatePatch and cmdStateUpdate (state patch, state update)', () => {
   });
 
   test('state update returns error when STATE.md missing', () => {
-    const result = runGsdTools('state update Status value', tmpDir);
+    const result = runGsdTools('state update Status value --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -935,7 +936,7 @@ describe('cmdStateAdvancePlan (state advance-plan)', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), advanceFixture);
 
     const before = new Date().toISOString().split('T')[0];
-    const result = runGsdTools('state advance-plan', tmpDir);
+    const result = runGsdTools('state advance-plan --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -958,7 +959,7 @@ describe('cmdStateAdvancePlan (state advance-plan)', () => {
     const lastPlanFixture = advanceFixture.replace('**Current Plan:** 1', '**Current Plan:** 3');
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), lastPlanFixture);
 
-    const result = runGsdTools('state advance-plan', tmpDir);
+    const result = runGsdTools('state advance-plan --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -971,7 +972,7 @@ describe('cmdStateAdvancePlan (state advance-plan)', () => {
   });
 
   test('returns error when STATE.md missing', () => {
-    const result = runGsdTools('state advance-plan', tmpDir);
+    const result = runGsdTools('state advance-plan --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -985,7 +986,7 @@ describe('cmdStateAdvancePlan (state advance-plan)', () => {
       '# Project State\n\n**Status:** Active\n'
     );
 
-    const result = runGsdTools('state advance-plan', tmpDir);
+    const result = runGsdTools('state advance-plan --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -999,7 +1000,7 @@ describe('cmdStateAdvancePlan (state advance-plan)', () => {
       `# Project State\n\nPlan: 2 of 5 in current phase\nStatus: In progress\nLast activity: 2025-01-01\n`
     );
 
-    const result = runGsdTools('state advance-plan', tmpDir);
+    const result = runGsdTools('state advance-plan --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1021,7 +1022,7 @@ describe('cmdStateAdvancePlan (state advance-plan)', () => {
       `# Project State\n\nPlan: 3 of 3 in current phase\nStatus: In progress\nLast activity: 2025-01-01\n`
     );
 
-    const result = runGsdTools('state advance-plan', tmpDir);
+    const result = runGsdTools('state advance-plan --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1059,7 +1060,7 @@ describe('cmdStateRecordMetric (state record-metric)', () => {
   test('appends metric row to existing table', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), metricsFixture);
 
-    const result = runGsdTools('state record-metric --phase 2 --plan 1 --duration 5min --tasks 3 --files 4', tmpDir);
+    const result = runGsdTools('state record-metric --phase 2 --plan 1 --duration 5min --tasks 3 --files 4 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1095,7 +1096,7 @@ describe('cmdStateRecordMetric (state record-metric)', () => {
   test('returns error when required fields missing', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), metricsFixture);
 
-    const result = runGsdTools('state record-metric --phase 1', tmpDir);
+    const result = runGsdTools('state record-metric --phase 1 --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1107,7 +1108,7 @@ describe('cmdStateRecordMetric (state record-metric)', () => {
   });
 
   test('returns error when STATE.md missing', () => {
-    const result = runGsdTools('state record-metric --phase 1 --plan 1 --duration 2min', tmpDir);
+    const result = runGsdTools('state record-metric --phase 1 --plan 1 --duration 2min --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1144,7 +1145,7 @@ describe('cmdStateUpdateProgress (state update-progress)', () => {
     fs.mkdirSync(phase02Dir, { recursive: true });
     fs.writeFileSync(path.join(phase02Dir, '02-01-PLAN.md'), '# Plan\n');
 
-    const result = runGsdTools('state update-progress', tmpDir);
+    const result = runGsdTools('state update-progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1163,7 +1164,7 @@ describe('cmdStateUpdateProgress (state update-progress)', () => {
       '# Project State\n\n**Progress:** [░░░░░░░░░░] 0%\n'
     );
 
-    const result = runGsdTools('state update-progress', tmpDir);
+    const result = runGsdTools('state update-progress --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1176,7 +1177,7 @@ describe('cmdStateUpdateProgress (state update-progress)', () => {
       '# Project State\n\n**Status:** Active\n'
     );
 
-    const result = runGsdTools('state update-progress', tmpDir);
+    const result = runGsdTools('state update-progress --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1185,7 +1186,7 @@ describe('cmdStateUpdateProgress (state update-progress)', () => {
   });
 
   test('returns error when STATE.md missing', () => {
-    const result = runGsdTools('state update-progress', tmpDir);
+    const result = runGsdTools('state update-progress --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1224,7 +1225,7 @@ describe('cmdStateResolveBlocker (state resolve-blocker)', () => {
   test('removes matching blocker line (case-insensitive substring match)', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), blockerFixture);
 
-    const result = runGsdTools('state resolve-blocker --text "api credentials"', tmpDir);
+    const result = runGsdTools('state resolve-blocker --text "api credentials" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1263,7 +1264,7 @@ describe('cmdStateResolveBlocker (state resolve-blocker)', () => {
   test('returns error when text not provided', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), blockerFixture);
 
-    const result = runGsdTools('state resolve-blocker', tmpDir);
+    const result = runGsdTools('state resolve-blocker --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1275,7 +1276,7 @@ describe('cmdStateResolveBlocker (state resolve-blocker)', () => {
   });
 
   test('returns error when STATE.md missing', () => {
-    const result = runGsdTools('state resolve-blocker --text "anything"', tmpDir);
+    const result = runGsdTools('state resolve-blocker --text "anything" --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1286,7 +1287,7 @@ describe('cmdStateResolveBlocker (state resolve-blocker)', () => {
   test('returns resolved true even if no line matches', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), blockerFixture);
 
-    const result = runGsdTools('state resolve-blocker --text "nonexistent blocker text"', tmpDir);
+    const result = runGsdTools('state resolve-blocker --text "nonexistent blocker text" --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1319,7 +1320,7 @@ describe('cmdStateRecordSession (state record-session)', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), sessionFixture);
 
     const result = runGsdTools(
-      'state record-session --stopped-at "Phase 3, Plan 2" --resume-file ".planning/phases/03/03-02-PLAN.md"',
+      'state record-session --stopped-at "Phase 3, Plan 2" --resume-file ".planning/phases/03/03-02-PLAN.md" --json',
       tmpDir
     );
     assert.ok(result.success, `Command failed: ${result.error}`);
@@ -1339,7 +1340,7 @@ describe('cmdStateRecordSession (state record-session)', () => {
   test('updates Last session timestamp even with no other options', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), sessionFixture);
 
-    const result = runGsdTools('state record-session', tmpDir);
+    const result = runGsdTools('state record-session --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1365,7 +1366,7 @@ describe('cmdStateRecordSession (state record-session)', () => {
   });
 
   test('returns error when STATE.md missing', () => {
-    const result = runGsdTools('state record-session', tmpDir);
+    const result = runGsdTools('state record-session --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1379,7 +1380,7 @@ describe('cmdStateRecordSession (state record-session)', () => {
       '# Project State\n\n**Status:** Active\n**Phase:** 03\n'
     );
 
-    const result = runGsdTools('state record-session', tmpDir);
+    const result = runGsdTools('state record-session --json', tmpDir);
     assert.ok(result.success, `Command should exit 0: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1438,7 +1439,7 @@ describe('milestone-scoped phase counting in frontmatter', () => {
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     // Read the state json to check frontmatter
-    const jsonResult = runGsdTools('state json', tmpDir);
+    const jsonResult = runGsdTools('state json --json', tmpDir);
     assert.ok(jsonResult.success, `state json failed: ${jsonResult.error}`);
 
     const output = JSON.parse(jsonResult.output);
@@ -1479,7 +1480,7 @@ describe('milestone-scoped phase counting in frontmatter', () => {
     const result = runGsdTools('state update Status "Executing"', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
-    const jsonResult = runGsdTools('state json', tmpDir);
+    const jsonResult = runGsdTools('state json --json', tmpDir);
     assert.ok(jsonResult.success, `state json failed: ${jsonResult.error}`);
 
     const output = JSON.parse(jsonResult.output);
@@ -1504,7 +1505,7 @@ describe('milestone-scoped phase counting in frontmatter', () => {
     const result = runGsdTools('state update Status "In progress"', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
-    const jsonResult = runGsdTools('state json', tmpDir);
+    const jsonResult = runGsdTools('state json --json', tmpDir);
     assert.ok(jsonResult.success, `state json failed: ${jsonResult.error}`);
 
     const output = JSON.parse(jsonResult.output);
@@ -1557,7 +1558,7 @@ describe('cmdStateBeginPhase (state begin-phase)', () => {
   test('updates STATE.md fields for new phase start', () => {
     fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), beginPhaseFixture);
 
-    const result = runGsdTools(['state', 'begin-phase', '--phase', '03', '--name', 'API Layer', '--plans', '4'], tmpDir);
+    const result = runGsdTools(['state', 'begin-phase', '--phase', '03', '--name', 'API Layer', '--plans', '4', '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const out = JSON.parse(result.output);
@@ -1638,7 +1639,7 @@ describe('state adjust-quick-table command', () => {
       `# Project State\n\n**Current Phase:** 01\n`
     );
 
-    const result = runGsdTools('state adjust-quick-table', tmpDir);
+    const result = runGsdTools('state adjust-quick-table --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1653,7 +1654,7 @@ describe('state adjust-quick-table command', () => {
       `# Project State\n\n### Quick Tasks Completed\n\n| # | Description | Date | Commit | Status | Directory |\n|---|-------------|------|--------|--------|-----------|`
     );
 
-    const result = runGsdTools('state adjust-quick-table', tmpDir);
+    const result = runGsdTools('state adjust-quick-table --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1668,7 +1669,7 @@ describe('state adjust-quick-table command', () => {
       `# Project State\n\n### Quick Tasks Completed\n\n| # | Description | Date | Commit | Directory |\n|---|-------------|------|--------|-----------|`
     );
 
-    const result = runGsdTools('state adjust-quick-table', tmpDir);
+    const result = runGsdTools('state adjust-quick-table --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1684,7 +1685,7 @@ describe('state adjust-quick-table command', () => {
 | 260101-a1b | Fix typo | 2026-01-01 | abc1234 | [260101-a1b-fix-typo](./quick/260101-a1b-fix-typo/) |`
     );
 
-    const result = runGsdTools('state adjust-quick-table', tmpDir);
+    const result = runGsdTools('state adjust-quick-table --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1715,7 +1716,7 @@ describe('state adjust-quick-table command', () => {
       `# Project State\n\n### Quick Tasks Completed\n\n| # | Description | Date | Commit | Directory |\n|---|-------------|------|--------|-----------|`
     );
 
-    const result = runGsdTools('state adjust-quick-table', tmpDir);
+    const result = runGsdTools('state adjust-quick-table --json', tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1768,7 +1769,7 @@ status: testing
 `
     );
 
-    const result = runGsdTools(['state-snapshot', '--current'], tmpDir);
+    const result = runGsdTools(['state-snapshot', '--current', '--json'], tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1808,7 +1809,7 @@ status: testing
 `
     );
 
-    const result = runGsdTools(['state-snapshot', '--current'], tmpDir);
+    const result = runGsdTools(['state-snapshot', '--current', '--json'], tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1841,7 +1842,7 @@ status: testing
 `
     );
 
-    const result = runGsdTools(['state-snapshot'], tmpDir);
+    const result = runGsdTools(['state-snapshot', '--json'], tmpDir);
     assert.ok(result.success, `Command should succeed: ${result.error}`);
 
     const output = JSON.parse(result.output);

--- a/tests/verify.test.cjs
+++ b/tests/verify.test.cjs
@@ -62,7 +62,7 @@ describe('validate consistency command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-b'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-c'), { recursive: true });
 
-    const result = runGsdTools('validate consistency', tmpDir);
+    const result = runGsdTools('validate consistency --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -78,7 +78,7 @@ describe('validate consistency command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-orphan'), { recursive: true });
 
-    const result = runGsdTools('validate consistency', tmpDir);
+    const result = runGsdTools('validate consistency --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -97,7 +97,7 @@ describe('validate consistency command', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-a'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '03-c'), { recursive: true });
 
-    const result = runGsdTools('validate consistency', tmpDir);
+    const result = runGsdTools('validate consistency --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -128,7 +128,7 @@ describe('verify plan-structure command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, '# No frontmatter here\n\nJust a plan without YAML.\n');
 
-    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -143,7 +143,7 @@ describe('verify plan-structure command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, validPlanContent());
 
-    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -179,7 +179,7 @@ describe('verify plan-structure command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, content);
 
-    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -216,7 +216,7 @@ describe('verify plan-structure command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, content);
 
-    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -230,7 +230,7 @@ describe('verify plan-structure command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, validPlanContent({ wave: 2, dependsOn: '[]' }));
 
-    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -276,7 +276,7 @@ describe('verify plan-structure command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, content);
 
-    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify plan-structure .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -287,7 +287,7 @@ describe('verify plan-structure command', () => {
   });
 
   test('returns error for nonexistent file', () => {
-    const result = runGsdTools('verify plan-structure .planning/phases/01-test/nonexistent.md', tmpDir);
+    const result = runGsdTools('verify plan-structure .planning/phases/01-test/nonexistent.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -325,7 +325,7 @@ describe('verify phase-completeness command', () => {
     fs.writeFileSync(path.join(phaseDir, '01-01-PLAN.md'), '# Plan\n');
     fs.writeFileSync(path.join(phaseDir, '01-01-SUMMARY.md'), '# Summary\n');
 
-    const result = runGsdTools('verify phase-completeness 01', tmpDir);
+    const result = runGsdTools('verify phase-completeness 01 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -339,7 +339,7 @@ describe('verify phase-completeness command', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-test');
     fs.writeFileSync(path.join(phaseDir, '01-01-PLAN.md'), '# Plan\n');
 
-    const result = runGsdTools('verify phase-completeness 01', tmpDir);
+    const result = runGsdTools('verify phase-completeness 01 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -358,7 +358,7 @@ describe('verify phase-completeness command', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-test');
     fs.writeFileSync(path.join(phaseDir, '01-01-SUMMARY.md'), '# Summary\n');
 
-    const result = runGsdTools('verify phase-completeness 01', tmpDir);
+    const result = runGsdTools('verify phase-completeness 01 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -369,7 +369,7 @@ describe('verify phase-completeness command', () => {
   });
 
   test('returns error for nonexistent phase', () => {
-    const result = runGsdTools('verify phase-completeness 99', tmpDir);
+    const result = runGsdTools('verify phase-completeness 99 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -394,7 +394,7 @@ describe('verify summary command', () => {
   });
 
   test('returns not found for nonexistent summary', () => {
-    const result = runGsdTools('verify-summary .planning/phases/01-test/nonexistent.md', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/nonexistent.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -425,7 +425,7 @@ describe('verify summary command', () => {
       `Commit: ${hash}`,
     ].join('\n'));
 
-    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -442,7 +442,7 @@ describe('verify summary command', () => {
       'Created: `src/nonexistent.js`',
     ].join('\n'));
 
-    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -462,7 +462,7 @@ describe('verify summary command', () => {
       'All tests pass',
     ].join('\n'));
 
-    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -479,7 +479,7 @@ describe('verify summary command', () => {
       'Tests failed',
     ].join('\n'));
 
-    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -496,7 +496,7 @@ describe('verify summary command', () => {
       'Everything went well.',
     ].join('\n'));
 
-    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -516,7 +516,7 @@ describe('verify summary command', () => {
       'Some content here without a self-check heading.',
     ].join('\n'));
 
-    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -534,7 +534,7 @@ describe('verify summary command', () => {
     ].join('\n'));
 
     // Pass checkFileCount = 1 so only 1 file is checked
-    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --check-count 1', tmpDir);
+    const result = runGsdTools('verify-summary .planning/phases/01-test/01-01-SUMMARY.md --check-count 1 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -567,7 +567,7 @@ describe('verify references command', () => {
     const filePath = path.join(tmpDir, '.planning', 'phases', '01-test', 'doc.md');
     fs.writeFileSync(filePath, '@src/app.js\n');
 
-    const result = runGsdTools('verify references .planning/phases/01-test/doc.md', tmpDir);
+    const result = runGsdTools('verify references .planning/phases/01-test/doc.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -579,7 +579,7 @@ describe('verify references command', () => {
     const filePath = path.join(tmpDir, '.planning', 'phases', '01-test', 'doc.md');
     fs.writeFileSync(filePath, '@src/missing.js\n');
 
-    const result = runGsdTools('verify references .planning/phases/01-test/doc.md', tmpDir);
+    const result = runGsdTools('verify references .planning/phases/01-test/doc.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -595,7 +595,7 @@ describe('verify references command', () => {
     const filePath = path.join(tmpDir, '.planning', 'phases', '01-test', 'doc.md');
     fs.writeFileSync(filePath, 'See `src/utils/helper.js` for details.\n');
 
-    const result = runGsdTools('verify references .planning/phases/01-test/doc.md', tmpDir);
+    const result = runGsdTools('verify references .planning/phases/01-test/doc.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -608,7 +608,7 @@ describe('verify references command', () => {
     const filePath = path.join(tmpDir, '.planning', 'phases', '01-test', 'doc.md');
     fs.writeFileSync(filePath, '`${variable}/path/file.js`\n');
 
-    const result = runGsdTools('verify references .planning/phases/01-test/doc.md', tmpDir);
+    const result = runGsdTools('verify references .planning/phases/01-test/doc.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -617,7 +617,7 @@ describe('verify references command', () => {
   });
 
   test('returns error for nonexistent file', () => {
-    const result = runGsdTools('verify references .planning/phases/01-test/nonexistent.md', tmpDir);
+    const result = runGsdTools('verify references .planning/phases/01-test/nonexistent.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -643,7 +643,7 @@ describe('verify commits command', () => {
   test('validates real commit hashes', () => {
     const hash = execSync('git rev-parse --short HEAD', { cwd: tmpDir, encoding: 'utf-8' }).trim();
 
-    const result = runGsdTools(`verify commits ${hash}`, tmpDir);
+    const result = runGsdTools(`verify commits ${hash} --json`, tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -652,7 +652,7 @@ describe('verify commits command', () => {
   });
 
   test('reports invalid for fake hashes', () => {
-    const result = runGsdTools('verify commits abcdef1234567', tmpDir);
+    const result = runGsdTools('verify commits abcdef1234567 --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -666,7 +666,7 @@ describe('verify commits command', () => {
   test('handles mixed valid and invalid hashes', () => {
     const hash = execSync('git rev-parse --short HEAD', { cwd: tmpDir, encoding: 'utf-8' }).trim();
 
-    const result = runGsdTools(`verify commits ${hash} abcdef1234567`, tmpDir);
+    const result = runGsdTools(`verify commits ${hash} abcdef1234567 --json`, tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -731,7 +731,7 @@ describe('verify artifacts command', () => {
     ]);
     fs.writeFileSync(path.join(tmpDir, 'src', 'app.js'), 'const x = 1;\nexport default x;\nconst y = 2;\n');
 
-    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -743,7 +743,7 @@ describe('verify artifacts command', () => {
       '- path: "src/nonexistent.js"',
     ]);
 
-    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -761,7 +761,7 @@ describe('verify artifacts command', () => {
     ]);
     fs.writeFileSync(path.join(tmpDir, 'src', 'app.js'), 'const x = 1;\n');
 
-    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -779,7 +779,7 @@ describe('verify artifacts command', () => {
     ]);
     fs.writeFileSync(path.join(tmpDir, 'src', 'app.js'), 'const x = 1;\n');
 
-    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -798,7 +798,7 @@ describe('verify artifacts command', () => {
     ]);
     fs.writeFileSync(path.join(tmpDir, 'src', 'app.js'), 'const x = 1;\nexport const POST = () => {};\n');
 
-    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -829,7 +829,7 @@ describe('verify artifacts command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, content);
 
-    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify artifacts .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -897,7 +897,7 @@ describe('verify key-links command', () => {
     fs.writeFileSync(path.join(tmpDir, 'src', 'a.js'), "import { x } from './b';\n");
     fs.writeFileSync(path.join(tmpDir, 'src', 'b.js'), 'exports.x = 1;\n');
 
-    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -914,7 +914,7 @@ describe('verify key-links command', () => {
     fs.writeFileSync(path.join(tmpDir, 'src', 'a.js'), 'const x = 1;\n');
     fs.writeFileSync(path.join(tmpDir, 'src', 'b.js'), 'exports.targetFunc = () => {};\n');
 
-    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -934,7 +934,7 @@ describe('verify key-links command', () => {
     fs.writeFileSync(path.join(tmpDir, 'src', 'a.js'), 'const x = 1;\n');
     fs.writeFileSync(path.join(tmpDir, 'src', 'b.js'), 'const y = 2;\n');
 
-    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -951,7 +951,7 @@ describe('verify key-links command', () => {
     fs.writeFileSync(path.join(tmpDir, 'src', 'a.js'), "const b = require('./src/b.js');\n");
     fs.writeFileSync(path.join(tmpDir, 'src', 'b.js'), 'module.exports = {};\n');
 
-    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -970,7 +970,7 @@ describe('verify key-links command', () => {
     ]);
     fs.writeFileSync(path.join(tmpDir, 'src', 'b.js'), 'module.exports = {};\n');
 
-    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
@@ -1000,7 +1000,7 @@ describe('verify key-links command', () => {
     const planPath = path.join(tmpDir, '.planning', 'phases', '01-test', '01-01-PLAN.md');
     fs.writeFileSync(planPath, content);
 
-    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);

--- a/tests/workspace.test.cjs
+++ b/tests/workspace.test.cjs
@@ -416,7 +416,7 @@ describe('end-to-end pipeline', () => {
     const origOutput = require('../gsd-ng/bin/lib/core.cjs').output;
 
     // Use runGsdTools CLI (gsd-tools validate health) to avoid process.exit(0) side effects
-    const result = runGsdTools(['validate', 'health', '--cwd', tmpDir], tmpDir);
+    const result = runGsdTools(['validate', 'health', '--cwd', tmpDir, '--json'], tmpDir);
 
     assert.ok(result.output, 'health check should produce output');
     let parsed;
@@ -446,7 +446,7 @@ describe('cmdDetectWorkspace via gsd-tools', () => {
   });
 
   test('outputs valid JSON with type and signal fields', () => {
-    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir], tmpDir);
+    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir, '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     let parsed;
@@ -461,7 +461,7 @@ describe('cmdDetectWorkspace via gsd-tools', () => {
   test('reports submodule type for project with .gitmodules', () => {
     fs.writeFileSync(path.join(tmpDir, '.gitmodules'), '[submodule "foo"]\n  path = foo\n  url = https://example.com\n');
 
-    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir], tmpDir);
+    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir, '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const parsed = JSON.parse(result.output);
@@ -470,7 +470,7 @@ describe('cmdDetectWorkspace via gsd-tools', () => {
   });
 
   test('reports standalone for project without workspace signals', () => {
-    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir], tmpDir);
+    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir, '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const parsed = JSON.parse(result.output);
@@ -481,7 +481,7 @@ describe('cmdDetectWorkspace via gsd-tools', () => {
   test('includes submodule_paths field for submodule workspace', () => {
     fs.writeFileSync(path.join(tmpDir, '.gitmodules'),
       '[submodule "mylib"]\n\tpath = mylib\n\turl = https://example.com\n');
-    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir], tmpDir);
+    const result = runGsdTools(['detect-workspace', '--cwd', tmpDir, '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.type, 'submodule');
@@ -747,7 +747,7 @@ describe('resolveGitContext', () => {
         path.join(nonGitDir, '.planning', 'STATE.md'),
         '---\ngsd_state_version: 1.0\nmilestone: test\ncurrent_phase: 1\ncurrent_plan: Not started\nstatus: testing\n---\n\n# Project State\n'
       );
-      const result = runGsdTools(['init', 'execute-phase', '1'], nonGitDir);
+      const result = runGsdTools(['init', 'execute-phase', '1', '--json'], nonGitDir);
       // The command should succeed (error caught internally)
       assert.ok(result.success, `init should succeed even for non-git dir: ${result.error}`);
       const parsed = JSON.parse(result.output);
@@ -834,21 +834,21 @@ describe('resolveGitContext', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('--field extraction on git-context and detect-workspace', () => {
-  test('git-context --field is_submodule --raw returns scalar string', () => {
-    const result = runGsdTools(['git-context', '--field', 'is_submodule', '--raw']);
+  test('git-context --field is_submodule returns scalar string', () => {
+    const result = runGsdTools(['git-context', '--field', 'is_submodule']);
     assert.ok(result.success, `should succeed: ${result.error}`);
     // Output should be "true" or "false", not JSON
     assert.ok(['true', 'false'].includes(result.output.trim()), `expected boolean string, got: ${result.output}`);
   });
 
-  test('detect-workspace --field type --raw returns workspace type string', () => {
-    const result = runGsdTools(['detect-workspace', '--field', 'type', '--raw']);
+  test('detect-workspace --field type returns workspace type string', () => {
+    const result = runGsdTools(['detect-workspace', '--field', 'type']);
     assert.ok(result.success, `should succeed: ${result.error}`);
     assert.ok(['standalone', 'submodule'].includes(result.output.trim()), `expected type string, got: ${result.output}`);
   });
 
-  test('detect-workspace --field type --raw returns no JSON braces', () => {
-    const result = runGsdTools(['detect-workspace', '--field', 'type', '--raw']);
+  test('detect-workspace --field type returns no JSON braces', () => {
+    const result = runGsdTools(['detect-workspace', '--field', 'type']);
     assert.ok(result.success);
     assert.ok(!result.output.includes('{'), 'output should not contain JSON braces');
   });
@@ -860,7 +860,7 @@ describe('--field extraction on git-context and detect-workspace', () => {
 
 describe('ssh-check command', () => {
   test('ssh-check with HTTPS URL returns not_required', () => {
-    const result = runGsdTools(['ssh-check', 'https://github.com/user/repo.git']);
+    const result = runGsdTools(['ssh-check', 'https://github.com/user/repo.git', '--json']);
     assert.ok(result.success, `should succeed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.ssh_required, false);
@@ -868,21 +868,21 @@ describe('ssh-check command', () => {
   });
 
   test('ssh-check with SSH URL returns ssh_required=true', () => {
-    const result = runGsdTools(['ssh-check', 'git@github.com:user/repo.git']);
+    const result = runGsdTools(['ssh-check', 'git@github.com:user/repo.git', '--json']);
     assert.ok(result.success, `should succeed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.ssh_required, true);
     assert.ok(['ok', 'no_identities', 'agent_not_running'].includes(parsed.status), `unexpected status: ${parsed.status}`);
   });
 
-  test('ssh-check with --field status --raw returns scalar', () => {
-    const result = runGsdTools(['ssh-check', 'https://github.com/user/repo.git', '--field', 'status', '--raw']);
+  test('ssh-check with --field status returns scalar', () => {
+    const result = runGsdTools(['ssh-check', 'https://github.com/user/repo.git', '--field', 'status']);
     assert.ok(result.success, `should succeed: ${result.error}`);
     assert.strictEqual(result.output.trim(), 'not_required');
   });
 
   test('ssh-check with no URL returns not_required', () => {
-    const result = runGsdTools(['ssh-check']);
+    const result = runGsdTools(['ssh-check', '--json']);
     assert.ok(result.success, `should succeed: ${result.error}`);
     const parsed = JSON.parse(result.output);
     assert.strictEqual(parsed.status, 'not_required');
@@ -900,7 +900,7 @@ describe('cmdGitContext CLI integration', () => {
   test('Test 9: CLI git-context outputs valid JSON with expected top-level keys including platform, cli, ssh_url', () => {
     tmpDir = createTempGitRepo('https://github.com/user/myrepo.git');
 
-    const result = runGsdTools(['git-context', '--cwd', tmpDir], tmpDir);
+    const result = runGsdTools(['git-context', '--cwd', tmpDir, '--json'], tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     let parsed;


### PR DESCRIPTION
## Summary

- Refactor the `output()` API to raw/scalar output by default, with `--json` as opt-in for structured JSON
- Remove `--raw` and `--resolve` flags entirely — raw is the default, inline is unconditional
- Add `--default` flag to config-get, frontmatter get, roadmap get-phase, summary-extract
- Add `--count` flag to staleness-check, `--file` flag for opt-in temp file output
- Add `todo list-by-phase` and `todo scan-phase-linked` subcommands
- Eliminate all AST-triggering bash patterns from workflows (here-strings, @file: unwrap blocks, brace expansion)
- Replace all `2>/dev/null || echo` fallbacks with `--default` flag
- Inject Claude Code AST safety rules into `CLAUDE.md` on install

**Background:** Claude Code's tree-sitter-bash AST safety layer fires independently of sandbox/allowlist settings. No config suppresses it. The only mitigation is writing AST-safe commands and modernizing the CLI output API so workflows don't need workaround patterns.

## Output API refactor

The `output()` function signature changed from `output(result, raw, rawValue)` to `output(result, displayValue)`:

| Scenario | Old | New |
|----------|-----|-----|
| Scalar command | `output(val, raw, String(val))` | `output(val)` |
| Structured command | `output(obj, raw)` | `output(obj)` — auto-detects object, emits JSON |
| Dual command | `output({slug: v}, raw, v)` | `output({slug: v}, v)` — displays `v` by default |
| JSON needed | `--raw` absent | `--json` flag |

- `--raw` removed entirely (was needed on 100% of callers — sign the default was wrong)
- `--json` added as opt-in for JSON-wrapped output
- `--pick` auto-activates JSON mode for field extraction
- `--resolve` removed — inline output is unconditional (50KB @file: threshold gone)
- `--file` added as opt-in for legacy @file: temp file mechanism

## CLI additions

- `staleness-check --count` — numeric-only output, no JSON parsing needed
- `config-get --default <value>` — CLI-level default instead of shell `2>/dev/null || echo`
- `frontmatter get --default`, `roadmap get-phase --default`, `summary-extract --default`
- `todo list-by-phase <N>` and `todo scan-phase-linked <N>`
- AST safety rules injected into `CLAUDE.md` on `gsd install --runtime claude` (skipped for Copilot)

## Workflow cleanup

- All `<<<` here-strings replaced with `echo | ` pipes
- All `[[ "$VAR" == @file:* ]]` unwrap blocks removed (no longer needed)
- All `2>/dev/null || echo` gsd-tools fallbacks replaced with `--default`
- All `--raw` references removed from workflows, agents, commands
- AST safety reference table added to `agent-shared-context.md`
- AST safety block extracted to `templates/ast-safety-rules.md`

## Test Plan

- [x] 1372 tests pass, 0 failures (81 files changed)
- [x] `output(result, displayValue)` emits scalar by default, JSON for objects
- [x] `--json` flag forces JSON output
- [x] `--pick` auto-activates JSON mode
- [x] `--file` produces @file: temp file output
- [x] `--file --pick` extracts field from temp file correctly
- [x] `--default` returns default value on missing data
- [x] `staleness-check --count` returns integer
- [x] `todo list-by-phase` and `todo scan-phase-linked` work
- [x] CLAUDE.md injection: create, append, idempotency, Copilot-skip
- [x] Zero `--raw`, `--resolve`, `<<<`, `@file:*` unwrap patterns remain in source

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng) from phase 47 execution*