### PR TITLE
Phase 51: effort-level-per-subagent-from-gsd-profile

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1051,6 +1051,43 @@ function stripGsdFromCopilotInstructions(content) {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * Write the runtime field to .planning/config.json so effort-gating
+ * can determine whether effort: frontmatter should be injected.
+ * Creates .planning/ and config.json if they don't exist.
+ * Preserves existing config values — only sets/updates "runtime".
+ */
+function writeRuntimeToConfig(rt) {
+  const configDir = path.join(process.cwd(), '.planning');
+  const configPath = path.join(configDir, 'config.json');
+
+  // Ensure .planning directory exists
+  try {
+    fs.mkdirSync(configDir, { recursive: true });
+  } catch {}
+
+  let config = {};
+  try {
+    if (fs.existsSync(configPath)) {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    }
+  } catch {
+    // If config.json is corrupt, start fresh
+    config = {};
+  }
+
+  config.runtime = rt;
+
+  try {
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+  } catch {
+    // If .planning is gitignored or read-only, silently skip
+    // runtime will default to claude behavior in loadConfig
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 function install(isGlobal) {
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
@@ -1193,6 +1230,9 @@ function install(isGlobal) {
     fs.mkdirSync(path.dirname(versionDest), { recursive: true });
     fs.writeFileSync(versionDest, INSTALLED_VERSION);
     console.log(`  ${green}✓${reset} Wrote VERSION (${INSTALLED_VERSION})`);
+
+    // Persist runtime to .planning/config.json for effort-gating
+    writeRuntimeToConfig(runtime);
 
     return { settingsPath: null, settings: null, statuslineCommand: null, runtime };
   }
@@ -1603,6 +1643,9 @@ function install(isGlobal) {
       // Template missing or unreadable — skip
     }
   }
+
+  // Persist runtime to .planning/config.json for effort-gating
+  writeRuntimeToConfig(runtime);
 
   return { settingsPath, settings, statuslineCommand };
 }

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -15,6 +15,7 @@
  *   state get [section]                Get STATE.md content or section
  *   state patch --field val ...        Batch update STATE.md fields
  *   resolve-model <agent-type>         Get model for agent based on profile
+ *   resolve-effort <agent-type>        Get effort for agent based on profile
  *   find-phase <phase>                 Find phase directory by number
  *   commit <message> [--files f1 f2]   Commit planning docs
  *   verify-summary <path>              Verify a SUMMARY.md file
@@ -180,7 +181,7 @@ const testBaseline = require('./lib/test-baseline.cjs');
 // ─── Command Registry (for typo detection) ────────────────────────────────────
 
 const ALL_COMMANDS = [
-  'state', 'resolve-model', 'find-phase', 'commit', 'verify-summary',
+  'state', 'resolve-model', 'resolve-effort', 'find-phase', 'commit', 'verify-summary',
   'template', 'frontmatter', 'verify', 'generate-slug', 'current-timestamp',
   'list-todos', 'recurring-due', 'staleness-check', 'verify-path-exists',
   'config-ensure-section', 'config-set', 'config-set-model-profile',
@@ -834,6 +835,11 @@ async function main() {
 
     case 'resolve-model': {
       commands.cmdResolveModel(cwd, args[1]);
+      break;
+    }
+
+    case 'resolve-effort': {
+      commands.cmdResolveEffort(cwd, args[1]);
       break;
     }
 

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -5,9 +5,9 @@ const fs = require('fs');
 const path = require('path');
 const { execSync, spawnSync } = require('child_process');
 const os = require('os');
-const { safeReadFile, loadConfig, isGitIgnored, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, resolveModelInternal, extractCurrentMilestone, getPhaseCompletionStatus, toPosixPath, output, error, findPhaseInternal, planningPaths } = require('./core.cjs');
+const { safeReadFile, loadConfig, isGitIgnored, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, resolveModelInternal, resolveEffortInternal, extractCurrentMilestone, getPhaseCompletionStatus, toPosixPath, output, error, findPhaseInternal, planningPaths } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
-const { MODEL_PROFILES } = require('./model-profiles.cjs');
+const { MODEL_PROFILES, EFFORT_PROFILES } = require('./model-profiles.cjs');
 const { validatePath, scanForInjection, wrapUntrustedContent, logSecurityEvent } = require('./security.cjs');
 
 function cmdGenerateSlug(text) {
@@ -223,6 +223,22 @@ function cmdResolveModel(cwd, agentType) {
     ? { model, profile }
     : { model, profile, unknown_agent: true };
   output(result, model);
+}
+
+function cmdResolveEffort(cwd, agentType) {
+  if (!agentType) {
+    error('agent-type required');
+  }
+
+  const config = loadConfig(cwd);
+  const profile = config.model_profile || 'balanced';
+  const effort = resolveEffortInternal(cwd, agentType);
+
+  const agentEfforts = EFFORT_PROFILES[agentType];
+  const result = agentEfforts
+    ? { effort, profile }
+    : { effort, profile, unknown_agent: true };
+  output(result, effort || 'inherit');
 }
 
 function applyCommitFormat(message, config, context) {
@@ -4007,6 +4023,7 @@ module.exports = {
   cmdVerifyPathExists,
   cmdHistoryDigest,
   cmdResolveModel,
+  cmdResolveEffort,
   applyCommitFormat,
   appendIssueTrailers,
   cmdCommit,

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -9,7 +9,9 @@ const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 const {
   VALID_PROFILES,
   getAgentToModelMapForProfile,
+  getAgentToEffortMapForProfile,
   formatAgentToModelMapAsTable,
+  formatAgentToEffortMapAsTable,
 } = require('./model-profiles.cjs');
 
 const VALID_CONFIG_KEYS = new Set([
@@ -38,6 +40,8 @@ const VALID_CONFIG_KEYS = new Set([
 ]);
 
 const SUBMODULE_KEY_PATTERN = /^git\.submodules\.[^.]+\.(target_branch|branching_strategy|phase_branch_template|milestone_branch_template|review_branch_template|remote|auto_push|platform|pr_template|pr_draft|commit_format|commit_template|versioning_scheme|type_aliases|ssh_check)$/;
+
+const EFFORT_OVERRIDE_KEY_PATTERN = /^effort_overrides\.[a-z][\w-]+$/;
 
 const CONFIG_KEY_SUGGESTIONS = {
   'workflow.nyquist_validation_enabled': 'workflow.nyquist_validation',
@@ -196,7 +200,7 @@ function cmdConfigSet(cwd, keyPath, value) {
     error('git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.');
   }
 
-  if (!VALID_CONFIG_KEYS.has(keyPath) && !SUBMODULE_KEY_PATTERN.test(keyPath)) {
+  if (!VALID_CONFIG_KEYS.has(keyPath) && !SUBMODULE_KEY_PATTERN.test(keyPath) && !EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath)) {
     error(`Unknown config key: "${keyPath}". Valid keys: ${[...VALID_CONFIG_KEYS].sort().join(', ')}`);
   }
 
@@ -286,16 +290,19 @@ function cmdConfigSetModelProfile(cwd, profile) {
 
   // Build result value / message and return
   const agentToModelMap = getAgentToModelMapForProfile(normalizedProfile);
+  const agentToEffortMap = getAgentToEffortMapForProfile(normalizedProfile);
   const result = {
     updated: true,
     profile: normalizedProfile,
     previousProfile,
     agentToModelMap,
+    agentToEffortMap,
   };
   const rawValue = getCmdConfigSetModelProfileResultMessage(
     normalizedProfile,
     previousProfile,
-    agentToModelMap
+    agentToModelMap,
+    agentToEffortMap
   );
   output(result, rawValue);
 }
@@ -307,21 +314,25 @@ function cmdConfigSetModelProfile(cwd, profile) {
 function getCmdConfigSetModelProfileResultMessage(
   normalizedProfile,
   previousProfile,
-  agentToModelMap
+  agentToModelMap,
+  agentToEffortMap
 ) {
   const agentToModelTable = formatAgentToModelMapAsTable(agentToModelMap);
+  const agentToEffortTable = agentToEffortMap ? formatAgentToEffortMapAsTable(agentToEffortMap) : null;
   const didChange = previousProfile !== normalizedProfile;
   const paragraphs = didChange
     ? [
-        `✓ Model profile set to: ${normalizedProfile} (was: ${previousProfile})`,
-        'Agents will now use:',
+        `\u2713 Model profile set to: ${normalizedProfile} (was: ${previousProfile})`,
+        'Model assignments:',
         agentToModelTable,
+        ...(agentToEffortTable ? ['Effort assignments:', agentToEffortTable] : []),
         'Next spawned agents will use the new profile.',
       ]
     : [
-        `✓ Model profile is already set to: ${normalizedProfile}`,
-        'Agents are using:',
+        `\u2713 Model profile is already set to: ${normalizedProfile}`,
+        'Model assignments:',
         agentToModelTable,
+        ...(agentToEffortTable ? ['Effort assignments:', agentToEffortTable] : []),
       ];
   return paragraphs.join('\n\n');
 }

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync, execFileSync, spawnSync } = require('child_process');
-const { MODEL_PROFILES } = require('./model-profiles.cjs');
+const { MODEL_PROFILES, EFFORT_PROFILES } = require('./model-profiles.cjs');
 const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 
 // ─── Path helpers ────────────────────────────────────────────────────────────
@@ -221,6 +221,8 @@ function loadConfig(cwd) {
       nyquist_validation: get('nyquist_validation', { section: 'workflow', field: 'nyquist_validation' }) ?? defaults.nyquist_validation,
       parallelization,
       model_overrides: parsed.model_overrides || null,
+      effort_overrides: parsed.effort_overrides || null,
+      runtime: parsed.runtime || null,
     };
   } catch {
     return defaults;
@@ -500,6 +502,31 @@ function resolveModelInternal(cwd, agentType) {
   return agentModels[profile] || agentModels['balanced'] || 'sonnet';
 }
 
+function resolveEffortInternal(cwd, agentType) {
+  const config = loadConfig(cwd);
+
+  // Non-Claude runtimes do not support effort: frontmatter — skip silently.
+  // When runtime is null/undefined, default to claude behavior (backward compat).
+  if (config.runtime && config.runtime !== 'claude') {
+    return null;
+  }
+
+  // 1. Check per-agent effort override first
+  const override = config.effort_overrides?.[agentType];
+  if (override) {
+    return override === 'inherit' ? null : override;
+  }
+
+  // 2. Fall back to profile lookup
+  const profile = config.model_profile || 'balanced';
+  const agentEfforts = EFFORT_PROFILES[agentType];
+  if (!agentEfforts) return null; // Unknown agent -> inherit
+
+  const effort = agentEfforts[profile];
+  if (!effort || effort === 'inherit') return null; // null -> omit from spawn
+  return effort;
+}
+
 // ─── Misc utilities ───────────────────────────────────────────────────────────
 
 function pathExistsInternal(cwd, targetPath) {
@@ -666,6 +693,7 @@ module.exports = {
   getArchivedPhaseDirs,
   getRoadmapPhaseInternal,
   resolveModelInternal,
+  resolveEffortInternal,
   pathExistsInternal,
   generateSlugInternal,
   getMilestoneInfo,

--- a/gsd-ng/bin/lib/init.cjs
+++ b/gsd-ng/bin/lib/init.cjs
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone, normalizePhaseName, toPosixPath, output, error, planningPaths } = require('./core.cjs');
+const { loadConfig, resolveModelInternal, resolveEffortInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone, normalizePhaseName, toPosixPath, output, error, planningPaths } = require('./core.cjs');
 const { DEFAULTS } = require('./defaults.cjs');
 const { validatePhaseNumber } = require('./security.cjs');
 const { adjustQuickTable } = require('./state.cjs');
@@ -55,6 +55,10 @@ function cmdInitExecutePhase(cwd, phase) {
     // Models
     executor_model: resolveModelInternal(cwd, 'gsd-executor'),
     verifier_model: resolveModelInternal(cwd, 'gsd-verifier'),
+
+    // Efforts
+    executor_effort: resolveEffortInternal(cwd, 'gsd-executor'),
+    verifier_effort: resolveEffortInternal(cwd, 'gsd-verifier'),
 
     // Config flags
     commit_docs: config.commit_docs,
@@ -211,6 +215,11 @@ function cmdInitPlanPhase(cwd, phase) {
     planner_model: resolveModelInternal(cwd, 'gsd-planner'),
     checker_model: resolveModelInternal(cwd, 'gsd-plan-checker'),
 
+    // Efforts
+    researcher_effort: resolveEffortInternal(cwd, 'gsd-phase-researcher'),
+    planner_effort: resolveEffortInternal(cwd, 'gsd-planner'),
+    checker_effort: resolveEffortInternal(cwd, 'gsd-plan-checker'),
+
     // Workflow flags
     research_enabled: config.research,
     plan_checker_enabled: config.plan_checker,
@@ -315,6 +324,11 @@ function cmdInitNewProject(cwd) {
     synthesizer_model: resolveModelInternal(cwd, 'gsd-research-synthesizer'),
     roadmapper_model: resolveModelInternal(cwd, 'gsd-roadmapper'),
 
+    // Efforts
+    researcher_effort: resolveEffortInternal(cwd, 'gsd-project-researcher'),
+    synthesizer_effort: resolveEffortInternal(cwd, 'gsd-research-synthesizer'),
+    roadmapper_effort: resolveEffortInternal(cwd, 'gsd-roadmapper'),
+
     // Config
     commit_docs: config.commit_docs,
 
@@ -348,6 +362,11 @@ function cmdInitNewMilestone(cwd) {
     researcher_model: resolveModelInternal(cwd, 'gsd-project-researcher'),
     synthesizer_model: resolveModelInternal(cwd, 'gsd-research-synthesizer'),
     roadmapper_model: resolveModelInternal(cwd, 'gsd-roadmapper'),
+
+    // Efforts
+    researcher_effort: resolveEffortInternal(cwd, 'gsd-project-researcher'),
+    synthesizer_effort: resolveEffortInternal(cwd, 'gsd-research-synthesizer'),
+    roadmapper_effort: resolveEffortInternal(cwd, 'gsd-roadmapper'),
 
     // Config
     commit_docs: config.commit_docs,
@@ -421,6 +440,12 @@ function cmdInitQuick(cwd, description, verifyMode) {
     executor_model: resolveModelInternal(cwd, 'gsd-executor'),
     checker_model: resolveModelInternal(cwd, 'gsd-plan-checker'),
     verifier_model: resolveModelInternal(cwd, 'gsd-verifier'),
+
+    // Efforts
+    planner_effort: resolveEffortInternal(cwd, 'gsd-planner'),
+    executor_effort: resolveEffortInternal(cwd, 'gsd-executor'),
+    checker_effort: resolveEffortInternal(cwd, 'gsd-plan-checker'),
+    verifier_effort: resolveEffortInternal(cwd, 'gsd-verifier'),
 
     // Config
     commit_docs: config.commit_docs,

--- a/gsd-ng/bin/lib/model-profiles.cjs
+++ b/gsd-ng/bin/lib/model-profiles.cjs
@@ -26,6 +26,32 @@ const MODEL_PROFILES = {
 const VALID_PROFILES = Object.keys(MODEL_PROFILES['gsd-planner']);
 
 /**
+ * Mapping of GSD agent to effort level for each profile.
+ *
+ * Quality: critical decision-makers (planner, roadmapper, debugger, verifier) at max, others at high.
+ * Balanced: all inherit (session default applies, matches current behavior).
+ * Budget: writers/decision-makers at high, mechanical/read-only agents at medium.
+ */
+const EFFORT_PROFILES = {
+  'gsd-planner':              { quality: 'max',     balanced: 'inherit', budget: 'high' },
+  'gsd-roadmapper':           { quality: 'max',     balanced: 'inherit', budget: 'high' },
+  'gsd-executor':             { quality: 'high',    balanced: 'inherit', budget: 'high' },
+  'gsd-phase-researcher':     { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-project-researcher':   { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-research-synthesizer': { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-debugger':             { quality: 'max',     balanced: 'inherit', budget: 'high' },
+  'gsd-codebase-mapper':      { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-incremental-mapper':   { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-verifier':             { quality: 'max',     balanced: 'inherit', budget: 'high' },
+  'gsd-plan-checker':         { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-integration-checker':  { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-nyquist-auditor':      { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-ui-researcher':        { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-ui-checker':           { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-ui-auditor':           { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+};
+
+/**
  * Formats the agent-to-model mapping as a human-readable table (in string format).
  *
  * @param {Object<string, string>} agentToModelMap - A mapping from agent to model
@@ -60,9 +86,47 @@ function getAgentToModelMapForProfile(normalizedProfile) {
   return agentToModelMap;
 }
 
+/**
+ * Formats the agent-to-effort mapping as a human-readable table (in string format).
+ *
+ * @param {Object<string, string>} agentToEffortMap - A mapping from agent to effort level
+ * @returns {string} A formatted table string
+ */
+function formatAgentToEffortMapAsTable(agentToEffortMap) {
+  const agentWidth = Math.max('Agent'.length, ...Object.keys(agentToEffortMap).map((a) => a.length));
+  const effortWidth = Math.max(
+    'Effort'.length,
+    ...Object.values(agentToEffortMap).map((e) => e.length)
+  );
+  const sep = '\u2500'.repeat(agentWidth + 2) + '\u253C' + '\u2500'.repeat(effortWidth + 2);
+  const header = ' ' + 'Agent'.padEnd(agentWidth) + ' \u2502 ' + 'Effort'.padEnd(effortWidth);
+  let table = header + '\n' + sep + '\n';
+  for (const [agent, effort] of Object.entries(agentToEffortMap)) {
+    table += ' ' + agent.padEnd(agentWidth) + ' \u2502 ' + effort.padEnd(effortWidth) + '\n';
+  }
+  return table;
+}
+
+/**
+ * Returns a mapping from agent to effort level for the given effort profile.
+ *
+ * @param {string} normalizedProfile - The normalized (lowercase and trimmed) profile name
+ * @returns {Object<string, string>} A mapping from agent to effort for the given profile
+ */
+function getAgentToEffortMapForProfile(normalizedProfile) {
+  const agentToEffortMap = {};
+  for (const [agent, profileToEffortMap] of Object.entries(EFFORT_PROFILES)) {
+    agentToEffortMap[agent] = profileToEffortMap[normalizedProfile];
+  }
+  return agentToEffortMap;
+}
+
 module.exports = {
   MODEL_PROFILES,
+  EFFORT_PROFILES,
   VALID_PROFILES,
   formatAgentToModelMapAsTable,
+  formatAgentToEffortMapAsTable,
   getAgentToModelMapForProfile,
+  getAgentToEffortMapForProfile,
 };

--- a/gsd-ng/references/model-profiles.md
+++ b/gsd-ng/references/model-profiles.md
@@ -91,3 +91,84 @@ Read-only exploration and pattern extraction. No reasoning required, just struct
 
 **Why `inherit` instead of passing `opus` directly?**
 Claude Code's `"opus"` alias maps to a specific model version. Organizations may block older opus versions while allowing newer ones. The `inherit` profile causes `resolveModelInternal` to return `null`, which omits the `model` parameter from Agent tool calls. This lets opus-tier agents inherit whatever model the user's session is running. This avoids version conflicts and silent fallbacks to Sonnet.
+
+## Effort Profiles
+
+Effort profiles control the `effort:` frontmatter injected into agent spawn calls. This maps each agent to a thinking budget tier. Effort is Claude-only — it is not injected for Copilot runtimes.
+
+### Effort Profile Definitions
+
+| Agent | `quality` | `balanced` | `budget` |
+|-------|-----------|------------|----------|
+| gsd-planner | max | inherit | high |
+| gsd-roadmapper | max | inherit | high |
+| gsd-executor | high | inherit | high |
+| gsd-phase-researcher | high | inherit | medium |
+| gsd-project-researcher | high | inherit | medium |
+| gsd-research-synthesizer | high | inherit | medium |
+| gsd-debugger | max | inherit | high |
+| gsd-codebase-mapper | high | inherit | medium |
+| gsd-incremental-mapper | high | inherit | medium |
+| gsd-verifier | max | inherit | high |
+| gsd-plan-checker | high | inherit | medium |
+| gsd-integration-checker | high | inherit | medium |
+| gsd-nyquist-auditor | high | inherit | medium |
+| gsd-ui-researcher | high | inherit | medium |
+| gsd-ui-checker | high | inherit | medium |
+| gsd-ui-auditor | high | inherit | medium |
+
+### Valid Effort Values
+
+- `low` — Minimal thinking budget
+- `medium` — Moderate thinking budget
+- `high` — High thinking budget
+- `max` — Maximum thinking budget
+- `inherit` — Omit effort from spawn; session default applies (current behavior)
+
+### Effort Resolution Order
+
+```
+1. Check effort_overrides[agent] in .planning/config.json
+2. If no override, look up agent in EFFORT_PROFILES[agent][profile]
+3. If value is 'inherit', return null (omit effort parameter)
+4. If runtime != 'claude', return null (effort unsupported)
+```
+
+### Runtime Gating
+
+Effort is only injected when `runtime` in `.planning/config.json` is `"claude"`. Copilot installs always receive null from `resolveEffortInternal` regardless of profile or overrides. The `runtime` field is written by `install.js` at install time.
+
+### Per-Agent Effort Overrides
+
+Override specific agents without changing the entire profile:
+
+```json
+{
+  "model_profile": "balanced",
+  "effort_overrides": {
+    "gsd-executor": "max",
+    "gsd-planner": "high"
+  }
+}
+```
+
+Configure via CLI: `gsd-tools config-set effort_overrides.gsd-executor max`
+
+Overrides take precedence over the profile. Valid values: `low`, `medium`, `high`, `max`.
+
+### Profile Philosophy
+
+**quality** — Maximum reasoning power
+- Critical decision-makers (planner, roadmapper, debugger, verifier) at `max`
+- All other agents at `high`
+- No agent below `high` — use when quota is available and correctness is critical
+
+**balanced** (default) — Session default applies
+- All agents at `inherit` — omits effort from spawn
+- Current behavior preserved: matches session-level thinking budget
+- Use for normal development when you don't want to override session settings
+
+**budget** — Reduced thinking where safe
+- Decision-makers (planner, executor, debugger, verifier) at `high`
+- Mechanical/read-only agents (researchers, mappers, checkers) at `medium`
+- Use when conserving budget; never drops below `medium`

--- a/gsd-ng/references/model-profiles.md
+++ b/gsd-ng/references/model-profiles.md
@@ -128,10 +128,10 @@ Effort profiles control the `effort:` frontmatter injected into agent spawn call
 ### Effort Resolution Order
 
 ```
-1. Check effort_overrides[agent] in .planning/config.json
-2. If no override, look up agent in EFFORT_PROFILES[agent][profile]
-3. If value is 'inherit', return null (omit effort parameter)
-4. If runtime != 'claude', return null (effort unsupported)
+1. If runtime != 'claude', return null (effort unsupported)
+2. Check effort_overrides[agent] in .planning/config.json
+3. If no override, look up agent in EFFORT_PROFILES[agent][profile]
+4. If value is 'inherit', return null (omit effort parameter)
 ```
 
 ### Runtime Gating
@@ -154,7 +154,7 @@ Override specific agents without changing the entire profile:
 
 Configure via CLI: `gsd-tools config-set effort_overrides.gsd-executor max`
 
-Overrides take precedence over the profile. Valid values: `low`, `medium`, `high`, `max`.
+Overrides take precedence over the profile. Valid values: `low`, `medium`, `high`, `max`, `inherit`. Use `inherit` to clear the per-agent override so effort is omitted/null and the session-level behavior is preserved.
 
 ### Profile Philosophy
 

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -13,6 +13,7 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 const { runGsdTools, createTempProject, cleanup, resolveTmpDir } = require('./helpers.cjs');
+const { EFFORT_PROFILES, getAgentToEffortMapForProfile, formatAgentToEffortMapAsTable } = require('../gsd-ng/bin/lib/model-profiles.cjs');
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
@@ -579,5 +580,169 @@ describe('Per-submodule config keys (SUBMOD-01)', () => {
     const result = runGsdTools('config-get git.submodule.workspace_branch', tmpDir);
     // Should succeed (returns value for migration) but stderr has warning
     assert.match(result.stderr || result.output || result.error || '', /deprecated/i);
+  });
+});
+
+// ─── EFFORT_PROFILES ──────────────────────────────────────────────────────────
+
+describe('EFFORT_PROFILES', () => {
+  const EXPECTED_AGENTS = [
+    'gsd-planner',
+    'gsd-roadmapper',
+    'gsd-executor',
+    'gsd-phase-researcher',
+    'gsd-project-researcher',
+    'gsd-research-synthesizer',
+    'gsd-debugger',
+    'gsd-codebase-mapper',
+    'gsd-incremental-mapper',
+    'gsd-verifier',
+    'gsd-plan-checker',
+    'gsd-integration-checker',
+    'gsd-nyquist-auditor',
+    'gsd-ui-researcher',
+    'gsd-ui-checker',
+    'gsd-ui-auditor',
+  ];
+
+  test('Test 1: EFFORT_PROFILES has all 16 agent entries', () => {
+    const agents = Object.keys(EFFORT_PROFILES);
+    assert.strictEqual(agents.length, 16, `Expected 16 agents, got ${agents.length}: ${agents.join(', ')}`);
+    for (const agent of EXPECTED_AGENTS) {
+      assert.ok(agent in EFFORT_PROFILES, `Missing agent: ${agent}`);
+    }
+  });
+
+  test('Test 2: EFFORT_PROFILES quality profile has correct max/high values', () => {
+    assert.strictEqual(EFFORT_PROFILES['gsd-planner'].quality, 'max');
+    assert.strictEqual(EFFORT_PROFILES['gsd-debugger'].quality, 'max');
+    assert.strictEqual(EFFORT_PROFILES['gsd-verifier'].quality, 'max');
+    assert.strictEqual(EFFORT_PROFILES['gsd-roadmapper'].quality, 'max');
+    assert.strictEqual(EFFORT_PROFILES['gsd-executor'].quality, 'high');
+  });
+
+  test('Test 3: EFFORT_PROFILES balanced profile has all agents set to inherit', () => {
+    for (const [agent, profiles] of Object.entries(EFFORT_PROFILES)) {
+      assert.strictEqual(
+        profiles.balanced,
+        'inherit',
+        `Expected balanced to be 'inherit' for ${agent}, got '${profiles.balanced}'`
+      );
+    }
+  });
+
+  test('Test 4: EFFORT_PROFILES budget profile has correct high/medium values', () => {
+    assert.strictEqual(EFFORT_PROFILES['gsd-planner'].budget, 'high');
+    assert.strictEqual(EFFORT_PROFILES['gsd-executor'].budget, 'high');
+    assert.strictEqual(EFFORT_PROFILES['gsd-debugger'].budget, 'high');
+    assert.strictEqual(EFFORT_PROFILES['gsd-verifier'].budget, 'high');
+    assert.strictEqual(EFFORT_PROFILES['gsd-codebase-mapper'].budget, 'medium');
+  });
+
+  test('Test 5: getAgentToEffortMapForProfile quality returns object with all 16 agents mapped', () => {
+    const map = getAgentToEffortMapForProfile('quality');
+    assert.strictEqual(typeof map, 'object');
+    assert.strictEqual(Object.keys(map).length, 16);
+    for (const agent of EXPECTED_AGENTS) {
+      assert.ok(agent in map, `Missing agent in quality map: ${agent}`);
+      assert.strictEqual(typeof map[agent], 'string');
+    }
+  });
+
+  test('Test 6: getAgentToEffortMapForProfile balanced returns all values as inherit', () => {
+    const map = getAgentToEffortMapForProfile('balanced');
+    for (const [agent, effort] of Object.entries(map)) {
+      assert.strictEqual(effort, 'inherit', `Expected 'inherit' for ${agent}, got '${effort}'`);
+    }
+  });
+
+  test('Test 7: formatAgentToEffortMapAsTable produces string with Agent and Effort column headers', () => {
+    const map = getAgentToEffortMapForProfile('quality');
+    const table = formatAgentToEffortMapAsTable(map);
+    assert.strictEqual(typeof table, 'string');
+    assert.ok(table.includes('Agent'), 'Table should contain "Agent" header');
+    assert.ok(table.includes('Effort'), 'Table should contain "Effort" header');
+  });
+
+  test('Test 8: VALID_PROFILES is shared — quality, balanced, budget profiles exist in EFFORT_PROFILES', () => {
+    const firstAgent = EFFORT_PROFILES['gsd-planner'];
+    assert.ok('quality' in firstAgent, 'quality profile should exist');
+    assert.ok('balanced' in firstAgent, 'balanced profile should exist');
+    assert.ok('budget' in firstAgent, 'budget profile should exist');
+    assert.strictEqual(Object.keys(firstAgent).length, 3, 'Should have exactly 3 profiles');
+  });
+});
+
+// ─── set-profile effort display and config-set effort_overrides (EFF-04, EFF-05) ─
+
+describe('set-profile effort display and effort_overrides config-set (EFF-04, EFF-05)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    runGsdTools('config-ensure-section', tmpDir);
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('Test 6: cmdConfigSetModelProfile result includes agentToEffortMap field', () => {
+    const result = runGsdTools('config-set-model-profile quality --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok('agentToEffortMap' in output, 'result should include agentToEffortMap');
+    assert.ok(typeof output.agentToEffortMap === 'object', 'agentToEffortMap should be an object');
+    assert.ok('gsd-executor' in output.agentToEffortMap, 'agentToEffortMap should have gsd-executor key');
+  });
+
+  test('Test 7: set-profile raw message includes "Effort" table header', () => {
+    const result = runGsdTools('config-set-model-profile quality', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    assert.ok(
+      result.output.includes('Effort'),
+      `Raw output should contain "Effort" table header. Got: ${result.output.substring(0, 300)}`
+    );
+  });
+
+  test('Test 9: config-set accepts effort_overrides.gsd-executor as valid key', () => {
+    const result = runGsdTools('config-set effort_overrides.gsd-executor max', tmpDir);
+    assert.ok(
+      result.success,
+      `config-set effort_overrides.gsd-executor should succeed, got error: ${result.error}`
+    );
+
+    const config = JSON.parse(
+      require('fs').readFileSync(require('path').join(tmpDir, '.planning', 'config.json'), 'utf-8')
+    );
+    assert.strictEqual(config.effort_overrides['gsd-executor'], 'max');
+  });
+
+  test('Test 10: config-set accepts effort_overrides.gsd-planner as valid key', () => {
+    const result = runGsdTools('config-set effort_overrides.gsd-planner high', tmpDir);
+    assert.ok(
+      result.success,
+      `config-set effort_overrides.gsd-planner should succeed, got error: ${result.error}`
+    );
+
+    const config = JSON.parse(
+      require('fs').readFileSync(require('path').join(tmpDir, '.planning', 'config.json'), 'utf-8')
+    );
+    assert.strictEqual(config.effort_overrides['gsd-planner'], 'high');
+  });
+
+  test('Test 11: config-set rejects effort_overrides_typo.gsd-executor as invalid key', () => {
+    const result = runGsdTools('config-set effort_overrides_typo.gsd-executor max', tmpDir);
+    assert.strictEqual(
+      result.success,
+      false,
+      'effort_overrides_typo.gsd-executor should be rejected as unknown config key'
+    );
+    assert.ok(
+      result.error.includes('Unknown config key'),
+      `Expected "Unknown config key" in error, got: ${result.error}`
+    );
   });
 });

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -15,6 +15,7 @@ const { resolveTmpDir, cleanup } = require('./helpers.cjs');
 const {
   loadConfig,
   resolveModelInternal,
+  resolveEffortInternal,
   escapeRegex,
   generateSlugInternal,
   normalizePhaseName,
@@ -1053,5 +1054,81 @@ describe('output() inline default and --file flag', () => {
     const coreExports = require('../gsd-ng/bin/lib/core.cjs');
     assert.strictEqual(typeof coreExports.setFileOutput, 'function', 'setFileOutput should be exported');
     assert.strictEqual(typeof coreExports.setResolveOutput, 'undefined', 'setResolveOutput should NOT be exported');
+  });
+});
+
+// ─── resolveEffortInternal ─────────────────────────────────────────────────────
+
+describe('resolveEffortInternal', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-core-test-'));
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  function writeConfig(obj) {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify(obj, null, 2)
+    );
+  }
+
+  test('Test 1: returns max for gsd-planner when model_profile=quality and no overrides', () => {
+    writeConfig({ model_profile: 'quality' });
+    const result = resolveEffortInternal(tmpDir, 'gsd-planner');
+    assert.strictEqual(result, 'max');
+  });
+
+  test('Test 2: returns null for gsd-planner when model_profile=balanced (inherit resolves to null)', () => {
+    writeConfig({ model_profile: 'balanced' });
+    const result = resolveEffortInternal(tmpDir, 'gsd-planner');
+    assert.strictEqual(result, null);
+  });
+
+  test('Test 3: returns effort_overrides value when set (override takes precedence over profile)', () => {
+    writeConfig({
+      model_profile: 'balanced',
+      effort_overrides: { 'gsd-planner': 'max' },
+    });
+    const result = resolveEffortInternal(tmpDir, 'gsd-planner');
+    assert.strictEqual(result, 'max');
+  });
+
+  test('Test 4: returns null for effort_overrides=inherit (override set to inherit resolves to null)', () => {
+    writeConfig({
+      model_profile: 'quality',
+      effort_overrides: { 'gsd-planner': 'inherit' },
+    });
+    const result = resolveEffortInternal(tmpDir, 'gsd-planner');
+    assert.strictEqual(result, null);
+  });
+
+  test('Test 5: returns null for unknown agent (not in EFFORT_PROFILES)', () => {
+    writeConfig({ model_profile: 'quality' });
+    const result = resolveEffortInternal(tmpDir, 'gsd-nonexistent');
+    assert.strictEqual(result, null);
+  });
+
+  test('Test 6: returns null when config.runtime is copilot (non-Claude runtime suppression)', () => {
+    writeConfig({ model_profile: 'quality', runtime: 'copilot' });
+    const result = resolveEffortInternal(tmpDir, 'gsd-planner');
+    assert.strictEqual(result, null);
+  });
+
+  test('Test 7: returns normal value when config.runtime is claude', () => {
+    writeConfig({ model_profile: 'quality', runtime: 'claude' });
+    const result = resolveEffortInternal(tmpDir, 'gsd-planner');
+    assert.strictEqual(result, 'max');
+  });
+
+  test('Test 8: returns normal value when config.runtime is undefined (backward compat)', () => {
+    writeConfig({ model_profile: 'quality' });
+    const result = resolveEffortInternal(tmpDir, 'gsd-planner');
+    assert.strictEqual(result, 'max');
   });
 });

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -200,6 +200,113 @@ describe('init commands', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Effort fields in init commands (EFF-03)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('Effort fields in init commands (EFF-03)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  function writeClaudeConfig(dir) {
+    const configPath = path.join(dir, '.planning', 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({ model_profile: 'quality', runtime: 'claude' }, null, 2), 'utf-8');
+  }
+
+  function writeCopilotConfig(dir) {
+    const configPath = path.join(dir, '.planning', 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({ model_profile: 'quality', runtime: 'copilot' }, null, 2), 'utf-8');
+  }
+
+  test('Test 1: init execute-phase result includes executor_effort and verifier_effort fields', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '# Plan');
+    writeClaudeConfig(tmpDir);
+
+    const result = runGsdTools('init execute-phase 03 --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok('executor_effort' in output, 'executor_effort should be present');
+    assert.ok('verifier_effort' in output, 'verifier_effort should be present');
+    assert.ok(output.executor_effort !== undefined, 'executor_effort should not be undefined');
+    assert.ok(output.verifier_effort !== undefined, 'verifier_effort should not be undefined');
+  });
+
+  test('Test 2: init plan-phase result includes researcher_effort, planner_effort, checker_effort', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    writeClaudeConfig(tmpDir);
+
+    const result = runGsdTools('init plan-phase 03 --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok('researcher_effort' in output, 'researcher_effort should be present');
+    assert.ok('planner_effort' in output, 'planner_effort should be present');
+    assert.ok('checker_effort' in output, 'checker_effort should be present');
+  });
+
+  test('Test 3: init new-project result includes researcher_effort, synthesizer_effort, roadmapper_effort', () => {
+    writeClaudeConfig(tmpDir);
+
+    const result = runGsdTools('init new-project --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok('researcher_effort' in output, 'researcher_effort should be present');
+    assert.ok('synthesizer_effort' in output, 'synthesizer_effort should be present');
+    assert.ok('roadmapper_effort' in output, 'roadmapper_effort should be present');
+  });
+
+  test('Test 4: init new-milestone result includes researcher_effort, synthesizer_effort, roadmapper_effort', () => {
+    writeClaudeConfig(tmpDir);
+
+    const result = runGsdTools('init new-milestone --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok('researcher_effort' in output, 'researcher_effort should be present');
+    assert.ok('synthesizer_effort' in output, 'synthesizer_effort should be present');
+    assert.ok('roadmapper_effort' in output, 'roadmapper_effort should be present');
+  });
+
+  test('Test 5: init quick result includes planner_effort, executor_effort, checker_effort, verifier_effort', () => {
+    writeClaudeConfig(tmpDir);
+
+    const result = runGsdTools('init quick test-task --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok('planner_effort' in output, 'planner_effort should be present');
+    assert.ok('executor_effort' in output, 'executor_effort should be present');
+    assert.ok('checker_effort' in output, 'checker_effort should be present');
+    assert.ok('verifier_effort' in output, 'verifier_effort should be present');
+  });
+
+  test('Test 8: effort fields are null when config.json has runtime=copilot', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '# Plan');
+    writeCopilotConfig(tmpDir);
+
+    const result = runGsdTools('init execute-phase 03 --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.executor_effort, null, 'executor_effort should be null for copilot runtime');
+    assert.strictEqual(output.verifier_effort, null, 'verifier_effort should be null for copilot runtime');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // cmdInitTodos (INIT-01)
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/install-js.test.cjs
+++ b/tests/install-js.test.cjs
@@ -1253,3 +1253,141 @@ test('SVN-03: --runtime claude --local writes manifest.version equal to VERSION 
     cleanup(tmpDir);
   }
 });
+
+// ── RUNTIME-01: install.js writes runtime field to .planning/config.json ─────
+
+test('RUNTIME-01: install.js --runtime claude writes "runtime":"claude" to .planning/config.json', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR,'gsd-js-runtime-claude-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+      }
+    );
+
+    assert.strictEqual(
+      result.status,
+      0,
+      'install.js --local --runtime claude must exit 0 (RUNTIME-01)\nstderr: ' + (result.stderr || '')
+    );
+
+    const configPath = path.join(tmpDir, '.planning', 'config.json');
+    assert.ok(fs.existsSync(configPath), '.planning/config.json must exist after install (RUNTIME-01)');
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    assert.strictEqual(
+      config.runtime,
+      'claude',
+      'config.json must contain "runtime":"claude" after claude install (RUNTIME-01)'
+    );
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+test('RUNTIME-02: install.js --runtime copilot writes "runtime":"copilot" to .planning/config.json', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR,'gsd-js-runtime-copilot-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'copilot', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+      }
+    );
+
+    assert.strictEqual(
+      result.status,
+      0,
+      'install.js --local --runtime copilot must exit 0 (RUNTIME-02)\nstderr: ' + (result.stderr || '')
+    );
+
+    const configPath = path.join(tmpDir, '.planning', 'config.json');
+    assert.ok(fs.existsSync(configPath), '.planning/config.json must exist after copilot install (RUNTIME-02)');
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    assert.strictEqual(
+      config.runtime,
+      'copilot',
+      'config.json must contain "runtime":"copilot" after copilot install (RUNTIME-02)'
+    );
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+test('RUNTIME-03: install.js preserves existing config.json values when writing runtime field', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR,'gsd-js-runtime-preserve-'));
+  try {
+    // Create .planning dir and pre-existing config.json with some values
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality', commit_docs: false }, null, 2),
+      'utf-8'
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+      }
+    );
+
+    assert.strictEqual(
+      result.status,
+      0,
+      'install.js must exit 0 even when config.json already exists (RUNTIME-03)\nstderr: ' + (result.stderr || '')
+    );
+
+    const config = JSON.parse(fs.readFileSync(path.join(tmpDir, '.planning', 'config.json'), 'utf8'));
+    assert.strictEqual(config.runtime, 'claude', 'runtime field must be added (RUNTIME-03)');
+    assert.strictEqual(config.model_profile, 'quality', 'existing model_profile must be preserved (RUNTIME-03)');
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+test('RUNTIME-04: install.js updates existing runtime field in config.json', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR,'gsd-js-runtime-update-'));
+  try {
+    // Pre-create config.json with runtime: copilot
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ runtime: 'copilot' }, null, 2),
+      'utf-8'
+    );
+
+    // Install with claude runtime — should update to claude
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+      }
+    );
+
+    assert.strictEqual(result.status, 0, 'install.js must exit 0 (RUNTIME-04)\nstderr: ' + (result.stderr || ''));
+
+    const config = JSON.parse(fs.readFileSync(path.join(tmpDir, '.planning', 'config.json'), 'utf8'));
+    assert.strictEqual(config.runtime, 'claude', 'runtime must be updated from copilot to claude (RUNTIME-04)');
+  } finally {
+    cleanup(tmpDir);
+  }
+});


### PR DESCRIPTION
## Summary

Configure effort/reasoning levels per subagent type based on GSD profile (quality/balanced/budget), mirroring the existing model profile pattern. Effort injection is Claude-only (runtime-gated).

## Changes

- **51-01**: EFFORT_PROFILES constant (16 agents × 3 profiles), `resolveEffortInternal` with override > profile > inherit chain, `resolve-effort` CLI command, and 16 unit tests
- **51-02**: Effort fields in all 5 init commands (`executor_effort`, `verifier_effort`, `planner_effort`, etc.), set-profile now displays both model and effort tables, `EFFORT_OVERRIDE_KEY_PATTERN` for `config-set effort_overrides.*` support, `writeRuntimeToConfig` in install.js persists runtime for effort-gating

## Test Plan

- [x] Automated tests pass (1616 → 1647, +31 tests, 0 regressions)
- [x] Verification passed (9/9 must-haves)
- [ ] Manual: `node gsd-ng/bin/gsd-tools.cjs resolve-effort gsd-planner` returns expected effort
- [ ] Manual: `node gsd-ng/bin/gsd-tools.cjs config-set-model-profile quality` shows both model and effort tables

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng) from phase 51 execution*