### PR TITLE
feat: release pipeline hardening, CI guardrails, and supply chain security

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+# Prevent accidental commit of large binaries
+*.tar.gz binary -diff
+*.zip binary -diff
+*.gz binary -diff
+*.tgz binary -diff
+
+# Exclude env files from GitHub language stats
+.env linguist-generated
+.env.* linguist-generated
+*.pem binary -diff
+*.key binary -diff
+
+# Normalize line endings for shell scripts
+*.sh text eol=lf
+*.cjs text eol=lf
+*.js text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,23 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        with:
+          fail-on-severity: high
+          deny-licenses: GPL-3.0-only, GPL-3.0-or-later, AGPL-3.0-only, AGPL-3.0-or-later

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,111 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to release (e.g., 1.0.0-dev.4, 1.0.0)'
+        required: true
+        type: string
+      branch:
+        description: 'Branch to release from'
+        required: true
+        default: 'develop'
+        type: choice
+        options:
+          - develop
+          - main
+permissions:
+  contents: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.branch }}
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+
+      - name: Validate version
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+            echo "::error::Invalid version format: $VERSION"
+            exit 1
+          fi
+          if git ls-remote --tags origin "refs/tags/v$VERSION" | grep -q .; then
+            RELEASE_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+              -H "Authorization: Bearer $GH_TOKEN" \
+              "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/v$VERSION")
+            if [ "$RELEASE_STATUS" = "200" ]; then
+              echo "::error::Tag v$VERSION and GitHub release already exist"
+              exit 1
+            fi
+            echo "::error::Tag v$VERSION exists but no GitHub release was found. Re-run the release and publish workflows from the Actions tab for this tag instead."
+            exit 1
+          fi
+          # Enforce gitflow: prereleases from develop, stable from main
+          if [[ "$VERSION" == *-* && "$BRANCH" != "develop" ]]; then
+            echo "::error::Prerelease versions must be released from develop, not $BRANCH"
+            exit 1
+          fi
+          if [[ "$VERSION" != *-* && "$BRANCH" != "main" ]]; then
+            echo "::error::Stable versions must be released from main, not $BRANCH"
+            exit 1
+          fi
+          CURRENT=$(node -p "require('./package.json').version")
+          echo "Releasing $VERSION (current: $CURRENT) from $BRANCH"
+
+      - name: Update package.json version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version
+
+      - name: Update package-lock.json
+        run: npm install --package-lock-only
+
+      - name: Validate CHANGELOG.md
+        shell: bash
+        run: |
+          if ! grep -q '## \[Unreleased\]' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no [Unreleased] section. Add release notes under [Unreleased] before running this workflow."
+            exit 1
+          fi
+          # Check that [Unreleased] has content (not just the heading followed by another heading or EOF)
+          CONTENT=$(sed -n '/## \[Unreleased\]/,/## \[/{ /## \[/d; /^$/d; p; }' CHANGELOG.md)
+          if [ -z "$CONTENT" ]; then
+            echo "::error::CHANGELOG.md [Unreleased] section is empty. Add release notes before running this workflow."
+            exit 1
+          fi
+
+      - name: Stamp CHANGELOG.md
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          if grep -q '## \[Unreleased\]' CHANGELOG.md; then
+            sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
+          fi
+
+      - name: Commit and tag
+        shell: bash
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add package.json package-lock.json CHANGELOG.md
+          git commit -m "chore: release v$VERSION"
+          git tag -a "v$VERSION" -m "Release v$VERSION"
+          git push --atomic origin "$BRANCH" "v$VERSION"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,17 +12,19 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm for OIDC support
-        run: npm install -g npm@latest
+      - name: Validate release
+        shell: bash
+        run: bash scripts/validate-release.sh "${GITHUB_REF#refs/tags/v}"
 
       - name: Install dev dependencies
         run: npm ci
@@ -34,8 +36,8 @@ jobs:
           if [[ "$VERSION" == *-* ]]; then
             TAG=$(echo "$VERSION" | sed 's/.*-\([a-z]*\).*/\1/')
             echo "Publishing $VERSION under '$TAG' tag"
-            npm publish --access public --tag "$TAG"
+            npm publish --access public --provenance --tag "$TAG"
           else
             echo "Publishing $VERSION under 'latest' tag"
-            npm publish --access public
+            npm publish --access public --provenance
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,17 +7,24 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
+
+      - name: Validate release
+        shell: bash
+        run: bash scripts/validate-release.sh "${GITHUB_REF#refs/tags/v}"
 
       - name: Install dev dependencies
         run: npm ci
@@ -28,7 +35,7 @@ jobs:
       - name: Build tarball
         run: node scripts/build-tarball.js
 
-      - name: Detect prerelease
+      - name: Detect prerelease and build release body
         id: meta
         shell: bash
         run: |
@@ -38,12 +45,24 @@ jobs:
           else
             echo "prerelease=false" >> "$GITHUB_OUTPUT"
           fi
+          # Link to the changelog file at the tagged revision for release details
+          BODY="See [CHANGELOG.md](https://github.com/$GITHUB_REPOSITORY/blob/${TAG}/CHANGELOG.md) for details."
+          echo "body<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$BODY" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Attest tarball provenance
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4
+        with:
+          subject-path: dist/gsd-ng.tar.gz
 
       - name: Create GitHub Release as draft
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           files: dist/gsd-ng.tar.gz
+          body: ${{ steps.meta.outputs.body }}
           generate_release_notes: true
+          append_body: true
           prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
           draft: true
 

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -6,6 +6,7 @@ on:
       - '.planning/**'
       - '.claude/**'
       - '.github/**'
+      - 'scripts/**'
 
 permissions:
   checks: write
@@ -16,12 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout default branch (trusted)
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         # No ref specified — defaults to default branch (trusted execution model)
         # PR diff data is fetched via GitHub API in ci-security-scan.cjs, not via checkout
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: '22'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,54 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  package-files-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: '22'
+
+      - name: Validate package.json files allowlist
+        shell: bash
+        run: |
+          ALLOWED='bin commands gsd-ng agents hooks/dist'
+          FILES=$(node -p "require('./package.json').files.join(' ')")
+          for entry in $FILES; do
+            if ! echo "$ALLOWED" | grep -qw "$entry"; then
+              echo "::error::package.json files contain '$entry' which is not in the allowlist: $ALLOWED"
+              exit 1
+            fi
+          done
+          echo "package.json files OK: $FILES"
+
+  changelog-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+
+      - name: Check CHANGELOG updated
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.base_ref }}
+        shell: bash
+        run: |
+          if git diff --name-only "$BASE_SHA" "$HEAD_SHA" | grep -q 'CHANGELOG.md'; then
+            echo "CHANGELOG.md updated"
+          else
+            if [ "$BASE_REF" = "main" ]; then
+              echo "::error::CHANGELOG.md must be updated for PRs to main"
+              exit 1
+            else
+              echo "::warning::CHANGELOG.md was not updated in this PR"
+            fi
+          fi
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -24,13 +72,13 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        node-version: [20, 22]
+        node-version: [22, 24]
 
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 __pycache__/
 .DS_Store
+.env
+.env.*
 
 # Build artifacts (committed to npm, not git)
 hooks/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Phase 52 — AST safety hook with rule modernization, shared rule templates, install-time injection
+- Phase 47 — CLI output refactor and workflow bash simplification
+- Phase 46 — Discuss-phase gap detection and plan-checker coverage improvements
+- Phase 45 — E2E smoke test suite, dynamic UID fix, `--current` filter tests
+- Phase 44 — CLI argument validation (`--flag` parsing, typo suggestions) and snapshot commands
+- Phase 43 — Related-todo frontmatter tags with health checks (W021/W022), `--format newline` flag, repair handlers
+- Phase 42 — `--field` extraction, SSH check, ambiguous fallback, UID fix in init; create-pr/execute-phase/squash refactored to use `$INIT` fields
+- Phase 41 — Submodule-aware git operations: workspace topology detection, per-submodule config, `EFFECTIVE_TARGET_BRANCH` routing
+- Phase 40 — Security hardening with prompt injection defense
+- Phase 39 — Content optimization: 3-tier reference splits, shared ask-user-question and agent-shared-context references, philosophy condensation, behavioral benchmark tasks
+- Install-time templating engine (`fillBetweenMarkers`) and AskUserQuestion first-turn injection
+- `defaults.cjs` and `template-processor.cjs` with shared AST safety injection
+- `init-get` CLI command with `gsd-tools` dispatch, replacing all `node -e` one-liners
+- `init-valid` guard with self-recovery block across 26 workflows
+- SECURITY.md with responsible disclosure policy
+- VERSIONING.md documenting release strategy
 - CI/CD workflows — cross-platform tests on PRs, GitHub Release with tarball on tag, npm publish via OIDC trusted publisher
-- Branch protection rulesets for main and develop (squash-only, PR required), tag protection for v* and gsd/*
+- Branch protection rulesets for main and develop (squash-only, PR required), tag protection for `v*` and `gsd/*`
+
+### Changed
+- Deduplicated AST safety rules into single template
+- Wired `defaults.cjs` into config, core, init, verify, workspace modules
+- Removed stale Windows references and guards
+
+### Fixed
+- Debug session false positive and create-pr collision guard
+- `PUSH_TARGET` and `PR_TEMPLATE_PATH` in create-pr workflow
+- Triple guard on `EFFECTIVE_TARGET_BRANCH` block
+- Ambiguous path handling in init execute-phase and milestone-op output
+- Orphaned closing tags and empty headings in checkpoint reference files
+
+## [1.0.0-dev.3] - 2026-03-28
+
+### Fixed
+- GitHub Release workflow creates release as draft first, then publishes (workaround for immutable release tag constraint)
+
+## [1.0.0-dev.2] - 2026-03-28
+
+### Fixed
+- Added `npm install -g npm@latest` to publish workflow for OIDC token support
 
 ## [1.0.0-dev.1] - 2026-03-28
 
@@ -36,4 +74,3 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - EPIPE crash and slug max length in CLI
 - Command injection in `isGitIgnored`
 - 5 pre-existing test failures in dispatcher and state
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2025 Lex Christopherson
+Copyright (c) 2026 chrisdevchroma
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Responsible Disclosure
 
-We take security seriously and appreciate responsible disclosure of vulnerabilities. If you discover a security vulnerability in GSD-NG, please report it directly to **security@devchroma.nl** instead of opening a public GitHub issue.
+We take security seriously and appreciate responsible disclosure of vulnerabilities. If you discover a security vulnerability in GSD-NG, please report it through [GitHub's private vulnerability reporting](https://github.com/chrisdevchroma/gsd-ng/security/advisories/new) instead of opening a public issue. Alternatively, email **security@devchroma.nl**.
 
 ### What to Include in Your Report
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -30,6 +30,24 @@ Feature and fix work targets `develop` via prefixed branches (`feat/`, `fix/`, `
 
 **Minor and major releases** are staged: one or more `-dev.N` versions are published to `dev` for validation, then a stable tag is pushed to publish to `latest`.
 
+### Triggering a release
+
+Releases can be triggered two ways:
+
+1. **Dispatch workflow** (or use the Actions tab):
+   - Pre-release from develop: `gh workflow run prepare-release.yml -f version=X.Y.Z-dev.N -f branch=develop`
+   - Stable release from main: `gh workflow run prepare-release.yml -f version=X.Y.Z -f branch=main`
+
+   This validates the version, bumps `package.json`, commits, tags, and pushes — then the release and publish workflows trigger automatically.
+
+2. **Manual:** Bump `package.json`, commit, push a `v<version>` tag. The `release.yml` and `publish.yml` workflows trigger on the tag push and validate that the tag matches `package.json`.
+
+## CI guardrails
+
+- **Tag-version validation:** Both `release.yml` and `publish.yml` verify the pushed tag matches the version in `package.json`. A mismatch fails the workflow before any publish occurs.
+- **CHANGELOG enforcement:** PRs to `main` that don't update `CHANGELOG.md` fail CI; PRs to other branches receive a non-blocking warning.
+- **Release approval:** Publishing to npm requires a reviewer to approve the `release` environment in GitHub.
+
 ## Conventional commits
 
-Branch prefixes map to version bumps — `fix/` triggers PATCH, `feat/` triggers MINOR. `chore/`, `docs/`, and `refactor/` produce no version change.
+Branch prefixes (`fix/`, `feat/`, `chore/`) and squash-merge commit messages categorize changes but do not drive automated version bumps. Version numbers are a deliberate human decision at release time, following gitflow conventions.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
-  "name": "get-shit-done-ng",
+  "name": "gsd-ng",
   "version": "1.0.0-dev.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "get-shit-done-ng",
+      "name": "gsd-ng",
       "version": "1.0.0-dev.3",
       "license": "MIT",
       "bin": {
-        "get-shit-done-ng": "bin/install.js"
+        "gsd-ng": "bin/install.js"
       },
       "devDependencies": {
         "c8": "^11.0.0",
         "esbuild": "^0.24.0"
       },
       "engines": {
-        "node": ">=16.7.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "commands",
     "gsd-ng",
     "agents",
-    "hooks/dist",
-    "scripts"
+    "hooks/dist"
   ],
   "keywords": [
     "claude",
@@ -21,7 +20,7 @@
     "context-engineering",
     "spec-driven-development"
   ],
-  "author": "TÂCHES",
+  "author": "chrisdevchroma",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -32,7 +31,7 @@
     "url": "https://github.com/chrisdevchroma/gsd-ng/issues"
   },
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "devDependencies": {
     "c8": "^11.0.0",

--- a/scripts/validate-release.sh
+++ b/scripts/validate-release.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Validates release readiness: tag-version match and CHANGELOG stamped.
+# Usage: validate-release.sh <version>
+# Exit codes: 0 = valid, 1 = validation failure
+
+set -euo pipefail
+
+VERSION="${1:?Usage: validate-release.sh <version>}"
+
+# Validate tag matches package.json
+PKG=$(node -p "require('./package.json').version")
+if [ "$VERSION" != "$PKG" ]; then
+  echo "::error::Tag v$VERSION does not match package.json version $PKG"
+  exit 1
+fi
+
+# Validate CHANGELOG.md has an entry for this version
+if ! grep -qF "## [$VERSION]" CHANGELOG.md; then
+  echo "::error::CHANGELOG.md has no entry for [$VERSION]. Run the prepare-release workflow or update CHANGELOG.md manually."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Comprehensive hardening of the release pipeline, CI guardrails, and supply chain security posture. Driven by an audit of gaps in the existing tag-based release flow.

- **Release workflow:** New `prepare-release.yml` dispatch workflow with gitflow branch enforcement (prereleases→develop, stable→main), CHANGELOG validation (must have content under [Unreleased]), auto-stamping, and annotated tags with atomic push
- **Tag-version validation:** Shared `validate-release.sh` ensures tag matches `package.json` and CHANGELOG entry exists — used by both `release.yml` and `publish.yml`
- **Supply chain security:** npm provenance via `--provenance`, tarball attestation via `actions/attest-build-provenance`, GitHub environment protection with required reviewer
- **CI guardrails:** Dependency review on PRs (blocks high-severity vulns and GPL), package.json files allowlist check, CHANGELOG enforcement (blocks on PRs to main, warns on develop), security-scan expanded to `scripts/`
- **Maintenance:** Drop Node 20 (EOL 2026-04-30), add Node 24, pin actions to v6, remove npm upgrade step, remove `scripts/` from npm distribution
- **Docs:** VERSIONING.md rewritten to reflect actual gitflow process, CHANGELOG backfilled for dev.2/dev.3, LICENSE updated with fork author, SECURITY.md updated to use GitHub private vulnerability reporting

## Changes

| Area | Files |
|------|-------|
| New workflows | `prepare-release.yml`, `dependency-review.yml` |
| Updated workflows | `release.yml`, `publish.yml`, `test.yml`, `security-scan.yml` |
| New scripts | `scripts/validate-release.sh` |
| Docs | `VERSIONING.md`, `CHANGELOG.md`, `SECURITY.md`, `LICENSE` |
| Config | `package.json`, `package-lock.json`, `.gitattributes`, `.gitignore` |

## Test Plan

- [x] CI test matrix passes on Node 22 + 24
- [x] `dependency-review` job runs and passes on this PR
- [x] `package-files-check` job passes
- [x] `changelog-check` job runs on this PR (targets develop — warning expected)
- [ ] Verify `prepare-release.yml` appears in Actions tab with dispatch trigger
- [ ] Verify `release` environment exists with required reviewer configured

## GitHub Repo Config (applied this session)

- [x] `release` environment created with required reviewer (chrisdevchroma)
- [x] `release` environment restricted to protected branches only
- [x] `develop` branch ruleset bumped to 1 required reviewer
- [x] Dependency Graph enabled
- [x] Dependabot security updates enabled
- [x] Private vulnerability reporting enabled

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng)*