### PR TITLE
fix: debug session false positive and create-pr collision guard

### DIFF
--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -669,7 +669,7 @@ The knowledge base is a persistent, append-only record of resolved debug session
 ## File Location
 
 ```
-.planning/debug/knowledge-base.md
+.planning/debug/resolved/knowledge-base.md
 ```
 
 ## Entry Format
@@ -872,7 +872,7 @@ Gather symptoms through questioning. Update file after EACH answer.
 **Autonomous investigation. Update file continuously.**
 
 **Phase 0: Check knowledge base**
-- If `.planning/debug/knowledge-base.md` exists, read it
+- If `.planning/debug/resolved/knowledge-base.md` exists, read it. If not found, check `.planning/debug/knowledge-base.md` (legacy location).
 - Extract keywords from `Symptoms.errors` and `Symptoms.actual` (nouns, error substrings, identifiers)
 - Scan knowledge base entries for 2+ keyword overlap (case-insensitive)
 - If match found:
@@ -1055,7 +1055,7 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: resolve debug {slug}
 
 **Append to knowledge base:**
 
-Read `.planning/debug/resolved/{slug}.md` to extract final `Resolution` values. Then append to `.planning/debug/knowledge-base.md` (create file with header if it doesn't exist):
+Read `.planning/debug/resolved/{slug}.md` to extract final `Resolution` values. Then append to `.planning/debug/resolved/knowledge-base.md` (create `.planning/debug/resolved/` directory and file with header if they don't exist):
 
 If creating for the first time, write this header first:
 ```markdown
@@ -1081,7 +1081,7 @@ Then append the entry:
 
 Commit the knowledge base update alongside the resolved session:
 ```bash
-node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: update debug knowledge base with {slug}" --files .planning/debug/knowledge-base.md
+node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: update debug knowledge base with {slug}" --files .planning/debug/resolved/knowledge-base.md
 ```
 
 Report completion and offer next steps.

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -190,6 +190,27 @@ Save the current work branch for later:
 CURRENT_BRANCH=$(git -C "$GIT_CWD" branch --show-current)
 ```
 
+**Collision guard:** If the review branch name matches the current work branch, handle per mode to prevent data loss from `reset --hard`:
+```bash
+if [ "$REVIEW_BRANCH" = "$CURRENT_BRANCH" ]; then
+  if [ "$AUTO_MODE" = "true" ]; then
+    # Auto-suffix: append -2, -3, etc. until unique
+    SUFFIX=2
+    while [ "$REVIEW_BRANCH-$SUFFIX" = "$CURRENT_BRANCH" ] || git show-ref --verify --quiet "refs/heads/$REVIEW_BRANCH-$SUFFIX" 2>/dev/null; do
+      SUFFIX=$((SUFFIX + 1))
+    done
+    REVIEW_BRANCH="$REVIEW_BRANCH-$SUFFIX"
+    echo "Auto-suffixed review branch to '$REVIEW_BRANCH' to avoid collision with work branch."
+  else
+    echo "Error: review branch '$REVIEW_BRANCH' is the same as work branch '$CURRENT_BRANCH'."
+    echo "This would destroy uncommitted work via 'git reset --hard'."
+    echo "Fix: set a distinct review_branch_template in config.json."
+    echo "  Example: node \"\$HOME/.claude/gsd-ng/bin/gsd-tools.cjs\" config-set git.review_branch_template 'review/{phase}-{slug}'"
+    exit 1
+  fi
+fi
+```
+
 Create or reset review branch from target_branch:
 ```bash
 if git -C "$GIT_CWD" show-ref --verify --quiet "refs/heads/$REVIEW_BRANCH" 2>/dev/null; then


### PR DESCRIPTION
## Summary\n\n- Fix debug session counter false positive: relocate knowledge-base.md reference to resolved/ subdirectory\n- Add review branch collision guard to create-pr workflow to prevent data loss from `reset --hard` when a review branch already exists\n\nPart of Phase 48 (plan 03). Two independent bugfixes.\n\n## Test plan\n\n- [ ] `ls .planning/debug/*.md | grep -v resolved` no longer counts knowledge-base.md\n- [ ] create-pr workflow checks for existing review branch before creating one