### PR TITLE
refactor: wire defaults.cjs into consumer modules

### DIFF
--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const { output, error, planningPaths } = require('./core.cjs');
+const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 const {
   VALID_PROFILES,
   getAgentToModelMapForProfile,
@@ -97,19 +98,14 @@ function ensureConfigFile(cwd) {
 
   // Create default config (user-level defaults override hardcoded defaults)
   const hardcoded = {
-    model_profile: 'balanced',
-    commit_docs: true,
-    search_gitignored: false,
-    branching_strategy: 'none',
-    phase_branch_template: 'gsd/phase-{phase}-{slug}',
-    milestone_branch_template: 'gsd/{milestone}-{slug}',
-    workflow: {
-      research: true,
-      plan_check: true,
-      verifier: true,
-      nyquist_validation: true,
-    },
-    parallelization: true,
+    model_profile: DEFAULTS.model_profile,
+    commit_docs: DEFAULTS.commit_docs,
+    search_gitignored: DEFAULTS.search_gitignored,
+    branching_strategy: DEFAULTS.branching_strategy,
+    phase_branch_template: DEFAULTS.phase_branch_template,
+    milestone_branch_template: DEFAULTS.milestone_branch_template,
+    workflow: { ...WORKFLOW_DEFAULTS },
+    parallelization: DEFAULTS.parallelization,
   };
   const defaults = {
     ...hardcoded,

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { execSync, execFileSync, spawnSync } = require('child_process');
 const { MODEL_PROFILES } = require('./model-profiles.cjs');
+const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 
 // ─── Path helpers ────────────────────────────────────────────────────────────
 
@@ -156,26 +157,11 @@ function safeReadFile(filePath) {
 function loadConfig(cwd) {
   const { config: configPath } = planningPaths(cwd);
   const defaults = {
-    model_profile: 'balanced',
-    commit_docs: true,
-    search_gitignored: false,
-    branching_strategy: 'none',
-    phase_branch_template: 'gsd/phase-{phase}-{slug}',
-    milestone_branch_template: 'gsd/{milestone}-{slug}',
-    target_branch: 'main',
-    auto_push: false,
-    remote: 'origin',
-    review_branch_template: '{type}/{phase}-{slug}',
-    pr_draft: true,
-    platform: null,
-    commit_format: 'gsd',
-    commit_template: null,
-    versioning_scheme: 'semver',
-    research: true,
-    plan_checker: true,
-    verifier: true,
-    nyquist_validation: true,
-    parallelization: true,
+    ...DEFAULTS,
+    research: WORKFLOW_DEFAULTS.research,
+    plan_checker: WORKFLOW_DEFAULTS.plan_check,
+    verifier: WORKFLOW_DEFAULTS.verifier,
+    nyquist_validation: WORKFLOW_DEFAULTS.nyquist_validation,
   };
 
   try {

--- a/gsd-ng/bin/lib/init.cjs
+++ b/gsd-ng/bin/lib/init.cjs
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
 const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone, normalizePhaseName, toPosixPath, output, error, planningPaths } = require('./core.cjs');
+const { DEFAULTS } = require('./defaults.cjs');
 const { validatePhaseNumber } = require('./security.cjs');
 const { adjustQuickTable } = require('./state.cjs');
 const { resolveGitContext } = require('./workspace.cjs');
@@ -1048,11 +1049,11 @@ const INIT_FIELD_DEFAULTS = {
   researcher_model: null,
   planner_model: null,
   // plain strings with defaults
-  branching_strategy: 'none',
-  target_branch: 'main',
-  remote: 'origin',
-  phase_branch_template: 'phase/{phase}-{slug}',
-  milestone_branch_template: 'milestone/{milestone}-{slug}',
+  branching_strategy: DEFAULTS.branching_strategy,
+  target_branch: DEFAULTS.target_branch,
+  remote: DEFAULTS.remote,
+  phase_branch_template: DEFAULTS.phase_branch_template,
+  milestone_branch_template: DEFAULTS.milestone_branch_template,
   // numbers
   plan_count: 0,
   incomplete_count: 0,

--- a/gsd-ng/bin/lib/verify.cjs
+++ b/gsd-ng/bin/lib/verify.cjs
@@ -6,6 +6,8 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { safeReadFile, normalizePhaseName, execGit, findPhaseInternal, getMilestoneInfo, extractCurrentMilestone, output, error, planningPaths } = require('./core.cjs');
+const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
+const { RUNTIMES } = require('./template-processor.cjs');
 const { extractFrontmatter, spliceFrontmatter, parseMustHavesBlock } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 const { detectWorkspaceType, generateMemoriesSection, generateMemoryMd } = require('./workspace.cjs');
@@ -726,20 +728,22 @@ function cmdValidateHealth(cwd, options) {
     }
   }
 
-  // ─── Check 9: CLAUDE.md exists when .planning/ exists ────────────────────
-  const claudeMdPath = path.join(cwd, 'CLAUDE.md');
+  // ─── Check 9: Project rules file exists when .planning/ exists ────────────
+  const gsdRuntime = process.env.GSD_RUNTIME || 'claude';
+  const projectRulesFile = (RUNTIMES[gsdRuntime] || RUNTIMES.claude).PROJECT_RULES_FILE;
+  const projectRulesPath = path.join(cwd, projectRulesFile);
   const memoryDir = path.join(cwd, '.claude', 'memory');
   const memoryDirExists = fs.existsSync(memoryDir);
-  const claudeMdExists = fs.existsSync(claudeMdPath);
+  const projectRulesExists = fs.existsSync(projectRulesPath);
 
-  if (!claudeMdExists) {
-    addIssue('warning', 'W010', 'CLAUDE.md not found — agents will not receive project instructions', 'Run /gsd:health --repair to generate CLAUDE.md with Memories section', true);
+  if (!projectRulesExists) {
+    addIssue('warning', 'W010', `${projectRulesFile} not found — agents will not receive project instructions`, `Run /gsd:health --repair to generate ${projectRulesFile} with Memories section`, true);
     if (!repairs.includes('writeCLAUDEmd')) repairs.push('writeCLAUDEmd');
   }
 
-  // ─── Check 10-12: Memory-related checks (gate on CLAUDE.md + memory dir) ──
-  if (claudeMdExists && memoryDirExists) {
-    const claudeContent = fs.readFileSync(claudeMdPath, 'utf-8');
+  // ─── Check 10-12: Memory-related checks (gate on project rules file + memory dir) ──
+  if (projectRulesExists && memoryDirExists) {
+    const claudeContent = fs.readFileSync(projectRulesPath, 'utf-8');
     const memFiles = fs.readdirSync(memoryDir)
       .filter(f => f.endsWith('.md') && f !== 'MEMORY.md');
 
@@ -998,19 +1002,14 @@ function cmdValidateHealth(cwd, options) {
           case 'createConfig':
           case 'resetConfig': {
             const defaults = {
-              model_profile: 'balanced',
-              commit_docs: true,
-              search_gitignored: false,
-              branching_strategy: 'none',
-              phase_branch_template: 'gsd/phase-{phase}-{slug}',
-              milestone_branch_template: 'gsd/{milestone}-{slug}',
-              workflow: {
-                research: true,
-                plan_check: true,
-                verifier: true,
-                nyquist_validation: true,
-              },
-              parallelization: true,
+              model_profile: DEFAULTS.model_profile,
+              commit_docs: DEFAULTS.commit_docs,
+              search_gitignored: DEFAULTS.search_gitignored,
+              branching_strategy: DEFAULTS.branching_strategy,
+              phase_branch_template: DEFAULTS.phase_branch_template,
+              milestone_branch_template: DEFAULTS.milestone_branch_template,
+              workflow: { ...WORKFLOW_DEFAULTS },
+              parallelization: DEFAULTS.parallelization,
             };
             fs.writeFileSync(configPath, JSON.stringify(defaults, null, 2), 'utf-8');
             repairActions.push({ action: repair, success: true, path: 'config.json' });
@@ -1057,29 +1056,33 @@ function cmdValidateHealth(cwd, options) {
             break;
           }
           case 'writeCLAUDEmd': {
-            const claudePath = path.join(cwd, 'CLAUDE.md');
+            const repairRuntime = process.env.GSD_RUNTIME || 'claude';
+            const repairRulesFile = (RUNTIMES[repairRuntime] || RUNTIMES.claude).PROJECT_RULES_FILE;
+            const repairRulesPath = path.join(cwd, repairRulesFile);
             const memoriesSection = generateMemoriesSection(cwd);
-            if (fs.existsSync(claudePath)) {
+            if (fs.existsSync(repairRulesPath)) {
               // Append Memories section if not already present
-              let content = fs.readFileSync(claudePath, 'utf-8');
+              let content = fs.readFileSync(repairRulesPath, 'utf-8');
               if (!content.includes('## Memories')) {
                 content += '\n\n' + memoriesSection;
-                fs.writeFileSync(claudePath, content, 'utf-8');
+                fs.writeFileSync(repairRulesPath, content, 'utf-8');
               }
             } else {
-              // Create new CLAUDE.md with a project header and Memories section
+              // Create new project rules file with a project header and Memories section
               const projectName = path.basename(cwd);
               let content = `# ${projectName}\n\n`;
               if (memoriesSection) content += memoriesSection;
-              fs.writeFileSync(claudePath, content, 'utf-8');
+              fs.writeFileSync(repairRulesPath, content, 'utf-8');
             }
-            repairActions.push({ action: repair, success: true, path: 'CLAUDE.md' });
+            repairActions.push({ action: repair, success: true, path: repairRulesFile });
             break;
           }
           case 'syncCLAUDEmdMemories': {
-            const claudePath = path.join(cwd, 'CLAUDE.md');
-            if (fs.existsSync(claudePath)) {
-              let content = fs.readFileSync(claudePath, 'utf-8');
+            const syncRuntime = process.env.GSD_RUNTIME || 'claude';
+            const syncRulesFile = (RUNTIMES[syncRuntime] || RUNTIMES.claude).PROJECT_RULES_FILE;
+            const syncRulesPath = path.join(cwd, syncRulesFile);
+            if (fs.existsSync(syncRulesPath)) {
+              let content = fs.readFileSync(syncRulesPath, 'utf-8');
               const newSection = generateMemoriesSection(cwd);
               // Replace existing Memories section or append
               const sectionStart = content.indexOf('## Memories');
@@ -1091,8 +1094,8 @@ function cmdValidateHealth(cwd, options) {
               } else {
                 content += '\n\n' + newSection;
               }
-              fs.writeFileSync(claudePath, content, 'utf-8');
-              repairActions.push({ action: repair, success: true, path: 'CLAUDE.md' });
+              fs.writeFileSync(syncRulesPath, content, 'utf-8');
+              repairActions.push({ action: repair, success: true, path: syncRulesFile });
             }
             break;
           }

--- a/gsd-ng/bin/lib/workspace.cjs
+++ b/gsd-ng/bin/lib/workspace.cjs
@@ -5,6 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const { output, error, execGit, loadConfig, planningPaths } = require('./core.cjs');
+const { DEFAULTS } = require('./defaults.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { cmdDetectPlatform } = require('./commands.cjs');
 
@@ -391,8 +392,8 @@ function resolveGitContext(cwd) {
     cli_install_url: platformInfo.cli_install_url || null,
     branching_strategy: configSubmodule.branching_strategy || 'none',
     auto_push: configSubmodule.auto_push !== undefined ? configSubmodule.auto_push : false,
-    phase_branch_template: configSubmodule.phase_branch_template || 'phase/{phase}-{slug}',
-    milestone_branch_template: configSubmodule.milestone_branch_template || 'milestone/{milestone}-{slug}',
+    phase_branch_template: configSubmodule.phase_branch_template || DEFAULTS.phase_branch_template,
+    milestone_branch_template: configSubmodule.milestone_branch_template || DEFAULTS.milestone_branch_template,
     review_branch_template: configSubmodule.review_branch_template || null,
     pr_draft: configSubmodule.pr_draft !== undefined ? configSubmodule.pr_draft : true,
     pr_template: configSubmodule.pr_template || null,


### PR DESCRIPTION
## Summary\n\n- Wire centralized defaults.cjs (from PR #19) into config.cjs, core.cjs, init.cjs, verify.cjs, workspace.cjs\n- Replace scattered hardcoded strings with DEFAULTS/WORKFLOW_DEFAULTS imports\n- Fix phase_branch_template fallback bug in workspace.cjs\n- Add runtime-aware project rules file resolution in verify.cjs\n\nPart of Phase 48 (plan 04).\n\n## Test plan\n\n- [ ] `npm test` passes\n- [ ] All 5 consumer files import from defaults.cjs instead of hardcoding values