### PR TITLE
chore: replace all jq usage with built-in --pick and init-get

### DIFF
--- a/gsd-ng/bin/gsd
+++ b/gsd-ng/bin/gsd
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 # gsd -- thin wrapper around gsd-tools.cjs
-# Callers can pipe directly: gsd roadmap get-phase 17 | jq '.section'
+# Callers can extract fields: gsd roadmap get-phase 17 --pick section
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 node "$SCRIPT_DIR/gsd-tools.cjs" "$@"

--- a/gsd-ng/references/decimal-phase-calculation.md
+++ b/gsd-ng/references/decimal-phase-calculation.md
@@ -32,9 +32,8 @@ With existing decimals:
 ## Extract Values
 
 ```bash
-DECIMAL_INFO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phase next-decimal "${AFTER_PHASE}")
-DECIMAL_PHASE=$(printf '%s\n' "$DECIMAL_INFO" | jq -r '.next')
-BASE_PHASE=$(printf '%s\n' "$DECIMAL_INFO" | jq -r '.base_phase')
+DECIMAL_PHASE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phase next-decimal "${AFTER_PHASE}" --pick next)
+BASE_PHASE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phase next-decimal "${AFTER_PHASE}" --pick base_phase)
 ```
 
 Or with flag:

--- a/gsd-ng/references/phase-argument-parsing.md
+++ b/gsd-ng/references/phase-argument-parsing.md
@@ -45,8 +45,8 @@ fi
 Use `roadmap get-phase` to validate phase exists:
 
 ```bash
-PHASE_CHECK=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}")
-if [ "$(printf '%s\n' "$PHASE_CHECK" | jq -r '.found')" = "false" ]; then
+PHASE_FOUND=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}" --pick found)
+if [ "$PHASE_FOUND" = "false" ]; then
   echo "ERROR: Phase ${PHASE} not found in roadmap"
   exit 1
 fi

--- a/gsd-ng/workflows/plan-milestone-gaps.md
+++ b/gsd-ng/workflows/plan-milestone-gaps.md
@@ -67,8 +67,7 @@ Gap: Flow "View dashboard" broken at data fetch
 Find highest existing phase:
 ```bash
 # Get sorted phase list, extract last one
-PHASES=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phases list)
-HIGHEST=$(echo "$PHASES" | jq -r '.directories[-1]')
+HIGHEST=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" phases list --pick "directories[-1]")
 ```
 
 New phases continue from there:

--- a/gsd-ng/workflows/plan-phase.md
+++ b/gsd-ng/workflows/plan-phase.md
@@ -463,14 +463,14 @@ ls "${PHASE_DIR}"/*-PLAN.md 2>/dev/null
 Extract from INIT JSON:
 
 ```bash
-STATE_PATH=$(echo "$INIT" | jq -r '.state_path // empty')
-ROADMAP_PATH=$(echo "$INIT" | jq -r '.roadmap_path // empty')
-REQUIREMENTS_PATH=$(echo "$INIT" | jq -r '.requirements_path // empty')
-RESEARCH_PATH=$(echo "$INIT" | jq -r '.research_path // empty')
-VERIFICATION_PATH=$(echo "$INIT" | jq -r '.verification_path // empty')
-UAT_PATH=$(echo "$INIT" | jq -r '.uat_path // empty')
-CONTEXT_PATH=$(echo "$INIT" | jq -r '.context_path // empty')
-GAP_RESEARCH_PATH=$(echo "$INIT" | jq -r '.gap_research_path // empty')
+STATE_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" state_path)
+ROADMAP_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" roadmap_path)
+REQUIREMENTS_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" requirements_path)
+RESEARCH_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" research_path)
+VERIFICATION_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" verification_path)
+UAT_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" uat_path)
+CONTEXT_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" context_path)
+GAP_RESEARCH_PATH=$(node "${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/.claude/gsd-ng/bin/gsd-tools.cjs" init-get "$INIT" gap_research_path)
 ```
 
 ## 7.5. Verify Nyquist Artifacts


### PR DESCRIPTION
## Summary

Replace `jq` with built-in `--pick` and `init-get` in workflows and references.

**Depends on:** #34 (which handles create-pr.md, audit-milestone.md, complete-milestone.md)

## Changes

| File | Before | After |
|------|--------|-------|
| plan-phase.md | `echo $INIT \| jq -r` (8 fields) | `init-get` |
| plan-milestone-gaps.md | `jq -r '.directories[-1]'` | `--pick "directories[-1]"` |
| phase-argument-parsing.md | `jq -r '.found'` | `--pick found` |
| decimal-phase-calculation.md | `jq -r '.next'` | `--pick next/base_phase` |
| bin/gsd | jq usage comment | updated to `--pick` |

## Test Plan

- [x] All 1616 tests pass (develop baseline)

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng)*