### PR TITLE
chore: remove first-turn-rule workaround

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -16,7 +16,7 @@ const reset = '\x1b[0m';
 
 // Get version from package.json
 const pkg = require('../package.json');
-const { processTemplate, buildContext, injectAfterFrontmatter, injectAppendToFile, fillBetweenMarkers } = require('../gsd-ng/bin/lib/template-processor.cjs');
+const { processTemplate, buildContext, injectAppendToFile, fillBetweenMarkers } = require('../gsd-ng/bin/lib/template-processor.cjs');
 const { getPlatformCliPatterns, PLATFORM_TO_CLI } = require(path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'allowlist.cjs'));
 
 // Parse args
@@ -353,11 +353,6 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, isCommand = false)
       content = content.replace(localClaudeRegex, `./${dirName}/`);
       // Template variable: project rules file path (Claude Code uses CLAUDE.md)
       content = content.replace(/\{\{PROJECT_RULES_FILE\}\}/g, 'CLAUDE.md');
-      // Inject first-turn rule into Claude command files that use AskUserQuestion
-      if (isCommand && runtime === 'claude' && content.includes('AskUserQuestion')) {
-        const ftrTemplate = path.join(__dirname, '..', 'gsd-ng', 'templates', 'first-turn-rule.md');
-        content = injectAfterFrontmatter(content, ftrTemplate, 'first_turn_rule');
-      }
       content = processAttribution(content, getCommitAttribution());
       fs.writeFileSync(destPath, content);
     } else {
@@ -1023,8 +1018,6 @@ function mergeCopilotInstructions(instructionsPath, templateContent) {
     fs.writeFileSync(instructionsPath, existing + separator + gsdBlock + '\n');
   }
 }
-
-// injectFirstTurnRule moved to template-processor.cjs as injectAfterFrontmatter.
 
 /**
  * Remove the GSD block from copilot-instructions.md content.

--- a/gsd-ng/bin/lib/template-processor.cjs
+++ b/gsd-ng/bin/lib/template-processor.cjs
@@ -90,31 +90,6 @@ function buildContext(runtime, options) {
 }
 
 /**
- * Inject a template block after YAML frontmatter in a command file.
- * Idempotent: skips if the marker tag is already present.
- *
- * @param {string} content - File content with YAML frontmatter
- * @param {string} templatePath - Absolute path to template file
- * @param {string} marker - Tag name to check for idempotency (e.g. 'first_turn_rule')
- * @returns {string} Content with template injected, or unchanged if already present
- */
-function injectAfterFrontmatter(content, templatePath, marker) {
-  if (content.includes('<' + marker + '>')) {
-    return content; // Already injected
-  }
-  if (!fs.existsSync(templatePath)) {
-    return content; // Template missing — skip silently
-  }
-  const block = fs.readFileSync(templatePath, 'utf8').trim();
-  const frontmatterEnd = content.indexOf('\n---\n');
-  if (frontmatterEnd === -1) {
-    return content; // No frontmatter — skip
-  }
-  const insertPos = frontmatterEnd + 5;
-  return content.slice(0, insertPos) + '\n' + block + '\n' + content.slice(insertPos);
-}
-
-/**
  * Append a template block to a file. Creates the file if it doesn't exist.
  * Idempotent: skips if the marker string is already present in the file.
  *
@@ -171,4 +146,4 @@ function fillBetweenMarkers(filePath, templatePath, startMarker, endMarker) {
   fs.writeFileSync(filePath, before + innerContent + after, 'utf8');
 }
 
-module.exports = { processTemplate, validateMarkers, buildContext, RUNTIMES, injectAfterFrontmatter, injectAppendToFile, fillBetweenMarkers };
+module.exports = { processTemplate, validateMarkers, buildContext, RUNTIMES, injectAppendToFile, fillBetweenMarkers };

--- a/gsd-ng/references/ask-user-question.md
+++ b/gsd-ng/references/ask-user-question.md
@@ -1,9 +1,3 @@
-<!-- ONLY:claude -->
-<first_turn_rule>
-CRITICAL: AskUserQuestion is broken on the FIRST response turn after a command loads (Claude Code issue #29530). On your first response, do NOT call {{USER_QUESTION_TOOL}} — it must wait until turn two (after a user reply creates a turn boundary) to render reliably. Other tool work (Read, Bash, Agent, etc.) IS fine on turn one, but your first response's user-visible text must be only a brief plain-text status or "Ready" acknowledgment; detailed planning or execution prose must wait until after the turn boundary. After that first exchange, {{USER_QUESTION_TOOL}} works normally.
-</first_turn_rule>
-<!-- /ONLY:claude -->
-
 <tool_usage>
 CRITICAL: Every user choice in this workflow MUST be made via the {{USER_QUESTION_TOOL}} tool. NEVER write plain-text menus, lettered option lists (a/b/c), or numbered option lists. Presenting choices in plain text bypasses the interactive UI and violates this workflow's contract.
 

--- a/gsd-ng/templates/first-turn-rule.md
+++ b/gsd-ng/templates/first-turn-rule.md
@@ -1,3 +1,0 @@
-<first_turn_rule>
-On your FIRST response after this command loads, do NOT call {{USER_QUESTION_TOOL}} — it must wait until turn two (after a user reply creates a turn boundary) to render reliably. Other tool work (Read, Bash, Agent, etc.) IS fine on turn one, but keep user-visible text to a brief plain-text status (e.g., "Loading context..."). Detailed planning or execution prose must wait until after the turn boundary. {{USER_QUESTION_TOOL}} works normally on subsequent turns.
-</first_turn_rule>


### PR DESCRIPTION
## Summary

- Removes the first-turn-rule workaround that tried to paper over Claude Code issue #29530 (AskUserQuestion broken on the first turn after a command loads). Two prior attempts to fix the wording (PR #38 plus a follow-up tightening) still produced reader-error modes where Claude deferred questions awkwardly, narrated stalls, or mis-sized first responses — the workaround itself became a source of mistakes rather than a mitigation.
- Deletes the injected template (`gsd-ng/templates/first-turn-rule.md`), its only consumer (`injectAfterFrontmatter` in `template-processor.cjs`), the injection hook in `install.js`, and the companion `<first_turn_rule>` block in `gsd-ng/references/ask-user-question.md`.
- No source command file (`gsd-ng/commands/gsd/*.md`) contains the block inline, so a clean re-install wipes it from every deployed `commands/gsd/*.md` — removal is complete end-to-end.

## Test plan

- [ ] `node gsd-ng/bin/install.js --local --runtime claude` — verify no `<first_turn_rule>` appears in any installed `.claude/commands/gsd/*.md`
- [ ] `node gsd-ng/bin/install.js --local --runtime copilot` — verify Copilot install is unaffected (it never included the block)
- [ ] Existing tests in `gsd-ng/tests/` still pass (no tests reference `injectAfterFrontmatter` or `first-turn-rule`, so green means the removal is clean)
- [ ] Invoke any slash command that calls AskUserQuestion (e.g. `/gsd:plan-phase`) — verify the command prompt is free of the `<first_turn_rule>` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)