### PR TITLE
feat: install-time templating and AskUserQuestion first-turn injection

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -16,6 +16,7 @@ const reset = '\x1b[0m';
 
 // Get version from package.json
 const pkg = require('../package.json');
+const { processTemplate, buildContext, injectAfterFrontmatter, injectAppendToFile, fillBetweenMarkers } = require('../gsd-ng/bin/lib/template-processor.cjs');
 
 // Parse args
 const args = process.argv.slice(2);
@@ -296,6 +297,11 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, isCommand = false)
       content = content.replace(localClaudeRegex, `./${dirName}/`);
       // Template variable: project rules file path (Claude Code uses CLAUDE.md)
       content = content.replace(/\{\{PROJECT_RULES_FILE\}\}/g, 'CLAUDE.md');
+      // Inject first-turn rule into Claude command files that use AskUserQuestion
+      if (isCommand && runtime === 'claude' && content.includes('AskUserQuestion')) {
+        const ftrTemplate = path.join(__dirname, '..', 'gsd-ng', 'templates', 'first-turn-rule.md');
+        content = injectAfterFrontmatter(content, ftrTemplate, 'first_turn_rule');
+      }
       content = processAttribution(content, getCommitAttribution());
       fs.writeFileSync(destPath, content);
     } else {
@@ -864,8 +870,10 @@ function convertClaudeToCopilotContent(content, isGlobal = false) {
   // Slash command prefix: gsd: → gsd- (applies to all Markdown content)
   out = out.replace(/gsd:/g, 'gsd-');
 
-  // Template variable: project rules file path
-  out = out.replace(/\{\{PROJECT_RULES_FILE\}\}/g, '.github/copilot-instructions.md');
+  // Resolve {{variables}} and <!-- ONLY:x --> conditional blocks via template-processor.
+  // Path rewriting stays above (separate per design — CONTEXT.md Decision #7).
+  const ctx = buildContext('copilot');
+  out = processTemplate(out, ctx);
 
   // Standalone CLAUDE.md references → copilot-instructions.md
   out = out.replace(/\bCLAUDE\.md\b/g, 'copilot-instructions.md');
@@ -981,67 +989,9 @@ function mergeCopilotInstructions(instructionsPath, templateContent) {
   }
 }
 
-/**
- * Append the GSD AST safety ruleset block to CLAUDE.md in cwd.
- * Idempotent: skips if the START marker is already present.
- * Only called for Claude Code runtime installs — Copilot CLI has no equivalent
- * AST safety layer and must never receive this injection.
- *
- * The template (gsd-ng/templates/ast-safety-rules.md) is the single source of
- * truth for AST safety rules. Issue links are preserved in the JSDoc above the
- * marker constants (search: GSD_AST_SAFETY_MARKER).
- *
- * @param {string} claudeMdPath - Absolute path to CLAUDE.md (in project cwd)
- */
-function injectAstSafetyBlock(claudeMdPath) {
-  // Check for existing marker (idempotency)
-  if (fs.existsSync(claudeMdPath)) {
-    const existing = fs.readFileSync(claudeMdPath, 'utf8');
-    if (existing.includes(GSD_AST_SAFETY_MARKER)) {
-      return; // Already injected — skip
-    }
-  }
-
-  const templatePath = path.join(__dirname, '..', 'gsd-ng', 'templates', 'ast-safety-rules.md');
-  const blockContent = fs.readFileSync(templatePath, 'utf8').trim();
-  const block = '\n' + blockContent + '\n';
-
-  if (fs.existsSync(claudeMdPath)) {
-    fs.appendFileSync(claudeMdPath, block, 'utf8');
-  } else {
-    fs.writeFileSync(claudeMdPath, block.trimStart(), 'utf8');
-  }
-}
-
-/**
- * Fill the GSD AST safety block in an installed file that has marker placeholders.
- * Unlike injectAstSafetyBlock (which appends to CLAUDE.md), this replaces content
- * between existing markers — keeping the file in sync with the template on every install.
- * Only called for Claude Code runtime installs.
- *
- * @param {string} filePath - Absolute path to the installed file containing AST safety markers
- */
-function fillAstSafetyBlock(filePath) {
-  if (!fs.existsSync(filePath)) return;
-  const existing = fs.readFileSync(filePath, 'utf8');
-  const startIdx = existing.indexOf(GSD_AST_SAFETY_MARKER);
-  const endIdx = existing.indexOf(GSD_AST_SAFETY_CLOSE_MARKER);
-  if (startIdx === -1 || endIdx === -1) return;
-
-  const templatePath = path.join(__dirname, '..', 'gsd-ng', 'templates', 'ast-safety-rules.md');
-  const template = fs.readFileSync(templatePath, 'utf8');
-
-  // Extract inner content between the template's own markers
-  const tStart = template.indexOf(GSD_AST_SAFETY_MARKER);
-  const tEnd = template.indexOf(GSD_AST_SAFETY_CLOSE_MARKER);
-  const innerContent = (tStart !== -1 && tEnd !== -1)
-    ? template.slice(tStart + GSD_AST_SAFETY_MARKER.length, tEnd)
-    : '\n' + template.trim() + '\n';
-
-  const before = existing.slice(0, startIdx + GSD_AST_SAFETY_MARKER.length);
-  const after = existing.slice(endIdx);
-  fs.writeFileSync(filePath, before + innerContent + after, 'utf8');
-}
+// injectFirstTurnRule, injectAstSafetyBlock, and fillAstSafetyBlock moved to
+// template-processor.cjs as injectAfterFrontmatter, injectAppendToFile, and
+// fillBetweenMarkers respectively.
 
 /**
  * Remove the GSD block from copilot-instructions.md content.
@@ -1341,14 +1291,44 @@ function install(isGlobal) {
   // agent-shared-context.md (marker placeholders) so subagents see them too.
   // Single source of truth: gsd-ng/templates/ast-safety-rules.md
   // See: https://github.com/anthropics/claude-code/issues/30435
-  if (!isCopilot) {
+  if (runtime === 'claude') {
     const claudeMdPath = path.join(process.cwd(), 'CLAUDE.md');
-    injectAstSafetyBlock(claudeMdPath);
+    const astTemplatePath = path.join(__dirname, '..', 'gsd-ng', 'templates', 'ast-safety-rules.md');
+    injectAppendToFile(claudeMdPath, astTemplatePath, GSD_AST_SAFETY_MARKER);
     console.log(`  ${green}✓${reset} Injected AST safety rules into CLAUDE.md`);
 
     const agentSharedContextPath = path.join(targetDir, 'gsd-ng', 'references', 'agent-shared-context.md');
-    fillAstSafetyBlock(agentSharedContextPath);
+    fillBetweenMarkers(agentSharedContextPath, astTemplatePath, GSD_AST_SAFETY_MARKER, GSD_AST_SAFETY_CLOSE_MARKER);
     console.log(`  ${green}✓${reset} Filled AST safety rules in agent-shared-context.md`);
+  }
+
+  // Resolve {{variables}} and <!-- ONLY:x --> markers in Claude workflow/reference/lib files.
+  // Uses template-processor.cjs (centralized template engine).
+  // Copilot path handles this separately in convertClaudeToCopilotContent().
+  // Path rewriting (e.g., ~/.claude/ -> ~/.copilot/) stays separate per design.
+  if (runtime === 'claude') {
+    const ctx = buildContext('claude');
+    const claudeTemplateDirs = [
+      path.join(targetDir, 'gsd-ng', 'workflows'),
+      path.join(targetDir, 'gsd-ng', 'references'),
+      path.join(targetDir, 'gsd-ng', 'bin', 'lib'),
+    ];
+    for (const dir of claudeTemplateDirs) {
+      if (!fs.existsSync(dir)) continue;
+      const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') || f.endsWith('.cjs'));
+      for (const file of files) {
+        const filePath = path.join(dir, file);
+        let content = fs.readFileSync(filePath, 'utf-8');
+        if (content.includes('{{') || content.includes('<!-- ONLY:')) {
+          try {
+            content = processTemplate(content, ctx);
+            fs.writeFileSync(filePath, content, 'utf-8');
+          } catch {
+            // Skip files with unbalanced markers (e.g., documentation containing example syntax)
+          }
+        }
+      }
+    }
   }
 
   // Report any backed-up local patches
@@ -1477,7 +1457,7 @@ function install(isGlobal) {
   }
 
   // Seed permissions.allow from settings-sandbox.json template
-  if (!noSeedPermissionsConfig && !isCopilot) {
+  if (!noSeedPermissionsConfig && runtime === 'claude') {
     const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
     try {
       const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
@@ -1530,7 +1510,7 @@ function install(isGlobal) {
   }
 
   // Seed sandbox settings by default (opt-out via --no-seed-sandbox-config)
-  if (!noSeedSandboxConfig && !isCopilot) {
+  if (!noSeedSandboxConfig && runtime === 'claude') {
     const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
     try {
       const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));

--- a/commands/gsd/add-tests.md
+++ b/commands/gsd/add-tests.md
@@ -16,6 +16,8 @@ argument-instructions: |
   Example: /gsd:add-tests 12
   Example: /gsd:add-tests 12 focus on edge cases in the pricing module
 ---
+
+
 <objective>
 Generate unit and E2E tests for a completed phase, using its SUMMARY.md, CONTEXT.md, and VERIFICATION.md as specifications.
 
@@ -36,9 +38,9 @@ Phase: $ARGUMENTS
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -58,7 +60,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/add-todo.md
+++ b/commands/gsd/add-todo.md
@@ -9,6 +9,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 <objective>
 Capture an idea, task, or issue that surfaces during a GSD session as a structured todo for later work.
 
@@ -33,9 +34,9 @@ State is resolved in-workflow via `init todos` and targeted reads.
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -55,7 +56,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/check-todos.md
+++ b/commands/gsd/check-todos.md
@@ -9,6 +9,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 <objective>
 List all pending todos, allow selection, load full context for the selected todo, and route to appropriate action.
 
@@ -32,9 +33,9 @@ Todo state and roadmap correlation are loaded in-workflow using `list-todos` and
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -54,7 +55,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/cleanup.md
+++ b/commands/gsd/cleanup.md
@@ -7,6 +7,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 Run the cleanup command in dry-run mode first, show the preview to the user, then ask for confirmation before executing:
 
 1. Show dry-run preview:
@@ -14,7 +15,7 @@ Run the cleanup command in dry-run mode first, show the preview to the user, the
 
 2. If nothing_to_do is true, tell the user "All milestones already archived. Nothing to clean up." and stop.
 
-3. Otherwise, show the preview and use AskUserQuestion to ask "Proceed with archiving?" with options "Yes, archive" and "Cancel".
+3. Otherwise, show the preview and use {{USER_QUESTION_TOOL}} to ask "Proceed with archiving?" with options "Yes, archive" and "Cancel".
 
 4. If confirmed, execute:
 !`node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" cleanup`

--- a/commands/gsd/complete-milestone.md
+++ b/commands/gsd/complete-milestone.md
@@ -10,6 +10,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 <objective>
 Mark milestone {{version}} complete, archive to milestones/, and update ROADMAP.md and REQUIREMENTS.md.
 
@@ -18,9 +19,9 @@ Output: Milestone archived (roadmap + requirements), PROJECT.md evolved, git tag
 </objective>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -40,7 +41,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <execution_context>

--- a/commands/gsd/create-pr.md
+++ b/commands/gsd/create-pr.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Grep
   - AskUserQuestion
 ---
+
+
 <objective>
 Create a pull/merge request from the current branch with auto-generated description from phase context.
 </objective>

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -9,6 +9,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 <objective>
 Debug issues using scientific method with subagent isolation.
 
@@ -27,9 +28,9 @@ ls .planning/debug/*.md 2>/dev/null | grep -v resolved | head -5
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -49,7 +50,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -14,6 +14,7 @@ allowed-tools:
   - mcp__context7__query-docs
 ---
 
+
 <objective>
 Extract implementation decisions that downstream agents need — researcher and planner will use CONTEXT.md to know what to investigate and what choices are locked.
 
@@ -29,9 +30,9 @@ Extract implementation decisions that downstream agents need — researcher and 
 </objective>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -51,7 +52,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <execution_context>

--- a/commands/gsd/do.md
+++ b/commands/gsd/do.md
@@ -7,6 +7,8 @@ allowed-tools:
   - Bash
   - AskUserQuestion
 ---
+
+
 <objective>
 Analyze freeform natural language input and dispatch to the most appropriate GSD command.
 
@@ -25,9 +27,9 @@ $ARGUMENTS
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -47,7 +49,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -13,6 +13,8 @@ allowed-tools:
   - TodoWrite
   - AskUserQuestion
 ---
+
+
 <objective>
 Execute all plans in a phase using wave-based parallel execution.
 
@@ -36,9 +38,9 @@ Context files are resolved inside the workflow via `gsd-tools init execute-phase
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -58,7 +60,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/health.md
+++ b/commands/gsd/health.md
@@ -8,6 +8,8 @@ allowed-tools:
   - Write
   - AskUserQuestion
 ---
+
+
 <objective>
 Validate `.planning/` directory integrity and report actionable issues. Checks for missing files, invalid configurations, inconsistent state, and orphaned plans.
 </objective>
@@ -17,9 +19,9 @@ Validate `.planning/` directory integrity and report actionable issues. Checks f
 </execution_context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -39,7 +41,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/import-issues.md
+++ b/commands/gsd/import-issues.md
@@ -9,6 +9,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 <objective>
 Import external issues from connected issue trackers as GSD todos with external_ref frontmatter.
 
@@ -29,9 +30,9 @@ Arguments: $ARGUMENTS (optional issue number for quick single import)
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -51,7 +52,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/map-codebase.md
+++ b/commands/gsd/map-codebase.md
@@ -12,6 +12,7 @@ allowed-tools:
   - Agent
 ---
 
+
 <objective>
 Analyze existing codebase using parallel gsd-codebase-mapper agents to produce structured codebase documents.
 
@@ -21,9 +22,9 @@ Output: .planning/codebase/ folder with 7 structured documents about the codebas
 </objective>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -43,7 +44,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <execution_context>

--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Agent
   - AskUserQuestion
 ---
+
+
 <objective>
 Start a new milestone: questioning → research (optional) → requirements → roadmap.
 
@@ -39,9 +41,9 @@ Project and milestone context files are resolved inside the workflow (`init new-
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -61,7 +63,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Agent
   - AskUserQuestion
 ---
+
+
 <context>
 **Flags:**
 - `--auto` — Automatic mode. After config questions, runs research → requirements → roadmap without further interaction. Expects idea document via @ reference.
@@ -37,9 +39,9 @@ Initialize a new project through unified flow: questioning → research (optiona
 </execution_context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -59,7 +61,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/plan-milestone-gaps.md
+++ b/commands/gsd/plan-milestone-gaps.md
@@ -9,6 +9,8 @@ allowed-tools:
   - Grep
   - AskUserQuestion
 ---
+
+
 <objective>
 Create all phases necessary to close gaps identified by `/gsd:audit-milestone`.
 
@@ -29,9 +31,9 @@ Original intent and current planning state are loaded on demand inside the workf
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -51,7 +53,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -14,6 +14,8 @@ allowed-tools:
   - WebFetch
   - mcp__context7__*
 ---
+
+
 <objective>
 Create executable phase prompts (PLAN.md files) for a roadmap phase with integrated research and verification.
 
@@ -23,9 +25,9 @@ Create executable phase prompts (PLAN.md files) for a roadmap phase with integra
 </objective>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -45,7 +47,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <execution_context>

--- a/commands/gsd/quick.md
+++ b/commands/gsd/quick.md
@@ -12,6 +12,8 @@ allowed-tools:
   - Agent
   - AskUserQuestion
 ---
+
+
 <objective>
 Execute small, ad-hoc tasks with GSD guarantees (atomic commits, STATE.md tracking).
 
@@ -51,9 +53,9 @@ Context files are resolved inside the workflow (`init quick`) and delegated via 
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -73,7 +75,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/reapply-patches.md
+++ b/commands/gsd/reapply-patches.md
@@ -3,14 +3,15 @@ description: Reapply local modifications after a GSD update
 allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
 ---
 
+
 <purpose>
 After a GSD update wipes and reinstalls files, this command merges user's previously saved local modifications back into the new version. Uses intelligent comparison to handle cases where the upstream file also changed.
 </purpose>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -30,7 +31,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/resume-work.md
+++ b/commands/gsd/resume-work.md
@@ -9,6 +9,7 @@ allowed-tools:
   - SlashCommand
 ---
 
+
 <objective>
 Restore complete project context and resume work seamlessly from previous session.
 
@@ -26,9 +27,9 @@ Routes to the resume-project workflow which handles:
 </execution_context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -48,7 +49,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/seed-memories.md
+++ b/commands/gsd/seed-memories.md
@@ -11,6 +11,7 @@ allowed-tools:
 argument-hint: "[--force]"
 ---
 
+
 Detect workspace topology (submodule, monorepo, standalone) and seed appropriate structure-hazard memories into `.claude/memory/`. Updates both CLAUDE.md Memories section and `.claude/memory/MEMORY.md`.
 
 **Steps:**
@@ -31,6 +32,6 @@ Detect workspace topology (submodule, monorepo, standalone) and seed appropriate
 7. Commit changes
 
 **If `--force` flag:** Skip confirmation, bypass skip detection, and overwrite existing memory files even if existing memories already cover the concept.
-**Otherwise:** Show what would be seeded and ask user to confirm via AskUserQuestion before writing.
+**Otherwise:** Show what would be seeded and ask user to confirm via {{USER_QUESTION_TOOL}} before writing.
 
 Run from: `/gsd:seed-memories`

--- a/commands/gsd/settings.md
+++ b/commands/gsd/settings.md
@@ -8,6 +8,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 <objective>
 Interactive configuration of GSD workflow agents and model profile via multi-question prompt.
 
@@ -24,9 +25,9 @@ Routes to the settings workflow which handles:
 </execution_context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -46,7 +47,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/squash.md
+++ b/commands/gsd/squash.md
@@ -7,6 +7,8 @@ allowed-tools:
   - Bash
   - AskUserQuestion
 ---
+
+
 <objective>
 Squash phase commits into clean history for code review.
 
@@ -28,9 +30,9 @@ $ARGUMENTS
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -50,7 +52,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/sync-issues.md
+++ b/commands/gsd/sync-issues.md
@@ -8,6 +8,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 <objective>
 Sync GSD planning state with external issue trackers (GitHub, GitLab, Forgejo, Gitea).
 
@@ -28,9 +29,9 @@ Arguments: $ARGUMENTS (optional phase filter)
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -50,7 +51,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/ui-phase.md
+++ b/commands/gsd/ui-phase.md
@@ -13,6 +13,8 @@ allowed-tools:
   - AskUserQuestion
   - mcp__context7__*
 ---
+
+
 <objective>
 Create a UI design contract (UI-SPEC.md) for a frontend phase.
 Orchestrates gsd-ui-researcher and gsd-ui-checker.
@@ -29,9 +31,9 @@ Phase number: $ARGUMENTS — optional, auto-detects next unplanned phase if omit
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -51,7 +53,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/ui-review.md
+++ b/commands/gsd/ui-review.md
@@ -11,6 +11,8 @@ allowed-tools:
   - Agent
   - AskUserQuestion
 ---
+
+
 <objective>
 Conduct a retroactive 6-pillar visual audit. Produces UI-REVIEW.md with
 graded assessment (1-4 per pillar). Works on any project.
@@ -27,9 +29,9 @@ Phase: $ARGUMENTS — optional, defaults to last completed phase.
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -49,7 +51,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/update.md
+++ b/commands/gsd/update.md
@@ -6,6 +6,7 @@ allowed-tools:
   - AskUserQuestion
 ---
 
+
 Run the update command in dry-run mode first, then ask for confirmation before executing:
 
 1. Check for updates:
@@ -19,7 +20,7 @@ Run the update command in dry-run mode first, then ask for confirmation before e
 
 3. If update_available: show the user "Update available: {installed} -> {latest} (via {update_source})" and warn about clean install (commands/gsd/ and gsd-ng/ will be wiped and replaced; custom files preserved).
 
-4. Use AskUserQuestion to ask "Proceed with update?" with options "Yes, update now" and "Cancel".
+4. Use {{USER_QUESTION_TOOL}} to ask "Proceed with update?" with options "Yes, update now" and "Cancel".
 
 5. If confirmed, execute with the install_type from dry-run result:
 !`node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" update --{install_type}`

--- a/commands/gsd/validate-phase.md
+++ b/commands/gsd/validate-phase.md
@@ -12,6 +12,8 @@ allowed-tools:
   - Agent
   - AskUserQuestion
 ---
+
+
 <objective>
 Audit Nyquist validation coverage for a completed phase. Three states:
 - (A) VALIDATION.md exists — audit and fill gaps
@@ -30,9 +32,9 @@ Phase: $ARGUMENTS — optional, defaults to last completed phase.
 </context>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -52,7 +54,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <process>

--- a/commands/gsd/verify-work.md
+++ b/commands/gsd/verify-work.md
@@ -12,6 +12,8 @@ allowed-tools:
   - AskUserQuestion
   - Agent
 ---
+
+
 <objective>
 Validate built features through conversational testing with persistent state.
 
@@ -21,9 +23,9 @@ Output: {phase_num}-UAT.md tracking all test results. If issues found: diagnosed
 </objective>
 
 <tool_usage>
-CRITICAL: You MUST use the AskUserQuestion tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real AskUserQuestion tool call with the questions parameter.
+CRITICAL: You MUST use the {{USER_QUESTION_TOOL}} tool for ALL user choices in this workflow. NEVER output plain-text menus, lettered lists (a/b/c), or numbered option lists. Every decision point requires a real {{USER_QUESTION_TOOL}} tool call with the questions parameter.
 
-The AskUserQuestion tool schema:
+The {{USER_QUESTION_TOOL}} tool schema:
 ```json
 {
   "questions": [
@@ -43,7 +45,7 @@ Key constraints:
 - header: max 12 characters (abbreviate if needed)
 - options: 2-4 items; "Other" is added automatically by the tool — do NOT add it yourself
 - multiSelect: true for "select all that apply", false for "pick one"
-- If user picks "Other" (free text): follow up as plain text, not another AskUserQuestion
+- If user picks "Other" (free text): follow up as plain text, not another {{USER_QUESTION_TOOL}}
 </tool_usage>
 
 <execution_context>

--- a/gsd-ng/bin/lib/template-processor.cjs
+++ b/gsd-ng/bin/lib/template-processor.cjs
@@ -1,5 +1,8 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
+
 const RUNTIMES = {
   claude: {
     PROJECT_RULES_FILE: 'CLAUDE.md',
@@ -86,4 +89,86 @@ function buildContext(runtime, options) {
   return { runtime, ...(options || {}) };
 }
 
-module.exports = { processTemplate, validateMarkers, buildContext, RUNTIMES };
+/**
+ * Inject a template block after YAML frontmatter in a command file.
+ * Idempotent: skips if the marker tag is already present.
+ *
+ * @param {string} content - File content with YAML frontmatter
+ * @param {string} templatePath - Absolute path to template file
+ * @param {string} marker - Tag name to check for idempotency (e.g. 'first_turn_rule')
+ * @returns {string} Content with template injected, or unchanged if already present
+ */
+function injectAfterFrontmatter(content, templatePath, marker) {
+  if (content.includes('<' + marker + '>')) {
+    return content; // Already injected
+  }
+  if (!fs.existsSync(templatePath)) {
+    return content; // Template missing — skip silently
+  }
+  const block = fs.readFileSync(templatePath, 'utf8').trim();
+  const frontmatterEnd = content.indexOf('\n---\n');
+  if (frontmatterEnd === -1) {
+    return content; // No frontmatter — skip
+  }
+  const insertPos = frontmatterEnd + 5;
+  return content.slice(0, insertPos) + '\n' + block + '\n' + content.slice(insertPos);
+}
+
+/**
+ * Append a template block to a file. Creates the file if it doesn't exist.
+ * Idempotent: skips if the marker string is already present in the file.
+ *
+ * @param {string} filePath - Absolute path to target file
+ * @param {string} templatePath - Absolute path to template file
+ * @param {string} marker - String to check for idempotency
+ */
+function injectAppendToFile(filePath, templatePath, marker) {
+  if (fs.existsSync(filePath)) {
+    const existing = fs.readFileSync(filePath, 'utf8');
+    if (existing.includes(marker)) {
+      return; // Already injected
+    }
+  }
+  if (!fs.existsSync(templatePath)) {
+    return; // Template missing — skip silently
+  }
+  const blockContent = fs.readFileSync(templatePath, 'utf8').trim();
+  const block = '\n' + blockContent + '\n';
+  if (fs.existsSync(filePath)) {
+    fs.appendFileSync(filePath, block, 'utf8');
+  } else {
+    fs.writeFileSync(filePath, block.trimStart(), 'utf8');
+  }
+}
+
+/**
+ * Fill content between a pair of markers in a file, using the inner content
+ * extracted from between the same markers in a template file.
+ * Idempotent: always overwrites to stay in sync with the template.
+ * No-op if the file does not exist or either marker is missing.
+ *
+ * @param {string} filePath - Absolute path to the target file containing the markers
+ * @param {string} templatePath - Absolute path to the template file
+ * @param {string} startMarker - Opening marker string
+ * @param {string} endMarker - Closing marker string
+ */
+function fillBetweenMarkers(filePath, templatePath, startMarker, endMarker) {
+  if (!fs.existsSync(filePath)) return;
+  const existing = fs.readFileSync(filePath, 'utf8');
+  const startIdx = existing.indexOf(startMarker);
+  const endIdx = existing.indexOf(endMarker);
+  if (startIdx === -1 || endIdx === -1) return;
+
+  const template = fs.readFileSync(templatePath, 'utf8');
+  const tStart = template.indexOf(startMarker);
+  const tEnd = template.indexOf(endMarker);
+  const innerContent = (tStart !== -1 && tEnd !== -1)
+    ? template.slice(tStart + startMarker.length, tEnd)
+    : '\n' + template.trim() + '\n';
+
+  const before = existing.slice(0, startIdx + startMarker.length);
+  const after = existing.slice(endIdx);
+  fs.writeFileSync(filePath, before + innerContent + after, 'utf8');
+}
+
+module.exports = { processTemplate, validateMarkers, buildContext, RUNTIMES, injectAfterFrontmatter, injectAppendToFile, fillBetweenMarkers };

--- a/gsd-ng/references/agent-shared-context.md
+++ b/gsd-ng/references/agent-shared-context.md
@@ -1,7 +1,7 @@
 <project_context>
 Before executing, discover project context:
 
-**Project instructions:** Read `./CLAUDE.md` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
+**Project instructions:** Read `./{{PROJECT_RULES_FILE}}` if it exists in the working directory. Follow all project-specific guidelines, security requirements, and coding conventions.
 
 **Project skills:** Check `.claude/skills/` or `.agents/skills/` directory if either exists:
 1. List available skills (subdirectories)

--- a/gsd-ng/references/ask-user-question.md
+++ b/gsd-ng/references/ask-user-question.md
@@ -1,7 +1,13 @@
-<tool_usage>
-CRITICAL: Every user choice in this workflow MUST be made via the AskUserQuestion tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
+<!-- ONLY:claude -->
+<first_turn_rule>
+CRITICAL: AskUserQuestion is broken on the FIRST response turn after a command loads (Claude Code issue #29530). On your very first response, output ONLY plain text -- a brief status message or "Ready" acknowledgment. Do NOT call {{USER_QUESTION_TOOL}} until the user replies (creating a turn boundary). After that first exchange, {{USER_QUESTION_TOOL}} works normally.
+</first_turn_rule>
+<!-- /ONLY:claude -->
 
-The AskUserQuestion tool accepts a `questions` array. Each question must have:
+<tool_usage>
+CRITICAL: Every user choice in this workflow MUST be made via the {{USER_QUESTION_TOOL}} tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
+
+The {{USER_QUESTION_TOOL}} tool accepts a `questions` array. Each question must have:
 - `question` (string) — the question text
 - `header` (string, max 12 chars) — short label shown above the question
 - `multiSelect` (boolean) — true for "select all that apply", false for single choice
@@ -24,5 +30,5 @@ Example call structure:
 }
 ```
 
-If the user picks "Other" (free text): follow up as plain text — NOT another AskUserQuestion.
+If the user picks "Other" (free text): follow up as plain text — NOT another {{USER_QUESTION_TOOL}}.
 </tool_usage>

--- a/gsd-ng/templates/first-turn-rule.md
+++ b/gsd-ng/templates/first-turn-rule.md
@@ -1,0 +1,3 @@
+<first_turn_rule>
+On your FIRST response after this command loads, output ONLY a brief plain-text status (e.g., "Loading context..." or a summary of what you'll do). Do NOT call {{USER_QUESTION_TOOL}} on this first turn. After the user replies, {{USER_QUESTION_TOOL}} works normally.
+</first_turn_rule>

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -255,7 +255,7 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
        - {phase_dir}/{plan_file} (Plan)
        - .planning/STATE.md (State)
        - .planning/config.json (Config, if exists)
-       - ./CLAUDE.md (Project instructions, if exists — follow project-specific guidelines and coding conventions)
+       - ./{{PROJECT_RULES_FILE}} (Project instructions, if exists — follow project-specific guidelines and coding conventions)
        - .claude/skills/ or .agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
        </files_to_read>
 

--- a/gsd-ng/workflows/plan-phase.md
+++ b/gsd-ng/workflows/plan-phase.md
@@ -277,7 +277,7 @@ Do NOT re-research the full phase scope.
 <additional_context>
 **Phase description:** {phase_description}
 
-**Project instructions:** Read ./CLAUDE.md if exists — follow project-specific guidelines
+**Project instructions:** Read ./{{PROJECT_RULES_FILE}} if exists — follow project-specific guidelines
 **Project skills:** Check .claude/skills/ or .agents/skills/ directory (if either exists) — read SKILL.md files, research should account for project skill patterns
 </additional_context>
 
@@ -357,7 +357,7 @@ Answer: "What do I need to know to PLAN this phase well?"
 **Phase description:** {phase_description}
 **Phase requirement IDs (MUST address):** {phase_req_ids}
 
-**Project instructions:** Read ./CLAUDE.md if exists — follow project-specific guidelines
+**Project instructions:** Read ./{{PROJECT_RULES_FILE}} if exists — follow project-specific guidelines
 **Project skills:** Check .claude/skills/ or .agents/skills/ directory (if either exists) — read SKILL.md files, research should account for project skill patterns
 </additional_context>
 
@@ -528,7 +528,7 @@ Planner prompt:
 
 **Phase requirement IDs (every ID MUST appear in a plan's `requirements` field):** {phase_req_ids}
 
-**Project instructions:** Read ./CLAUDE.md if exists — follow project-specific guidelines
+**Project instructions:** Read ./{{PROJECT_RULES_FILE}} if exists — follow project-specific guidelines
 **Project skills:** Check .claude/skills/ or .agents/skills/ directory (if either exists) — read SKILL.md files, plans should account for project skill rules
 </planning_context>
 
@@ -625,7 +625,7 @@ Checker prompt:
 
 **Phase requirement IDs (MUST ALL be covered):** {phase_req_ids}
 
-**Project instructions:** Read ./CLAUDE.md if exists — verify plans honor project guidelines
+**Project instructions:** Read ./{{PROJECT_RULES_FILE}} if exists — verify plans honor project guidelines
 **Project skills:** Check .claude/skills/ or .agents/skills/ directory (if either exists) — verify plans account for project skill rules
 </verification_context>
 

--- a/gsd-ng/workflows/quick.md
+++ b/gsd-ng/workflows/quick.md
@@ -343,7 +343,7 @@ Task(
 <files_to_read>
 - .planning/STATE.md (Project state — what's already built)
 - .planning/PROJECT.md (Project context)
-- ./CLAUDE.md (if exists — project-specific guidelines)
+- ./{{PROJECT_RULES_FILE}} (if exists — project-specific guidelines)
 ${DISCUSS_MODE ? '- ' + QUICK_DIR + '/' + quick_id + '-CONTEXT.md (User decisions — research should align with these)' : ''}
 </files_to_read>
 
@@ -396,7 +396,7 @@ Task(
 
 <files_to_read>
 - .planning/STATE.md (Project State)
-- ./CLAUDE.md (if exists — follow project-specific guidelines)
+- ./{{PROJECT_RULES_FILE}} (if exists — follow project-specific guidelines)
 ${DISCUSS_MODE ? '- ' + QUICK_DIR + '/' + quick_id + '-CONTEXT.md (User decisions — locked, do not revisit)' : ''}
 ${RESEARCH_MODE ? '- ' + QUICK_DIR + '/' + quick_id + '-RESEARCH.md (Research findings — use to inform implementation choices)' : ''}
 </files_to_read>
@@ -569,7 +569,7 @@ Do NOT modify deployed copies (e.g., .claude/gsd-ng/) — always edit source fir
 <files_to_read>
 - ${QUICK_DIR}/${quick_id}-PLAN.md (Plan)
 - .planning/STATE.md (Project state)
-- ./CLAUDE.md (Project instructions, if exists)
+- ./{{PROJECT_RULES_FILE}} (Project instructions, if exists)
 - .claude/skills/ or .agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
 </files_to_read>
 

--- a/tests/template-processor.test.cjs
+++ b/tests/template-processor.test.cjs
@@ -2,7 +2,12 @@
 
 const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
-const { processTemplate, validateMarkers, buildContext, RUNTIMES } = require('../gsd-ng/bin/lib/template-processor.cjs');
+const fs = require('fs');
+const path = require('path');
+const { processTemplate, validateMarkers, buildContext, RUNTIMES, fillBetweenMarkers } = require('../gsd-ng/bin/lib/template-processor.cjs');
+const { resolveTmpDir } = require('./helpers.cjs');
+
+const BASE_TMPDIR = resolveTmpDir();
 
 // --- Variable substitution ---
 
@@ -181,6 +186,86 @@ describe('RUNTIMES', () => {
 
   test('copilot PROJECT_RULES_FILE is .github/copilot-instructions.md', () => {
     assert.equal(RUNTIMES.copilot.PROJECT_RULES_FILE, '.github/copilot-instructions.md');
+  });
+});
+
+// --- fillBetweenMarkers ---
+
+describe('fillBetweenMarkers', () => {
+  test('fills content between markers from template inner content', () => {
+    const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'tp-fill-'));
+    try {
+      const targetPath = path.join(tmpDir, 'target.md');
+      const templatePath = path.join(tmpDir, 'template.md');
+      fs.writeFileSync(targetPath, 'before\n<!-- START -->\n<!-- /START -->\nafter\n');
+      fs.writeFileSync(templatePath, '<!-- START -->\ninner content\n<!-- /START -->\n');
+      fillBetweenMarkers(targetPath, templatePath, '<!-- START -->', '<!-- /START -->');
+      const result = fs.readFileSync(targetPath, 'utf8');
+      assert.ok(result.includes('inner content'), 'filled content must appear between markers');
+      assert.ok(result.includes('before'), 'content before markers must be preserved');
+      assert.ok(result.includes('after'), 'content after markers must be preserved');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('overwrites existing content between markers (always in sync with template)', () => {
+    const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'tp-fill-'));
+    try {
+      const targetPath = path.join(tmpDir, 'target.md');
+      const templatePath = path.join(tmpDir, 'template.md');
+      fs.writeFileSync(targetPath, '<!-- START -->\nstale content\n<!-- /START -->\n');
+      fs.writeFileSync(templatePath, '<!-- START -->\nfresh content\n<!-- /START -->\n');
+      fillBetweenMarkers(targetPath, templatePath, '<!-- START -->', '<!-- /START -->');
+      const result = fs.readFileSync(targetPath, 'utf8');
+      assert.ok(result.includes('fresh content'), 'stale content must be replaced with template content');
+      assert.ok(!result.includes('stale content'), 'stale content must not remain');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('no-op if target file does not exist', () => {
+    const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'tp-fill-'));
+    try {
+      const templatePath = path.join(tmpDir, 'template.md');
+      fs.writeFileSync(templatePath, '<!-- S -->\ncontent\n<!-- /S -->\n');
+      assert.doesNotThrow(() => {
+        fillBetweenMarkers(path.join(tmpDir, 'missing.md'), templatePath, '<!-- S -->', '<!-- /S -->');
+      });
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('no-op if markers are absent from target file', () => {
+    const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'tp-fill-'));
+    try {
+      const targetPath = path.join(tmpDir, 'target.md');
+      const templatePath = path.join(tmpDir, 'template.md');
+      const original = 'no markers here\n';
+      fs.writeFileSync(targetPath, original);
+      fs.writeFileSync(templatePath, '<!-- S -->\ncontent\n<!-- /S -->\n');
+      fillBetweenMarkers(targetPath, templatePath, '<!-- S -->', '<!-- /S -->');
+      assert.equal(fs.readFileSync(targetPath, 'utf8'), original, 'file must be unchanged when markers absent');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  test('falls back to full template when template has no markers', () => {
+    const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'tp-fill-'));
+    try {
+      const targetPath = path.join(tmpDir, 'target.md');
+      const templatePath = path.join(tmpDir, 'template.md');
+      fs.writeFileSync(targetPath, '<!-- S -->\n<!-- /S -->\n');
+      fs.writeFileSync(templatePath, 'bare template content\n');
+      fillBetweenMarkers(targetPath, templatePath, '<!-- S -->', '<!-- /S -->');
+      const result = fs.readFileSync(targetPath, 'utf8');
+      assert.ok(result.includes('bare template content'), 'bare template content must be injected as fallback');
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary\n\n- **48-05**: Flip runtime matching in install.js from negated `isCopilot` to positive runtime checks. Wire template-processor.cjs for `{{PROJECT_RULES_FILE}}` and `<!-- ONLY:runtime -->` processing across workflows and references.\n- **48-06**: Deduplicate AskUserQuestion first-turn preamble from 29 command files into `gsd-ng/templates/first-turn-rule.md`, injected at install-time via `injectAfterFrontmatter`.\n- **Refactor**: Extract `fillBetweenMarkers` from install.js into template-processor.cjs as a generic marker-based content fill function. Add `injectAfterFrontmatter` and `injectAppendToFile` to template-processor.cjs.\n\nPart of Phase 48 (plans 05-06). Split from the original PR:\n- PR #19: defaults.cjs + template-processor.cjs + AST safety (merged)\n- PR #20: bugfixes (48-03)\n- PR #21: wire defaults into consumers (48-04)\n\n## Test plan\n\n- [ ] `npm test` passes — 5 new fillBetweenMarkers cases\n- [ ] Install with `--runtime claude`: first-turn-rule injected into command files, `{{PROJECT_RULES_FILE}}` resolved to CLAUDE.md\n- [ ] Install with `--runtime copilot`: `<!-- ONLY:claude -->` blocks stripped, `{{PROJECT_RULES_FILE}}` resolved to .github/copilot-instructions.md