### PR TITLE
feat(quick-260407-r5z): add SECURITY.md with responsible disclosure policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# GSD-NG Security Policy
+
+## Responsible Disclosure
+
+We take security seriously and appreciate responsible disclosure of vulnerabilities. If you discover a security vulnerability in GSD-NG, please report it directly to **security@devchroma.nl** instead of opening a public GitHub issue.
+
+### What to Include in Your Report
+
+When reporting a vulnerability, please include:
+1. **Description** - A clear description of the vulnerability
+2. **Reproduction Steps** - How to reproduce the issue
+3. **Potential Impact** - What could be affected or compromised
+4. **Optional Suggested Fix** - If you have a proposed solution
+
+### Our Response Commitment
+
+We commit to:
+- **Acknowledgment** - Responding within 48 hours
+- **Initial Assessment** - Providing an initial assessment within one week
+- **Fix Timeline** - Based on severity:
+  - Critical issues: Targeted for 24-48 hours
+  - High severity: Within one week
+  - Medium/Low severity: Included in the next release
+
+### Attribution
+
+Security researchers who follow responsible disclosure practices will be recognized in release notes. Anonymity is available upon request if preferred.
+
+### In Scope
+
+Security issues affecting the GSD-NG codebase, including:
+- Vulnerabilities that could enable arbitrary code execution
+- Issues that could leak sensitive information (e.g., API credentials)
+- Problems that could undermine the reliability of generated plans and code


### PR DESCRIPTION
Adds `SECURITY.md` modeled after upstream GSD. Contact: `security@devchroma.nl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)