### PR TITLE
Phase 55: Claude-only profile system and effort frontmatter injection

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -403,205 +403,205 @@ function uninstall(isGlobal) {
 
   if (isClaudeCode) {
     // 1. Remove GSD commands
-  const gsdCommandsDir = path.join(targetDir, 'commands', 'gsd');
-  if (fs.existsSync(gsdCommandsDir)) {
-    fs.rmSync(gsdCommandsDir, { recursive: true });
-    removedCount++;
-    console.log(`  ${green}✓${reset} Removed commands/gsd/`);
-  }
-
-  // 2. Remove gsd-ng directory
-  const gsdDir = path.join(targetDir, 'gsd-ng');
-  if (fs.existsSync(gsdDir)) {
-    fs.rmSync(gsdDir, { recursive: true });
-    removedCount++;
-    console.log(`  ${green}✓${reset} Removed gsd-ng/`);
-  }
-
-  // 3. Remove GSD agents (gsd-*.md files only)
-  const agentsDir = path.join(targetDir, 'agents');
-  if (fs.existsSync(agentsDir)) {
-    const files = fs.readdirSync(agentsDir);
-    let agentCount = 0;
-    for (const file of files) {
-      if (file.startsWith('gsd-') && file.endsWith('.md')) {
-        fs.unlinkSync(path.join(agentsDir, file));
-        agentCount++;
-      }
-    }
-    if (agentCount > 0) {
+    const gsdCommandsDir = path.join(targetDir, 'commands', 'gsd');
+    if (fs.existsSync(gsdCommandsDir)) {
+      fs.rmSync(gsdCommandsDir, { recursive: true });
       removedCount++;
-      console.log(`  ${green}✓${reset} Removed ${agentCount} GSD agents`);
+      console.log(`  ${green}✓${reset} Removed commands/gsd/`);
     }
-  }
 
-  // 4. Remove GSD hooks
-  const hooksDir = path.join(targetDir, 'hooks');
-  if (fs.existsSync(hooksDir)) {
-    const gsdHooks = ['gsd-statusline.js', 'gsd-check-update.js', 'gsd-check-update.sh', 'gsd-context-monitor.js', 'gsd-sandbox-detect.js', 'gsd-guardrail.js'];
-    let hookCount = 0;
-    for (const hook of gsdHooks) {
-      const hookPath = path.join(hooksDir, hook);
-      if (fs.existsSync(hookPath)) {
-        fs.unlinkSync(hookPath);
-        hookCount++;
-      }
-    }
-    if (hookCount > 0) {
+    // 2. Remove gsd-ng directory
+    const gsdDir = path.join(targetDir, 'gsd-ng');
+    if (fs.existsSync(gsdDir)) {
+      fs.rmSync(gsdDir, { recursive: true });
       removedCount++;
-      console.log(`  ${green}✓${reset} Removed ${hookCount} GSD hooks`);
-    }
-  }
-
-  // 5. Remove GSD package.json (CommonJS mode marker)
-  const pkgJsonPath = path.join(targetDir, 'package.json');
-  if (fs.existsSync(pkgJsonPath)) {
-    try {
-      const content = fs.readFileSync(pkgJsonPath, 'utf8').trim();
-      // Only remove if it's our minimal CommonJS marker
-      if (content === '{"type":"commonjs"}') {
-        fs.unlinkSync(pkgJsonPath);
-        removedCount++;
-        console.log(`  ${green}✓${reset} Removed GSD package.json`);
-      }
-    } catch (e) {
-      // Ignore read errors
-    }
-  }
-
-  // 6. Clean up settings.json (remove GSD hooks and statusline)
-  const settingsPath = path.join(targetDir, 'settings.json');
-  if (fs.existsSync(settingsPath)) {
-    let settings = readSettings(settingsPath);
-    let settingsModified = false;
-
-    // Remove GSD statusline if it references our hook
-    if (settings.statusLine && settings.statusLine.command &&
-        settings.statusLine.command.includes('gsd-statusline')) {
-      delete settings.statusLine;
-      settingsModified = true;
-      console.log(`  ${green}✓${reset} Removed GSD statusline from settings`);
+      console.log(`  ${green}✓${reset} Removed gsd-ng/`);
     }
 
-    // Remove GSD hooks from SessionStart
-    if (settings.hooks && settings.hooks.SessionStart) {
-      const before = settings.hooks.SessionStart.length;
-      settings.hooks.SessionStart = settings.hooks.SessionStart.filter(entry => {
-        if (entry.hooks && Array.isArray(entry.hooks)) {
-          // Filter out GSD hooks
-          const hasGsdHook = entry.hooks.some(h =>
-            h.command && (h.command.includes('gsd-check-update') || h.command.includes('gsd-statusline'))
-          );
-          return !hasGsdHook;
+    // 3. Remove GSD agents (gsd-*.md files only)
+    const agentsDir = path.join(targetDir, 'agents');
+    if (fs.existsSync(agentsDir)) {
+      const files = fs.readdirSync(agentsDir);
+      let agentCount = 0;
+      for (const file of files) {
+        if (file.startsWith('gsd-') && file.endsWith('.md')) {
+          fs.unlinkSync(path.join(agentsDir, file));
+          agentCount++;
         }
-        return true;
-      });
-      if (settings.hooks.SessionStart.length < before) {
-        settingsModified = true;
-        console.log(`  ${green}✓${reset} Removed GSD hooks from settings`);
       }
-      // Clean up empty array
-      if (settings.hooks.SessionStart.length === 0) {
-        delete settings.hooks.SessionStart;
+      if (agentCount > 0) {
+        removedCount++;
+        console.log(`  ${green}✓${reset} Removed ${agentCount} GSD agents`);
       }
     }
 
-    // Remove GSD hooks from PostToolUse
-    for (const eventName of ['PostToolUse']) {
-      if (settings.hooks && settings.hooks[eventName]) {
-        const before = settings.hooks[eventName].length;
-        settings.hooks[eventName] = settings.hooks[eventName].filter(entry => {
+    // 4. Remove GSD hooks
+    const hooksDir = path.join(targetDir, 'hooks');
+    if (fs.existsSync(hooksDir)) {
+      const gsdHooks = ['gsd-statusline.js', 'gsd-check-update.js', 'gsd-check-update.sh', 'gsd-context-monitor.js', 'gsd-sandbox-detect.js', 'gsd-guardrail.js'];
+      let hookCount = 0;
+      for (const hook of gsdHooks) {
+        const hookPath = path.join(hooksDir, hook);
+        if (fs.existsSync(hookPath)) {
+          fs.unlinkSync(hookPath);
+          hookCount++;
+        }
+      }
+      if (hookCount > 0) {
+        removedCount++;
+        console.log(`  ${green}✓${reset} Removed ${hookCount} GSD hooks`);
+      }
+    }
+
+    // 5. Remove GSD package.json (CommonJS mode marker)
+    const pkgJsonPath = path.join(targetDir, 'package.json');
+    if (fs.existsSync(pkgJsonPath)) {
+      try {
+        const content = fs.readFileSync(pkgJsonPath, 'utf8').trim();
+        // Only remove if it's our minimal CommonJS marker
+        if (content === '{"type":"commonjs"}') {
+          fs.unlinkSync(pkgJsonPath);
+          removedCount++;
+          console.log(`  ${green}✓${reset} Removed GSD package.json`);
+        }
+      } catch (e) {
+        // Ignore read errors
+      }
+    }
+
+    // 6. Clean up settings.json (remove GSD hooks and statusline)
+    const settingsPath = path.join(targetDir, 'settings.json');
+    if (fs.existsSync(settingsPath)) {
+      let settings = readSettings(settingsPath);
+      let settingsModified = false;
+
+      // Remove GSD statusline if it references our hook
+      if (settings.statusLine && settings.statusLine.command &&
+          settings.statusLine.command.includes('gsd-statusline')) {
+        delete settings.statusLine;
+        settingsModified = true;
+        console.log(`  ${green}✓${reset} Removed GSD statusline from settings`);
+      }
+
+      // Remove GSD hooks from SessionStart
+      if (settings.hooks && settings.hooks.SessionStart) {
+        const before = settings.hooks.SessionStart.length;
+        settings.hooks.SessionStart = settings.hooks.SessionStart.filter(entry => {
           if (entry.hooks && Array.isArray(entry.hooks)) {
+            // Filter out GSD hooks
             const hasGsdHook = entry.hooks.some(h =>
-              h.command && h.command.includes('gsd-context-monitor')
+              h.command && (h.command.includes('gsd-check-update') || h.command.includes('gsd-statusline'))
             );
             return !hasGsdHook;
           }
           return true;
         });
-        if (settings.hooks[eventName].length < before) {
+        if (settings.hooks.SessionStart.length < before) {
           settingsModified = true;
-          console.log(`  ${green}✓${reset} Removed context monitor hook from settings`);
+          console.log(`  ${green}✓${reset} Removed GSD hooks from settings`);
         }
-        if (settings.hooks[eventName].length === 0) {
-          delete settings.hooks[eventName];
+        // Clean up empty array
+        if (settings.hooks.SessionStart.length === 0) {
+          delete settings.hooks.SessionStart;
         }
       }
-    }
 
-    // Remove GSD hooks from PreToolUse (gsd-sandbox-detect.js, gsd-guardrail.js)
-    if (settings.hooks && settings.hooks.PreToolUse) {
-      const before = settings.hooks.PreToolUse.length;
-      settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(entry => {
-        if (entry.hooks && Array.isArray(entry.hooks)) {
-          const hasGsdHook = entry.hooks.some(h =>
-            h.command && (h.command.includes('gsd-sandbox-detect') || h.command.includes('gsd-guardrail'))
-          );
-          return !hasGsdHook;
-        }
-        return true;
-      });
-      if (settings.hooks.PreToolUse.length < before) {
-        settingsModified = true;
-        console.log(`  ${green}✓${reset} Removed GSD PreToolUse hooks from settings`);
-      }
-      if (settings.hooks.PreToolUse.length === 0) {
-        delete settings.hooks.PreToolUse;
-      }
-    }
-
-    // Remove GSD-seeded permissions.allow entries
-    if (settings.permissions && Array.isArray(settings.permissions.allow)) {
-      const sandboxTemplatePath = path.join(__dirname, '..', 'gsd-ng', 'templates', 'settings-sandbox.json');
-      try {
-        let templateEntries = [];
-        if (fs.existsSync(sandboxTemplatePath)) {
-          const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
-          templateEntries = sandboxTemplate.permissions?.allow ?? [];
-        }
-
-        // Also compute dynamic platform CLI entries for removal
-        const platformCLIs = ['gh', 'glab', 'fj', 'tea'];
-        const dynamicEntries = [];
-        for (const cli of platformCLIs) {
-          try {
-            execSync(`which ${cli}`, { stdio: 'ignore', timeout: 2000 });
-            dynamicEntries.push(...getPlatformCliPatterns(cli));
-          } catch {
-            // CLI not installed — skip
+      // Remove GSD hooks from PostToolUse
+      for (const eventName of ['PostToolUse']) {
+        if (settings.hooks && settings.hooks[eventName]) {
+          const before = settings.hooks[eventName].length;
+          settings.hooks[eventName] = settings.hooks[eventName].filter(entry => {
+            if (entry.hooks && Array.isArray(entry.hooks)) {
+              const hasGsdHook = entry.hooks.some(h =>
+                h.command && h.command.includes('gsd-context-monitor')
+              );
+              return !hasGsdHook;
+            }
+            return true;
+          });
+          if (settings.hooks[eventName].length < before) {
+            settingsModified = true;
+            console.log(`  ${green}✓${reset} Removed context monitor hook from settings`);
+          }
+          if (settings.hooks[eventName].length === 0) {
+            delete settings.hooks[eventName];
           }
         }
-        const removalSet = new Set([...templateEntries, ...dynamicEntries]);
-        const before = settings.permissions.allow.length;
-        settings.permissions.allow = settings.permissions.allow.filter(e => !removalSet.has(e));
+      }
 
-        if (settings.permissions.allow.length < before) {
+      // Remove GSD hooks from PreToolUse (gsd-sandbox-detect.js, gsd-guardrail.js)
+      if (settings.hooks && settings.hooks.PreToolUse) {
+        const before = settings.hooks.PreToolUse.length;
+        settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(entry => {
+          if (entry.hooks && Array.isArray(entry.hooks)) {
+            const hasGsdHook = entry.hooks.some(h =>
+              h.command && (h.command.includes('gsd-sandbox-detect') || h.command.includes('gsd-guardrail'))
+            );
+            return !hasGsdHook;
+          }
+          return true;
+        });
+        if (settings.hooks.PreToolUse.length < before) {
           settingsModified = true;
-          console.log(`  ${green}✓${reset} Removed GSD permissions from settings`);
+          console.log(`  ${green}✓${reset} Removed GSD PreToolUse hooks from settings`);
         }
+        if (settings.hooks.PreToolUse.length === 0) {
+          delete settings.hooks.PreToolUse;
+        }
+      }
 
-        // Clean up empty structures
-        if (settings.permissions.allow.length === 0) {
-          delete settings.permissions.allow;
+      // Remove GSD-seeded permissions.allow entries
+      if (settings.permissions && Array.isArray(settings.permissions.allow)) {
+        const sandboxTemplatePath = path.join(__dirname, '..', 'gsd-ng', 'templates', 'settings-sandbox.json');
+        try {
+          let templateEntries = [];
+          if (fs.existsSync(sandboxTemplatePath)) {
+            const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
+            templateEntries = sandboxTemplate.permissions?.allow ?? [];
+          }
+
+          // Also compute dynamic platform CLI entries for removal
+          const platformCLIs = ['gh', 'glab', 'fj', 'tea'];
+          const dynamicEntries = [];
+          for (const cli of platformCLIs) {
+            try {
+              execSync(`which ${cli}`, { stdio: 'ignore', timeout: 2000 });
+              dynamicEntries.push(...getPlatformCliPatterns(cli));
+            } catch {
+              // CLI not installed — skip
+            }
+          }
+          const removalSet = new Set([...templateEntries, ...dynamicEntries]);
+          const before = settings.permissions.allow.length;
+          settings.permissions.allow = settings.permissions.allow.filter(e => !removalSet.has(e));
+
+          if (settings.permissions.allow.length < before) {
+            settingsModified = true;
+            console.log(`  ${green}✓${reset} Removed GSD permissions from settings`);
+          }
+
+          // Clean up empty structures
+          if (settings.permissions.allow.length === 0) {
+            delete settings.permissions.allow;
+          }
+          if (settings.permissions && Object.keys(settings.permissions).length === 0) {
+            delete settings.permissions;
+          }
+        } catch {
+          // Template missing or unreadable — skip
         }
-        if (settings.permissions && Object.keys(settings.permissions).length === 0) {
-          delete settings.permissions;
-        }
-      } catch {
-        // Template missing or unreadable — skip
+      }
+
+      // Clean up empty hooks object
+      if (settings.hooks && Object.keys(settings.hooks).length === 0) {
+        delete settings.hooks;
+      }
+
+      if (settingsModified) {
+        writeSettings(settingsPath, settings);
+        removedCount++;
       }
     }
-
-    // Clean up empty hooks object
-    if (settings.hooks && Object.keys(settings.hooks).length === 0) {
-      delete settings.hooks;
-    }
-
-    if (settingsModified) {
-      writeSettings(settingsPath, settings);
-      removedCount++;
-    }
-  }
 
     if (removedCount === 0) {
       console.log(`  ${yellow}⚠${reset} No GSD files found to remove.`);
@@ -1122,436 +1122,436 @@ function install(isGlobal) {
 
   if (isClaudeCode) {
     // Save any locally modified GSD files before they get wiped
-  saveLocalPatches(targetDir);
+    saveLocalPatches(targetDir);
 
-  // Claude Code: nested structure in commands/ directory
-  const commandsDir = path.join(targetDir, 'commands');
-  fs.mkdirSync(commandsDir, { recursive: true });
+    // Claude Code: nested structure in commands/ directory
+    const commandsDir = path.join(targetDir, 'commands');
+    fs.mkdirSync(commandsDir, { recursive: true });
 
-  const gsdSrc = path.join(src, 'commands', 'gsd');
-  const gsdDest = path.join(commandsDir, 'gsd');
-  copyWithPathReplacement(gsdSrc, gsdDest, pathPrefix, true);
-  if (verifyInstalled(gsdDest, 'commands/gsd')) {
-    console.log(`  ${green}✓${reset} Installed commands/gsd`);
-  } else {
-    failures.push('commands/gsd');
-  }
-
-  // Copy gsd-ng skill with path replacement
-  const skillSrc = path.join(src, 'gsd-ng');
-  const skillDest = path.join(targetDir, 'gsd-ng');
-  copyWithPathReplacement(skillSrc, skillDest, pathPrefix);
-  if (verifyInstalled(skillDest, 'gsd-ng')) {
-    console.log(`  ${green}✓${reset} Installed gsd-ng`);
-  } else {
-    failures.push('gsd-ng');
-  }
-
-  // Copy agents to agents directory
-  const agentsSrc = path.join(src, 'agents');
-  if (fs.existsSync(agentsSrc)) {
-    const agentsDest = path.join(targetDir, 'agents');
-    fs.mkdirSync(agentsDest, { recursive: true });
-
-    // Remove old GSD agents (gsd-*.md) before copying new ones
-    if (fs.existsSync(agentsDest)) {
-      for (const file of fs.readdirSync(agentsDest)) {
-        if (file.startsWith('gsd-') && file.endsWith('.md')) {
-          fs.unlinkSync(path.join(agentsDest, file));
-        }
-      }
-    }
-
-    // Copy new agents
-    const agentEntries = fs.readdirSync(agentsSrc, { withFileTypes: true });
-    for (const entry of agentEntries) {
-      if (entry.isFile() && entry.name.endsWith('.md')) {
-        let content = fs.readFileSync(path.join(agentsSrc, entry.name), 'utf8');
-        // Replace ~/.claude/ and $HOME/.claude/ as they are the source of truth in the repo
-        const dirRegex = /~\/\.claude\//g;
-        const homeDirRegex = /\$HOME\/\.claude\//g;
-        content = content.replace(dirRegex, toHomePrefix(pathPrefix));
-        content = content.replace(homeDirRegex, toHomePrefix(pathPrefix));
-        content = processAttribution(content, getCommitAttribution());
-        fs.writeFileSync(path.join(agentsDest, entry.name), content);
-      }
-    }
-    if (verifyInstalled(agentsDest, 'agents')) {
-      console.log(`  ${green}✓${reset} Installed agents`);
+    const gsdSrc = path.join(src, 'commands', 'gsd');
+    const gsdDest = path.join(commandsDir, 'gsd');
+    copyWithPathReplacement(gsdSrc, gsdDest, pathPrefix, true);
+    if (verifyInstalled(gsdDest, 'commands/gsd')) {
+      console.log(`  ${green}✓${reset} Installed commands/gsd`);
     } else {
-      failures.push('agents');
+      failures.push('commands/gsd');
     }
-  }
 
-  // Sync effort: frontmatter into deployed agent files (Claude-only, post-copy).
-  // Must run BEFORE writeManifest so manifest hashes the post-sync content.
-  // Note: this code path now lives inside Plan 03's outer `if (isClaudeCode) { ... }`
-  // wrapper, so the explicit isClaudeCode check below is technically redundant —
-  // keep it as a defensive guard that documents intent and survives future refactors.
-  if (isClaudeCode && fs.existsSync(path.join(targetDir, 'agents'))) {
-    const effortAgentsDir = path.join(targetDir, 'agents');
-    const syncResult = syncAgentEffortFrontmatter(process.cwd(), effortAgentsDir);
-    if (syncResult.changes && syncResult.changes.length > 0) {
-      console.log(`  ${green}✓${reset} Synced effort frontmatter (${syncResult.changes.length} agent${syncResult.changes.length === 1 ? '' : 's'} changed)`);
-      // CONTEXT.md Area 4 lock: restart notice on real changes at ALL three touchpoints
-      // (install, set-profile, config-set effort_overrides). Use stderr to match Plans 05/06
-      // emission style — keeps stdout / JSON-mode payloads clean and gives all three call
-      // sites one voice.
-      const restartNotice = formatRestartNotice(syncResult.changes);
-      if (restartNotice) {
-        process.stderr.write(restartNotice + '\n');
-      }
-    }
-  }
-
-  // Copy CHANGELOG.md
-  const changelogSrc = path.join(src, 'CHANGELOG.md');
-  const changelogDest = path.join(targetDir, 'gsd-ng', 'CHANGELOG.md');
-  if (fs.existsSync(changelogSrc)) {
-    fs.copyFileSync(changelogSrc, changelogDest);
-    if (verifyFileInstalled(changelogDest, 'CHANGELOG.md')) {
-      console.log(`  ${green}✓${reset} Installed CHANGELOG.md`);
+    // Copy gsd-ng skill with path replacement
+    const skillSrc = path.join(src, 'gsd-ng');
+    const skillDest = path.join(targetDir, 'gsd-ng');
+    copyWithPathReplacement(skillSrc, skillDest, pathPrefix);
+    if (verifyInstalled(skillDest, 'gsd-ng')) {
+      console.log(`  ${green}✓${reset} Installed gsd-ng`);
     } else {
-      failures.push('CHANGELOG.md');
+      failures.push('gsd-ng');
     }
-  }
 
-  // Write VERSION file (with +hash for snapshot/develop installs)
-  const versionDest = path.join(targetDir, 'gsd-ng', 'VERSION');
-  fs.writeFileSync(versionDest, INSTALLED_VERSION);
-  if (verifyFileInstalled(versionDest, 'VERSION')) {
-    console.log(`  ${green}✓${reset} Wrote VERSION (${INSTALLED_VERSION})`);
-  } else {
-    failures.push('VERSION');
-  }
+    // Copy agents to agents directory
+    const agentsSrc = path.join(src, 'agents');
+    if (fs.existsSync(agentsSrc)) {
+      const agentsDest = path.join(targetDir, 'agents');
+      fs.mkdirSync(agentsDest, { recursive: true });
 
-  // Write package.json to force CommonJS mode for GSD scripts
-  // Prevents "require is not defined" errors when project has "type": "module"
-  // Node.js walks up looking for package.json - this stops inheritance from project
-  const pkgJsonDest = path.join(targetDir, 'package.json');
-  fs.writeFileSync(pkgJsonDest, '{"type":"commonjs"}\n');
-  console.log(`  ${green}✓${reset} Wrote package.json (CommonJS mode)`);
-
-  // Copy hooks from dist/ (bundled with dependencies) and .cjs files directly from hooks/
-  // Template paths for the target runtime (replaces '.claude' with correct config dir)
-  const hooksSrc = path.join(src, 'hooks', 'dist');
-  const hooksCjsSrc = path.join(src, 'hooks');
-  if (fs.existsSync(hooksSrc) || fs.existsSync(hooksCjsSrc)) {
-    const hooksDest = path.join(targetDir, 'hooks');
-    fs.mkdirSync(hooksDest, { recursive: true });
-    const configDirReplacement = getConfigDirFromHome(runtime, isGlobal);
-
-    // Copy bundled .js hooks from dist/ (with config dir templating)
-    if (fs.existsSync(hooksSrc)) {
-      const hookEntries = fs.readdirSync(hooksSrc);
-      for (const entry of hookEntries) {
-        const srcFile = path.join(hooksSrc, entry);
-        if (fs.statSync(srcFile).isFile()) {
-          const destFile = path.join(hooksDest, entry);
-          // Template .js files to replace '.claude' with runtime-specific config dir
-          if (entry.endsWith('.js')) {
-            let content = fs.readFileSync(srcFile, 'utf8');
-            content = content.replace(/'\.claude'/g, configDirReplacement);
-            fs.writeFileSync(destFile, content);
-          } else {
-            fs.copyFileSync(srcFile, destFile);
+      // Remove old GSD agents (gsd-*.md) before copying new ones
+      if (fs.existsSync(agentsDest)) {
+        for (const file of fs.readdirSync(agentsDest)) {
+          if (file.startsWith('gsd-') && file.endsWith('.md')) {
+            fs.unlinkSync(path.join(agentsDest, file));
           }
         }
       }
+
+      // Copy new agents
+      const agentEntries = fs.readdirSync(agentsSrc, { withFileTypes: true });
+      for (const entry of agentEntries) {
+        if (entry.isFile() && entry.name.endsWith('.md')) {
+          let content = fs.readFileSync(path.join(agentsSrc, entry.name), 'utf8');
+          // Replace ~/.claude/ and $HOME/.claude/ as they are the source of truth in the repo
+          const dirRegex = /~\/\.claude\//g;
+          const homeDirRegex = /\$HOME\/\.claude\//g;
+          content = content.replace(dirRegex, toHomePrefix(pathPrefix));
+          content = content.replace(homeDirRegex, toHomePrefix(pathPrefix));
+          content = processAttribution(content, getCommitAttribution());
+          fs.writeFileSync(path.join(agentsDest, entry.name), content);
+        }
+      }
+      if (verifyInstalled(agentsDest, 'agents')) {
+        console.log(`  ${green}✓${reset} Installed agents`);
+      } else {
+        failures.push('agents');
+      }
     }
 
-    // Copy .cjs hooks directly from hooks/ (no bundling needed — no external dependencies)
-    if (fs.existsSync(hooksCjsSrc)) {
-      const cjsEntries = fs.readdirSync(hooksCjsSrc);
-      for (const entry of cjsEntries) {
-        if (entry.endsWith('.cjs')) {
-          const srcFile = path.join(hooksCjsSrc, entry);
+    // Sync effort: frontmatter into deployed agent files (Claude-only, post-copy).
+    // Must run BEFORE writeManifest so manifest hashes the post-sync content.
+    // Note: this code path now lives inside Plan 03's outer `if (isClaudeCode) { ... }`
+    // wrapper, so the explicit isClaudeCode check below is technically redundant —
+    // keep it as a defensive guard that documents intent and survives future refactors.
+    if (isClaudeCode && fs.existsSync(path.join(targetDir, 'agents'))) {
+      const effortAgentsDir = path.join(targetDir, 'agents');
+      const syncResult = syncAgentEffortFrontmatter(process.cwd(), effortAgentsDir);
+      if (syncResult.changes && syncResult.changes.length > 0) {
+        console.log(`  ${green}✓${reset} Synced effort frontmatter (${syncResult.changes.length} agent${syncResult.changes.length === 1 ? '' : 's'} changed)`);
+        // CONTEXT.md Area 4 lock: restart notice on real changes at ALL three touchpoints
+        // (install, set-profile, config-set effort_overrides). Use stderr to match Plans 05/06
+        // emission style — keeps stdout / JSON-mode payloads clean and gives all three call
+        // sites one voice.
+        const restartNotice = formatRestartNotice(syncResult.changes);
+        if (restartNotice) {
+          process.stderr.write(restartNotice + '\n');
+        }
+      }
+    }
+
+    // Copy CHANGELOG.md
+    const changelogSrc = path.join(src, 'CHANGELOG.md');
+    const changelogDest = path.join(targetDir, 'gsd-ng', 'CHANGELOG.md');
+    if (fs.existsSync(changelogSrc)) {
+      fs.copyFileSync(changelogSrc, changelogDest);
+      if (verifyFileInstalled(changelogDest, 'CHANGELOG.md')) {
+        console.log(`  ${green}✓${reset} Installed CHANGELOG.md`);
+      } else {
+        failures.push('CHANGELOG.md');
+      }
+    }
+
+    // Write VERSION file (with +hash for snapshot/develop installs)
+    const versionDest = path.join(targetDir, 'gsd-ng', 'VERSION');
+    fs.writeFileSync(versionDest, INSTALLED_VERSION);
+    if (verifyFileInstalled(versionDest, 'VERSION')) {
+      console.log(`  ${green}✓${reset} Wrote VERSION (${INSTALLED_VERSION})`);
+    } else {
+      failures.push('VERSION');
+    }
+
+    // Write package.json to force CommonJS mode for GSD scripts
+    // Prevents "require is not defined" errors when project has "type": "module"
+    // Node.js walks up looking for package.json - this stops inheritance from project
+    const pkgJsonDest = path.join(targetDir, 'package.json');
+    fs.writeFileSync(pkgJsonDest, '{"type":"commonjs"}\n');
+    console.log(`  ${green}✓${reset} Wrote package.json (CommonJS mode)`);
+
+    // Copy hooks from dist/ (bundled with dependencies) and .cjs files directly from hooks/
+    // Template paths for the target runtime (replaces '.claude' with correct config dir)
+    const hooksSrc = path.join(src, 'hooks', 'dist');
+    const hooksCjsSrc = path.join(src, 'hooks');
+    if (fs.existsSync(hooksSrc) || fs.existsSync(hooksCjsSrc)) {
+      const hooksDest = path.join(targetDir, 'hooks');
+      fs.mkdirSync(hooksDest, { recursive: true });
+      const configDirReplacement = getConfigDirFromHome(runtime, isGlobal);
+
+      // Copy bundled .js hooks from dist/ (with config dir templating)
+      if (fs.existsSync(hooksSrc)) {
+        const hookEntries = fs.readdirSync(hooksSrc);
+        for (const entry of hookEntries) {
+          const srcFile = path.join(hooksSrc, entry);
           if (fs.statSync(srcFile).isFile()) {
-            fs.copyFileSync(srcFile, path.join(hooksDest, entry));
-          }
-        }
-      }
-    }
-
-    if (verifyInstalled(hooksDest, 'hooks')) {
-      console.log(`  ${green}✓${reset} Installed hooks (bundled)`);
-    } else {
-      failures.push('hooks');
-    }
-  }
-
-  if (failures.length > 0) {
-    console.error(`\n  ${yellow}Installation incomplete!${reset} Failed: ${failures.join(', ')}`);
-    process.exit(1);
-  }
-
-  // Resolve {{variables}} and <!-- ONLY:x --> markers in Claude workflow/reference/lib/commands files.
-  // Uses template-processor.cjs (centralized template engine).
-  // Copilot path handles this separately in convertClaudeToCopilotContent().
-  // Path rewriting (e.g., ~/.claude/ -> ~/.copilot/) stays separate per design.
-  const ctx = buildContext('claude');
-  const claudeTemplateDirs = [
-    path.join(targetDir, 'gsd-ng', 'workflows'),
-    path.join(targetDir, 'gsd-ng', 'references'),
-    path.join(targetDir, 'gsd-ng', 'bin', 'lib'),
-    path.join(targetDir, 'commands', 'gsd'),
-  ];
-  for (const dir of claudeTemplateDirs) {
-    if (!fs.existsSync(dir)) continue;
-    const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') || f.endsWith('.cjs'));
-    for (const file of files) {
-      const filePath = path.join(dir, file);
-      let content = fs.readFileSync(filePath, 'utf-8');
-      if (content.includes('{{') || content.includes('<!-- ONLY:')) {
-        try {
-          content = processTemplate(content, ctx);
-          fs.writeFileSync(filePath, content, 'utf-8');
-        } catch {
-          // Skip files with unbalanced markers (e.g., documentation containing example syntax)
-        }
-      }
-    }
-  }
-
-  // Write file manifest AFTER template post-pass so hashes match resolved on-disk content.
-  // (If writeManifest ran before the loop, next install would detect phantom local modifications.)
-  writeManifest(targetDir, INSTALLED_VERSION);
-  console.log(`  ${green}✓${reset} Wrote file manifest (${MANIFEST_NAME})`);
-
-  // Report any backed-up local patches
-  reportLocalPatches(targetDir);
-
-  // Configure statusline and hooks in settings.json
-  const postToolEvent = 'PostToolUse';
-  const settingsPath = path.join(targetDir, 'settings.json');
-  const settings = readSettings(settingsPath);
-  const statuslineCommand = isGlobal
-    ? buildHookCommand(targetDir, 'gsd-statusline.js')
-    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-statusline.js';
-  const updateCheckCommand = isGlobal
-    ? buildHookCommand(targetDir, 'gsd-check-update.js')
-    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-check-update.js';
-  const contextMonitorCommand = isGlobal
-    ? buildHookCommand(targetDir, 'gsd-context-monitor.js')
-    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-context-monitor.js';
-  const sandboxDetectCommand = isGlobal
-    ? buildHookCommand(targetDir, 'gsd-sandbox-detect.js')
-    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-sandbox-detect.js';
-  const guardrailCommand = isGlobal
-    ? buildHookCommand(targetDir, 'gsd-guardrail.js')
-    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-guardrail.js';
-  const bashSafetyCommand = isGlobal
-    ? buildHookCommand(targetDir, 'bash-safety-hook.cjs')
-    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/bash-safety-hook.cjs';
-
-  // Configure hooks in settings.json
-  if (!settings.hooks) {
-    settings.hooks = {};
-  }
-
-  // Configure SessionStart hook for update checking
-  if (!settings.hooks.SessionStart) {
-    settings.hooks.SessionStart = [];
-  }
-
-  const hasGsdUpdateHook = settings.hooks.SessionStart.some(entry =>
-    entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-check-update'))
-  );
-
-  if (!hasGsdUpdateHook) {
-    settings.hooks.SessionStart.push({
-      hooks: [
-        {
-          type: 'command',
-          command: updateCheckCommand
-        }
-      ]
-    });
-    console.log(`  ${green}✓${reset} Configured update check hook`);
-  }
-
-  // Configure post-tool hook for context window monitoring
-  if (!settings.hooks[postToolEvent]) {
-    settings.hooks[postToolEvent] = [];
-  }
-
-  const hasContextMonitorHook = settings.hooks[postToolEvent].some(entry =>
-    entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))
-  );
-
-  if (!hasContextMonitorHook) {
-    settings.hooks[postToolEvent].push({
-      matcher: 'Bash|Edit|Write|MultiEdit|Agent|Task',
-      hooks: [
-        {
-          type: 'command',
-          command: contextMonitorCommand,
-          timeout: 10
-        }
-      ]
-    });
-    console.log(`  ${green}✓${reset} Configured context window monitor hook`);
-  } else {
-    // Migration: add matcher/timeout to existing context monitor hooks without them
-    for (const entry of settings.hooks[postToolEvent]) {
-      if (entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))) {
-        if (!entry.matcher) {
-          entry.matcher = 'Bash|Edit|Write|MultiEdit|Agent|Task';
-        }
-        for (const h of entry.hooks) {
-          if (h.command && h.command.includes('gsd-context-monitor') && !h.timeout) {
-            h.timeout = 10;
-          }
-        }
-      }
-    }
-  }
-
-  // Configure PreToolUse hook for sandbox detection
-  if (!settings.hooks.PreToolUse) {
-    settings.hooks.PreToolUse = [];
-  }
-
-  const hasGsdSandboxDetectHook = settings.hooks.PreToolUse.some(entry =>
-    entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-sandbox-detect'))
-  );
-
-  if (!hasGsdSandboxDetectHook) {
-    settings.hooks.PreToolUse.push({
-      hooks: [
-        {
-          type: 'command',
-          command: sandboxDetectCommand
-        }
-      ]
-    });
-    console.log(`  ${green}✓${reset} Configured sandbox detection hook`);
-  }
-
-  // Configure PreToolUse hook for workflow guardrail
-  const hasGsdGuardrailHook = settings.hooks.PreToolUse.some(entry =>
-    entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-guardrail'))
-  );
-
-  if (!hasGsdGuardrailHook) {
-    settings.hooks.PreToolUse.push({
-      matcher: 'Edit|Write|EnterPlanMode',
-      hooks: [
-        {
-          type: 'command',
-          command: guardrailCommand,
-        }
-      ]
-    });
-    console.log(`  ${green}✓${reset} Configured workflow guardrail hook`);
-  }
-
-  // Configure PreToolUse hook for bash command safety (compound command allowlist).
-  // Replaces AST safety rules — transparent hook instead of model instructions.
-  // See: https://github.com/anthropics/claude-code/issues/30435
-  // Append at END of PreToolUse array — user's custom hooks run first.
-  const hasGsdBashSafetyHook = settings.hooks.PreToolUse.some(entry =>
-    entry.hooks && entry.hooks.some(h => h.command && h.command.includes('bash-safety-hook.cjs'))
-  );
-
-  if (!hasGsdBashSafetyHook) {
-    settings.hooks.PreToolUse.push({
-      matcher: 'Bash',
-      hooks: [
-        {
-          type: 'command',
-          command: bashSafetyCommand
-        }
-      ]
-    });
-    console.log(`  ${green}✓${reset} Configured bash command safety hook`);
-  }
-
-  // Seed permissions.allow from settings-sandbox.json template
-  if (!noSeedPermissionsConfig) {
-    const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
-    try {
-      const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
-      const templateEntries = sandboxTemplate.permissions?.allow ?? [];
-
-      // Detect platform CLIs dynamically
-      const platformCLIs = ['gh', 'glab', 'fj', 'tea'];
-      const dynamicEntries = [];
-      for (const cli of platformCLIs) {
-        try {
-          execSync(`which ${cli}`, { stdio: 'ignore', timeout: 2000 });
-          dynamicEntries.push(...getPlatformCliPatterns(cli));
-        } catch {
-          // CLI not installed — skip
-        }
-      }
-
-      // Also check .planning/config.json for configured platform
-      const configPath = path.join(process.cwd(), '.planning', 'config.json');
-      try {
-        if (fs.existsSync(configPath)) {
-          const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-          const platform = config.git?.platform;
-          if (platform && PLATFORM_TO_CLI[platform]) {
-            const cliPatterns = getPlatformCliPatterns(PLATFORM_TO_CLI[platform]);
-            for (const entry of cliPatterns) {
-              if (!dynamicEntries.includes(entry)) dynamicEntries.push(entry);
+            const destFile = path.join(hooksDest, entry);
+            // Template .js files to replace '.claude' with runtime-specific config dir
+            if (entry.endsWith('.js')) {
+              let content = fs.readFileSync(srcFile, 'utf8');
+              content = content.replace(/'\.claude'/g, configDirReplacement);
+              fs.writeFileSync(destFile, content);
+            } else {
+              fs.copyFileSync(srcFile, destFile);
             }
           }
         }
-      } catch {
-        // config.json missing or unparseable — skip
       }
 
-      // Non-destructive merge: add missing entries, keep existing
-      const allNewEntries = [...templateEntries, ...dynamicEntries];
-      const existingAllow = settings.permissions?.allow ?? [];
-      const entriesToAdd = allNewEntries.filter(e => !existingAllow.includes(e));
+      // Copy .cjs hooks directly from hooks/ (no bundling needed — no external dependencies)
+      if (fs.existsSync(hooksCjsSrc)) {
+        const cjsEntries = fs.readdirSync(hooksCjsSrc);
+        for (const entry of cjsEntries) {
+          if (entry.endsWith('.cjs')) {
+            const srcFile = path.join(hooksCjsSrc, entry);
+            if (fs.statSync(srcFile).isFile()) {
+              fs.copyFileSync(srcFile, path.join(hooksDest, entry));
+            }
+          }
+        }
+      }
 
-      if (entriesToAdd.length > 0) {
-        if (!settings.permissions) settings.permissions = {};
-        if (!settings.permissions.allow) settings.permissions.allow = [];
-        settings.permissions.allow.push(...entriesToAdd);
-        console.log(`  ${green}✓${reset} Seeded ${entriesToAdd.length} permissions`);
+      if (verifyInstalled(hooksDest, 'hooks')) {
+        console.log(`  ${green}✓${reset} Installed hooks (bundled)`);
       } else {
-        console.log(`  ${green}✓${reset} Permissions already up to date`);
+        failures.push('hooks');
       }
-    } catch {
-      // Template missing or unreadable — skip silently
     }
-  }
 
-  // Seed sandbox settings by default (opt-out via --no-seed-sandbox-config)
-  if (!noSeedSandboxConfig) {
-    const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
-    try {
-      const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
-      let sandboxSeeded = false;
-
-      if (sandboxTemplate.sandbox) {
-        if (!settings.sandbox) settings.sandbox = {};
-        if (settings.sandbox.enabled === undefined && sandboxTemplate.sandbox.enabled !== undefined) {
-          settings.sandbox.enabled = sandboxTemplate.sandbox.enabled;
-          sandboxSeeded = true;
-        }
-        if (settings.sandbox.autoAllowBashIfSandboxed === undefined && sandboxTemplate.sandbox.autoAllowBashIfSandboxed !== undefined) {
-          settings.sandbox.autoAllowBashIfSandboxed = sandboxTemplate.sandbox.autoAllowBashIfSandboxed;
-          sandboxSeeded = true;
-        }
-      }
-
-      if (sandboxSeeded) {
-        console.log(`  ${green}✓${reset} Enabled sandbox mode`);
-      }
-    } catch {
-      // Template missing or unreadable — skip
+    if (failures.length > 0) {
+      console.error(`\n  ${yellow}Installation incomplete!${reset} Failed: ${failures.join(', ')}`);
+      process.exit(1);
     }
-  }
 
-  // Persist runtime to .planning/config.json for effort-gating
-  writeRuntimeToConfig(runtime);
+    // Resolve {{variables}} and <!-- ONLY:x --> markers in Claude workflow/reference/lib/commands files.
+    // Uses template-processor.cjs (centralized template engine).
+    // Copilot path handles this separately in convertClaudeToCopilotContent().
+    // Path rewriting (e.g., ~/.claude/ -> ~/.copilot/) stays separate per design.
+    const ctx = buildContext('claude');
+    const claudeTemplateDirs = [
+      path.join(targetDir, 'gsd-ng', 'workflows'),
+      path.join(targetDir, 'gsd-ng', 'references'),
+      path.join(targetDir, 'gsd-ng', 'bin', 'lib'),
+      path.join(targetDir, 'commands', 'gsd'),
+    ];
+    for (const dir of claudeTemplateDirs) {
+      if (!fs.existsSync(dir)) continue;
+      const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') || f.endsWith('.cjs'));
+      for (const file of files) {
+        const filePath = path.join(dir, file);
+        let content = fs.readFileSync(filePath, 'utf-8');
+        if (content.includes('{{') || content.includes('<!-- ONLY:')) {
+          try {
+            content = processTemplate(content, ctx);
+            fs.writeFileSync(filePath, content, 'utf-8');
+          } catch {
+            // Skip files with unbalanced markers (e.g., documentation containing example syntax)
+          }
+        }
+      }
+    }
 
-  return { settingsPath, settings, statuslineCommand };
+    // Write file manifest AFTER template post-pass so hashes match resolved on-disk content.
+    // (If writeManifest ran before the loop, next install would detect phantom local modifications.)
+    writeManifest(targetDir, INSTALLED_VERSION);
+    console.log(`  ${green}✓${reset} Wrote file manifest (${MANIFEST_NAME})`);
+
+    // Report any backed-up local patches
+    reportLocalPatches(targetDir);
+
+    // Configure statusline and hooks in settings.json
+    const postToolEvent = 'PostToolUse';
+    const settingsPath = path.join(targetDir, 'settings.json');
+    const settings = readSettings(settingsPath);
+    const statuslineCommand = isGlobal
+      ? buildHookCommand(targetDir, 'gsd-statusline.js')
+      : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-statusline.js';
+    const updateCheckCommand = isGlobal
+      ? buildHookCommand(targetDir, 'gsd-check-update.js')
+      : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-check-update.js';
+    const contextMonitorCommand = isGlobal
+      ? buildHookCommand(targetDir, 'gsd-context-monitor.js')
+      : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-context-monitor.js';
+    const sandboxDetectCommand = isGlobal
+      ? buildHookCommand(targetDir, 'gsd-sandbox-detect.js')
+      : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-sandbox-detect.js';
+    const guardrailCommand = isGlobal
+      ? buildHookCommand(targetDir, 'gsd-guardrail.js')
+      : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-guardrail.js';
+    const bashSafetyCommand = isGlobal
+      ? buildHookCommand(targetDir, 'bash-safety-hook.cjs')
+      : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/bash-safety-hook.cjs';
+
+    // Configure hooks in settings.json
+    if (!settings.hooks) {
+      settings.hooks = {};
+    }
+
+    // Configure SessionStart hook for update checking
+    if (!settings.hooks.SessionStart) {
+      settings.hooks.SessionStart = [];
+    }
+
+    const hasGsdUpdateHook = settings.hooks.SessionStart.some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-check-update'))
+    );
+
+    if (!hasGsdUpdateHook) {
+      settings.hooks.SessionStart.push({
+        hooks: [
+          {
+            type: 'command',
+            command: updateCheckCommand
+          }
+        ]
+      });
+      console.log(`  ${green}✓${reset} Configured update check hook`);
+    }
+
+    // Configure post-tool hook for context window monitoring
+    if (!settings.hooks[postToolEvent]) {
+      settings.hooks[postToolEvent] = [];
+    }
+
+    const hasContextMonitorHook = settings.hooks[postToolEvent].some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))
+    );
+
+    if (!hasContextMonitorHook) {
+      settings.hooks[postToolEvent].push({
+        matcher: 'Bash|Edit|Write|MultiEdit|Agent|Task',
+        hooks: [
+          {
+            type: 'command',
+            command: contextMonitorCommand,
+            timeout: 10
+          }
+        ]
+      });
+      console.log(`  ${green}✓${reset} Configured context window monitor hook`);
+    } else {
+      // Migration: add matcher/timeout to existing context monitor hooks without them
+      for (const entry of settings.hooks[postToolEvent]) {
+        if (entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))) {
+          if (!entry.matcher) {
+            entry.matcher = 'Bash|Edit|Write|MultiEdit|Agent|Task';
+          }
+          for (const h of entry.hooks) {
+            if (h.command && h.command.includes('gsd-context-monitor') && !h.timeout) {
+              h.timeout = 10;
+            }
+          }
+        }
+      }
+    }
+
+    // Configure PreToolUse hook for sandbox detection
+    if (!settings.hooks.PreToolUse) {
+      settings.hooks.PreToolUse = [];
+    }
+
+    const hasGsdSandboxDetectHook = settings.hooks.PreToolUse.some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-sandbox-detect'))
+    );
+
+    if (!hasGsdSandboxDetectHook) {
+      settings.hooks.PreToolUse.push({
+        hooks: [
+          {
+            type: 'command',
+            command: sandboxDetectCommand
+          }
+        ]
+      });
+      console.log(`  ${green}✓${reset} Configured sandbox detection hook`);
+    }
+
+    // Configure PreToolUse hook for workflow guardrail
+    const hasGsdGuardrailHook = settings.hooks.PreToolUse.some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-guardrail'))
+    );
+
+    if (!hasGsdGuardrailHook) {
+      settings.hooks.PreToolUse.push({
+        matcher: 'Edit|Write|EnterPlanMode',
+        hooks: [
+          {
+            type: 'command',
+            command: guardrailCommand,
+          }
+        ]
+      });
+      console.log(`  ${green}✓${reset} Configured workflow guardrail hook`);
+    }
+
+    // Configure PreToolUse hook for bash command safety (compound command allowlist).
+    // Replaces AST safety rules — transparent hook instead of model instructions.
+    // See: https://github.com/anthropics/claude-code/issues/30435
+    // Append at END of PreToolUse array — user's custom hooks run first.
+    const hasGsdBashSafetyHook = settings.hooks.PreToolUse.some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('bash-safety-hook.cjs'))
+    );
+
+    if (!hasGsdBashSafetyHook) {
+      settings.hooks.PreToolUse.push({
+        matcher: 'Bash',
+        hooks: [
+          {
+            type: 'command',
+            command: bashSafetyCommand
+          }
+        ]
+      });
+      console.log(`  ${green}✓${reset} Configured bash command safety hook`);
+    }
+
+    // Seed permissions.allow from settings-sandbox.json template
+    if (!noSeedPermissionsConfig) {
+      const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
+      try {
+        const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
+        const templateEntries = sandboxTemplate.permissions?.allow ?? [];
+
+        // Detect platform CLIs dynamically
+        const platformCLIs = ['gh', 'glab', 'fj', 'tea'];
+        const dynamicEntries = [];
+        for (const cli of platformCLIs) {
+          try {
+            execSync(`which ${cli}`, { stdio: 'ignore', timeout: 2000 });
+            dynamicEntries.push(...getPlatformCliPatterns(cli));
+          } catch {
+            // CLI not installed — skip
+          }
+        }
+
+        // Also check .planning/config.json for configured platform
+        const configPath = path.join(process.cwd(), '.planning', 'config.json');
+        try {
+          if (fs.existsSync(configPath)) {
+            const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+            const platform = config.git?.platform;
+            if (platform && PLATFORM_TO_CLI[platform]) {
+              const cliPatterns = getPlatformCliPatterns(PLATFORM_TO_CLI[platform]);
+              for (const entry of cliPatterns) {
+                if (!dynamicEntries.includes(entry)) dynamicEntries.push(entry);
+              }
+            }
+          }
+        } catch {
+          // config.json missing or unparseable — skip
+        }
+
+        // Non-destructive merge: add missing entries, keep existing
+        const allNewEntries = [...templateEntries, ...dynamicEntries];
+        const existingAllow = settings.permissions?.allow ?? [];
+        const entriesToAdd = allNewEntries.filter(e => !existingAllow.includes(e));
+
+        if (entriesToAdd.length > 0) {
+          if (!settings.permissions) settings.permissions = {};
+          if (!settings.permissions.allow) settings.permissions.allow = [];
+          settings.permissions.allow.push(...entriesToAdd);
+          console.log(`  ${green}✓${reset} Seeded ${entriesToAdd.length} permissions`);
+        } else {
+          console.log(`  ${green}✓${reset} Permissions already up to date`);
+        }
+      } catch {
+        // Template missing or unreadable — skip silently
+      }
+    }
+
+    // Seed sandbox settings by default (opt-out via --no-seed-sandbox-config)
+    if (!noSeedSandboxConfig) {
+      const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
+      try {
+        const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
+        let sandboxSeeded = false;
+
+        if (sandboxTemplate.sandbox) {
+          if (!settings.sandbox) settings.sandbox = {};
+          if (settings.sandbox.enabled === undefined && sandboxTemplate.sandbox.enabled !== undefined) {
+            settings.sandbox.enabled = sandboxTemplate.sandbox.enabled;
+            sandboxSeeded = true;
+          }
+          if (settings.sandbox.autoAllowBashIfSandboxed === undefined && sandboxTemplate.sandbox.autoAllowBashIfSandboxed !== undefined) {
+            settings.sandbox.autoAllowBashIfSandboxed = sandboxTemplate.sandbox.autoAllowBashIfSandboxed;
+            sandboxSeeded = true;
+          }
+        }
+
+        if (sandboxSeeded) {
+          console.log(`  ${green}✓${reset} Enabled sandbox mode`);
+        }
+      } catch {
+        // Template missing or unreadable — skip
+      }
+    }
+
+    // Persist runtime to .planning/config.json for effort-gating
+    writeRuntimeToConfig(runtime);
+
+    return { settingsPath, settings, statuslineCommand };
 
   } else {
     // Copilot: skills (from commands), agents, gsd-ng engine, copilot-instructions.md

--- a/bin/install.js
+++ b/bin/install.js
@@ -18,6 +18,7 @@ const reset = '\x1b[0m';
 const pkg = require('../package.json');
 const { processTemplate, buildContext, injectAppendToFile, fillBetweenMarkers } = require('../gsd-ng/bin/lib/template-processor.cjs');
 const { getPlatformCliPatterns, PLATFORM_TO_CLI } = require(path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'allowlist.cjs'));
+const { syncAgentEffortFrontmatter, formatRestartNotice } = require(path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'effort-sync.cjs'));
 
 // Parse args
 const args = process.argv.slice(2);
@@ -33,7 +34,6 @@ const runtimeArgVal = runtimeArgIdx !== -1 ? args[runtimeArgIdx + 1] : null;
 // For non-interactive: --runtime is required (validated below).
 // For interactive: promptRuntime() sets this before install.
 let runtime = runtimeArgVal || null;  // null means "not specified yet"
-let isCopilot = runtime === 'copilot';
 
 // Validate --runtime value if provided
 if (runtimeArgVal && !['claude', 'copilot'].includes(runtimeArgVal)) {
@@ -70,6 +70,16 @@ function toHomePrefix(pathPrefix) {
     return '${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}/' + dirMatch[1];
   }
   return normalized;
+}
+
+/**
+ * Map a runtime identifier to a human-readable label for console output.
+ * Centralizes the mapping so future runtimes can be added in one place.
+ */
+function getRuntimeLabel(runtime) {
+  if (runtime === 'claude') return 'Claude Code';
+  if (runtime === 'copilot') return 'Copilot CLI';
+  return runtime || 'your runtime';
 }
 
 // Helper to get directory name based on runtime
@@ -367,6 +377,7 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, isCommand = false)
  * @param {boolean} isGlobal - Whether to uninstall from global or local
  */
 function uninstall(isGlobal) {
+  const isClaudeCode = runtime === 'claude';
   const dirName = getDirName(runtime);
 
   // Get the target directory based on install type
@@ -378,7 +389,7 @@ function uninstall(isGlobal) {
     ? targetDir.replace(os.homedir(), '~')
     : targetDir.replace(process.cwd(), '.');
 
-  const runtimeLabel = isCopilot ? 'Copilot CLI' : 'Claude Code';
+  const runtimeLabel = getRuntimeLabel(runtime);
   console.log(`  Uninstalling GSD from ${cyan}${runtimeLabel}${reset} at ${cyan}${locationLabel}${reset}\n`);
 
   // Check if target directory exists
@@ -390,81 +401,8 @@ function uninstall(isGlobal) {
 
   let removedCount = 0;
 
-  if (isCopilot) {
-    // 1. Remove GSD skills (skills/gsd-* directories)
-    const skillsDir = path.join(targetDir, 'skills');
-    if (fs.existsSync(skillsDir)) {
-      let skillCount = 0;
-      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
-        if (entry.isDirectory() && entry.name.startsWith('gsd-')) {
-          fs.rmSync(path.join(skillsDir, entry.name), { recursive: true });
-          skillCount++;
-        }
-      }
-      if (skillCount > 0) {
-        removedCount++;
-        console.log(`  ${green}✓${reset} Removed ${skillCount} Copilot skills`);
-      }
-    }
-
-    // 2. Remove gsd-ng engine directory
-    const gsdDir = path.join(targetDir, 'gsd-ng');
-    if (fs.existsSync(gsdDir)) {
-      fs.rmSync(gsdDir, { recursive: true });
-      removedCount++;
-      console.log(`  ${green}✓${reset} Removed gsd-ng/`);
-    }
-
-    // 3. Remove GSD agents (gsd-*.agent.md)
-    const agentsDir = path.join(targetDir, 'agents');
-    if (fs.existsSync(agentsDir)) {
-      let agentCount = 0;
-      for (const file of fs.readdirSync(agentsDir)) {
-        if (file.startsWith('gsd-') && file.endsWith('.agent.md')) {
-          fs.unlinkSync(path.join(agentsDir, file));
-          agentCount++;
-        }
-      }
-      if (agentCount > 0) {
-        removedCount++;
-        console.log(`  ${green}✓${reset} Removed ${agentCount} Copilot agents`);
-      }
-    }
-
-    // 4. Clean GSD section from copilot-instructions.md
-    const instructionsPath = path.join(targetDir, 'copilot-instructions.md');
-    if (fs.existsSync(instructionsPath)) {
-      const content = fs.readFileSync(instructionsPath, 'utf8');
-      const cleaned = stripGsdFromCopilotInstructions(content);
-      if (cleaned === null) {
-        fs.unlinkSync(instructionsPath);
-        removedCount++;
-        console.log(`  ${green}✓${reset} Removed copilot-instructions.md (was GSD-only)`);
-      } else if (cleaned !== content) {
-        fs.writeFileSync(instructionsPath, cleaned);
-        removedCount++;
-        console.log(`  ${green}✓${reset} Cleaned GSD section from copilot-instructions.md`);
-      }
-    }
-
-    // 5. Remove gsd-hooks.json
-    const gsdHooksPath = path.join(targetDir, 'hooks', 'gsd-hooks.json');
-    if (fs.existsSync(gsdHooksPath)) {
-      fs.unlinkSync(gsdHooksPath);
-      removedCount++;
-      console.log(`  ${green}✓${reset} Removed hooks/gsd-hooks.json`);
-    }
-
-    // Print summary and return (no settings.json cleanup for Copilot)
-    if (removedCount === 0) {
-      console.log(`  ${yellow}⚠${reset} No GSD files found to remove`);
-    } else {
-      console.log(`\n  ${green}✓${reset} Uninstalled ${removedCount} GSD component(s)`);
-    }
-    return;
-  }
-
-  // 1. Remove GSD commands
+  if (isClaudeCode) {
+    // 1. Remove GSD commands
   const gsdCommandsDir = path.join(targetDir, 'commands', 'gsd');
   if (fs.existsSync(gsdCommandsDir)) {
     fs.rmSync(gsdCommandsDir, { recursive: true });
@@ -665,14 +603,87 @@ function uninstall(isGlobal) {
     }
   }
 
-  if (removedCount === 0) {
-    console.log(`  ${yellow}⚠${reset} No GSD files found to remove.`);
-  }
+    if (removedCount === 0) {
+      console.log(`  ${yellow}⚠${reset} No GSD files found to remove.`);
+    }
 
-  console.log(`
+    console.log(`
   ${green}Done!${reset} GSD has been uninstalled from Claude Code.
   Your other files and settings have been preserved.
 `);
+  } else {
+    // Copilot uninstall path
+    // 1. Remove GSD skills (skills/gsd-* directories)
+    const skillsDir = path.join(targetDir, 'skills');
+    if (fs.existsSync(skillsDir)) {
+      let skillCount = 0;
+      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+        if (entry.isDirectory() && entry.name.startsWith('gsd-')) {
+          fs.rmSync(path.join(skillsDir, entry.name), { recursive: true });
+          skillCount++;
+        }
+      }
+      if (skillCount > 0) {
+        removedCount++;
+        console.log(`  ${green}✓${reset} Removed ${skillCount} Copilot skills`);
+      }
+    }
+
+    // 2. Remove gsd-ng engine directory
+    const gsdDir = path.join(targetDir, 'gsd-ng');
+    if (fs.existsSync(gsdDir)) {
+      fs.rmSync(gsdDir, { recursive: true });
+      removedCount++;
+      console.log(`  ${green}✓${reset} Removed gsd-ng/`);
+    }
+
+    // 3. Remove GSD agents (gsd-*.agent.md)
+    const agentsDir = path.join(targetDir, 'agents');
+    if (fs.existsSync(agentsDir)) {
+      let agentCount = 0;
+      for (const file of fs.readdirSync(agentsDir)) {
+        if (file.startsWith('gsd-') && file.endsWith('.agent.md')) {
+          fs.unlinkSync(path.join(agentsDir, file));
+          agentCount++;
+        }
+      }
+      if (agentCount > 0) {
+        removedCount++;
+        console.log(`  ${green}✓${reset} Removed ${agentCount} Copilot agents`);
+      }
+    }
+
+    // 4. Clean GSD section from copilot-instructions.md
+    const instructionsPath = path.join(targetDir, 'copilot-instructions.md');
+    if (fs.existsSync(instructionsPath)) {
+      const content = fs.readFileSync(instructionsPath, 'utf8');
+      const cleaned = stripGsdFromCopilotInstructions(content);
+      if (cleaned === null) {
+        fs.unlinkSync(instructionsPath);
+        removedCount++;
+        console.log(`  ${green}✓${reset} Removed copilot-instructions.md (was GSD-only)`);
+      } else if (cleaned !== content) {
+        fs.writeFileSync(instructionsPath, cleaned);
+        removedCount++;
+        console.log(`  ${green}✓${reset} Cleaned GSD section from copilot-instructions.md`);
+      }
+    }
+
+    // 5. Remove gsd-hooks.json
+    const gsdHooksPath = path.join(targetDir, 'hooks', 'gsd-hooks.json');
+    if (fs.existsSync(gsdHooksPath)) {
+      fs.unlinkSync(gsdHooksPath);
+      removedCount++;
+      console.log(`  ${green}✓${reset} Removed hooks/gsd-hooks.json`);
+    }
+
+    // Print summary and return (no settings.json cleanup for Copilot)
+    if (removedCount === 0) {
+      console.log(`  ${yellow}⚠${reset} No GSD files found to remove`);
+    } else {
+      console.log(`\n  ${green}✓${reset} Uninstalled ${removedCount} GSD component(s)`);
+    }
+  }
 }
 
 /**
@@ -1082,6 +1093,7 @@ function writeRuntimeToConfig(rt) {
 // ─────────────────────────────────────────────────────────────────────────────
 
 function install(isGlobal) {
+  const isClaudeCode = runtime === 'claude';
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
 
@@ -1102,135 +1114,14 @@ function install(isGlobal) {
     ? `${targetDir.replace(/\\/g, '/').replace(os.homedir().replace(/\\/g, '/'), '~')}/`
     : `./${dirName}/`;
 
-  const runtimeLabel = isCopilot ? 'Copilot CLI' : 'Claude Code';
+  const runtimeLabel = getRuntimeLabel(runtime);
   console.log(`  Installing for ${cyan}${runtimeLabel}${reset} to ${cyan}${locationLabel}${reset}\n`);
 
   // Track installation failures
   const failures = [];
 
-  if (isCopilot) {
-    // Copilot: skills (from commands), agents, gsd-ng engine, copilot-instructions.md
-    // NO settings.json, NO hooks, NO statusline, NO sandbox seeding
-
-    // 1. Copy gsd-ng skill engine (same as Claude Code)
-    const skillSrc = path.join(src, 'gsd-ng');
-    const skillDest = path.join(targetDir, 'gsd-ng');
-    copyWithPathReplacement(skillSrc, skillDest, pathPrefix);
-    if (verifyInstalled(skillDest, 'gsd-ng')) {
-      console.log(`  ${green}✓${reset} Installed gsd-ng`);
-    } else {
-      failures.push('gsd-ng');
-    }
-
-    // 2. Convert commands to Copilot skills (skills/gsd-{name}/SKILL.md)
-    const commandsSrc = path.join(src, 'commands', 'gsd');
-    const skillsDir = path.join(targetDir, 'skills');
-    if (fs.existsSync(commandsSrc)) {
-      // Clean existing GSD skills
-      if (fs.existsSync(skillsDir)) {
-        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
-          if (entry.isDirectory() && entry.name.startsWith('gsd-')) {
-            fs.rmSync(path.join(skillsDir, entry.name), { recursive: true });
-          }
-        }
-      }
-      fs.mkdirSync(skillsDir, { recursive: true });
-
-      const commandFiles = fs.readdirSync(commandsSrc).filter(f => f.endsWith('.md'));
-      let skillCount = 0;
-      for (const file of commandFiles) {
-        const content = fs.readFileSync(path.join(commandsSrc, file), 'utf8');
-        const skillName = 'gsd-' + path.basename(file, '.md').replace(/^gsd[:-]/, '');
-        const skillDir = path.join(skillsDir, skillName);
-        fs.mkdirSync(skillDir, { recursive: true });
-        const converted = convertClaudeCommandToCopilotSkill(content, skillName, isGlobal);
-        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), converted);
-        skillCount++;
-      }
-      console.log(`  ${green}✓${reset} Installed ${skillCount} Copilot skills`);
-    }
-
-    // 3. Convert agents to Copilot .agent.md format
-    const agentsSrc = path.join(src, 'agents');
-    if (fs.existsSync(agentsSrc)) {
-      const agentsDest = path.join(targetDir, 'agents');
-      // Clean existing GSD agents
-      if (fs.existsSync(agentsDest)) {
-        for (const file of fs.readdirSync(agentsDest)) {
-          if (file.startsWith('gsd-') && file.endsWith('.agent.md')) {
-            fs.unlinkSync(path.join(agentsDest, file));
-          }
-        }
-      }
-      fs.mkdirSync(agentsDest, { recursive: true });
-
-      const agentFiles = fs.readdirSync(agentsSrc).filter(f => f.endsWith('.md'));
-      let agentCount = 0;
-      for (const file of agentFiles) {
-        const content = fs.readFileSync(path.join(agentsSrc, file), 'utf8');
-        const converted = convertClaudeAgentToCopilotAgent(content, isGlobal);
-        const agentName = path.basename(file, '.md') + '.agent.md';
-        fs.writeFileSync(path.join(agentsDest, agentName), converted);
-        agentCount++;
-      }
-      console.log(`  ${green}✓${reset} Installed ${agentCount} Copilot agents`);
-    }
-
-    // 4. Generate copilot-instructions.md
-    const templatePath = path.join(targetDir, 'gsd-ng', 'templates', 'copilot-instructions.md');
-    const instructionsPath = path.join(targetDir, 'copilot-instructions.md');
-    if (fs.existsSync(templatePath)) {
-      const template = fs.readFileSync(templatePath, 'utf8');
-      mergeCopilotInstructions(instructionsPath, template);
-      console.log(`  ${green}✓${reset} Generated copilot-instructions.md`);
-    }
-
-    // 5. Write gsd-hooks.json (SessionStart update-check hook)
-    // Note: global Copilot hooks (~/.copilot/hooks/) are not yet supported by Copilot CLI
-    // (feature request #1354). Only wire hooks for local installs.
-    if (!isGlobal) {
-      const hooksDir = path.join(targetDir, 'hooks');
-      fs.mkdirSync(hooksDir, { recursive: true });
-      const gsdHooksPath = path.join(hooksDir, 'gsd-hooks.json');
-      const hookContent = JSON.stringify({
-        version: 1,
-        hooks: {
-          sessionStart: [
-            {
-              type: 'command',
-              bash: `node ${dirName}/gsd-ng/hooks/gsd-check-update.js`,
-              cwd: '.',
-              timeoutSec: 30,
-            }
-          ]
-        }
-      }, null, 2);
-      fs.writeFileSync(gsdHooksPath, hookContent);
-      console.log(`  ${green}✓${reset} Installed hooks/gsd-hooks.json`);
-    } else {
-      console.log(`  (hooks skipped — global Copilot hooks not yet supported by Copilot CLI)`);
-    }
-
-    // Copilot: no settings.json, no statusline, no sandbox seeding
-    if (failures.length > 0) {
-      console.log(`\n  ${yellow}⚠ ${failures.length} component(s) failed to install${reset}`);
-    }
-
-    // Write VERSION file (snapshot-aware, same as claude path) — overrides any
-    // verbatim copy from source tree so copilot installs get the same +hash
-    // suffix on dev checkouts.
-    const versionDest = path.join(targetDir, 'gsd-ng', 'VERSION');
-    fs.mkdirSync(path.dirname(versionDest), { recursive: true });
-    fs.writeFileSync(versionDest, INSTALLED_VERSION);
-    console.log(`  ${green}✓${reset} Wrote VERSION (${INSTALLED_VERSION})`);
-
-    // Persist runtime to .planning/config.json for effort-gating
-    writeRuntimeToConfig(runtime);
-
-    return { settingsPath: null, settings: null, statuslineCommand: null, runtime };
-  }
-
-  // Save any locally modified GSD files before they get wiped
+  if (isClaudeCode) {
+    // Save any locally modified GSD files before they get wiped
   saveLocalPatches(targetDir);
 
   // Claude Code: nested structure in commands/ directory
@@ -1289,6 +1180,27 @@ function install(isGlobal) {
       console.log(`  ${green}✓${reset} Installed agents`);
     } else {
       failures.push('agents');
+    }
+  }
+
+  // Sync effort: frontmatter into deployed agent files (Claude-only, post-copy).
+  // Must run BEFORE writeManifest so manifest hashes the post-sync content.
+  // Note: this code path now lives inside Plan 03's outer `if (isClaudeCode) { ... }`
+  // wrapper, so the explicit isClaudeCode check below is technically redundant —
+  // keep it as a defensive guard that documents intent and survives future refactors.
+  if (isClaudeCode && fs.existsSync(path.join(targetDir, 'agents'))) {
+    const effortAgentsDir = path.join(targetDir, 'agents');
+    const syncResult = syncAgentEffortFrontmatter(process.cwd(), effortAgentsDir);
+    if (syncResult.changes && syncResult.changes.length > 0) {
+      console.log(`  ${green}✓${reset} Synced effort frontmatter (${syncResult.changes.length} agent${syncResult.changes.length === 1 ? '' : 's'} changed)`);
+      // CONTEXT.md Area 4 lock: restart notice on real changes at ALL three touchpoints
+      // (install, set-profile, config-set effort_overrides). Use stderr to match Plans 05/06
+      // emission style — keeps stdout / JSON-mode payloads clean and gives all three call
+      // sites one voice.
+      const restartNotice = formatRestartNotice(syncResult.changes);
+      if (restartNotice) {
+        process.stderr.write(restartNotice + '\n');
+      }
     }
   }
 
@@ -1377,27 +1289,25 @@ function install(isGlobal) {
   // Uses template-processor.cjs (centralized template engine).
   // Copilot path handles this separately in convertClaudeToCopilotContent().
   // Path rewriting (e.g., ~/.claude/ -> ~/.copilot/) stays separate per design.
-  if (runtime === 'claude') {
-    const ctx = buildContext('claude');
-    const claudeTemplateDirs = [
-      path.join(targetDir, 'gsd-ng', 'workflows'),
-      path.join(targetDir, 'gsd-ng', 'references'),
-      path.join(targetDir, 'gsd-ng', 'bin', 'lib'),
-      path.join(targetDir, 'commands', 'gsd'),
-    ];
-    for (const dir of claudeTemplateDirs) {
-      if (!fs.existsSync(dir)) continue;
-      const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') || f.endsWith('.cjs'));
-      for (const file of files) {
-        const filePath = path.join(dir, file);
-        let content = fs.readFileSync(filePath, 'utf-8');
-        if (content.includes('{{') || content.includes('<!-- ONLY:')) {
-          try {
-            content = processTemplate(content, ctx);
-            fs.writeFileSync(filePath, content, 'utf-8');
-          } catch {
-            // Skip files with unbalanced markers (e.g., documentation containing example syntax)
-          }
+  const ctx = buildContext('claude');
+  const claudeTemplateDirs = [
+    path.join(targetDir, 'gsd-ng', 'workflows'),
+    path.join(targetDir, 'gsd-ng', 'references'),
+    path.join(targetDir, 'gsd-ng', 'bin', 'lib'),
+    path.join(targetDir, 'commands', 'gsd'),
+  ];
+  for (const dir of claudeTemplateDirs) {
+    if (!fs.existsSync(dir)) continue;
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.md') || f.endsWith('.cjs'));
+    for (const file of files) {
+      const filePath = path.join(dir, file);
+      let content = fs.readFileSync(filePath, 'utf-8');
+      if (content.includes('{{') || content.includes('<!-- ONLY:')) {
+        try {
+          content = processTemplate(content, ctx);
+          fs.writeFileSync(filePath, content, 'utf-8');
+        } catch {
+          // Skip files with unbalanced markers (e.g., documentation containing example syntax)
         }
       }
     }
@@ -1540,27 +1450,25 @@ function install(isGlobal) {
   // Replaces AST safety rules — transparent hook instead of model instructions.
   // See: https://github.com/anthropics/claude-code/issues/30435
   // Append at END of PreToolUse array — user's custom hooks run first.
-  if (runtime === 'claude') {
-    const hasGsdBashSafetyHook = settings.hooks.PreToolUse.some(entry =>
-      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('bash-safety-hook.cjs'))
-    );
+  const hasGsdBashSafetyHook = settings.hooks.PreToolUse.some(entry =>
+    entry.hooks && entry.hooks.some(h => h.command && h.command.includes('bash-safety-hook.cjs'))
+  );
 
-    if (!hasGsdBashSafetyHook) {
-      settings.hooks.PreToolUse.push({
-        matcher: 'Bash',
-        hooks: [
-          {
-            type: 'command',
-            command: bashSafetyCommand
-          }
-        ]
-      });
-      console.log(`  ${green}✓${reset} Configured bash command safety hook`);
-    }
+  if (!hasGsdBashSafetyHook) {
+    settings.hooks.PreToolUse.push({
+      matcher: 'Bash',
+      hooks: [
+        {
+          type: 'command',
+          command: bashSafetyCommand
+        }
+      ]
+    });
+    console.log(`  ${green}✓${reset} Configured bash command safety hook`);
   }
 
   // Seed permissions.allow from settings-sandbox.json template
-  if (!noSeedPermissionsConfig && runtime === 'claude') {
+  if (!noSeedPermissionsConfig) {
     const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
     try {
       const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
@@ -1614,7 +1522,7 @@ function install(isGlobal) {
   }
 
   // Seed sandbox settings by default (opt-out via --no-seed-sandbox-config)
-  if (!noSeedSandboxConfig && runtime === 'claude') {
+  if (!noSeedSandboxConfig) {
     const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
     try {
       const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
@@ -1644,6 +1552,134 @@ function install(isGlobal) {
   writeRuntimeToConfig(runtime);
 
   return { settingsPath, settings, statuslineCommand };
+
+  } else {
+    // Copilot: skills (from commands), agents, gsd-ng engine, copilot-instructions.md
+    // NO settings.json, NO hooks, NO statusline, NO sandbox seeding
+
+    // 1. Copy gsd-ng skill engine (same as Claude Code)
+    const skillSrc = path.join(src, 'gsd-ng');
+    const skillDest = path.join(targetDir, 'gsd-ng');
+    copyWithPathReplacement(skillSrc, skillDest, pathPrefix);
+    if (verifyInstalled(skillDest, 'gsd-ng')) {
+      console.log(`  ${green}✓${reset} Installed gsd-ng`);
+    } else {
+      failures.push('gsd-ng');
+    }
+
+    // 2. Convert commands to Copilot skills (skills/gsd-{name}/SKILL.md)
+    const commandsSrc = path.join(src, 'commands', 'gsd');
+    const skillsDir = path.join(targetDir, 'skills');
+    if (fs.existsSync(commandsSrc)) {
+      // Clean existing GSD skills
+      if (fs.existsSync(skillsDir)) {
+        for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+          if (entry.isDirectory() && entry.name.startsWith('gsd-')) {
+            fs.rmSync(path.join(skillsDir, entry.name), { recursive: true });
+          }
+        }
+      }
+      fs.mkdirSync(skillsDir, { recursive: true });
+
+      const commandFiles = fs.readdirSync(commandsSrc).filter(f => {
+        if (!f.endsWith('.md')) return false;
+        // Skip Claude-only commands. set-profile configures effort: frontmatter
+        // which Copilot does not support (see Phase 55 CONTEXT §Area 1).
+        if (f === 'set-profile.md') return false;
+        return true;
+      });
+      let skillCount = 0;
+      for (const file of commandFiles) {
+        const content = fs.readFileSync(path.join(commandsSrc, file), 'utf8');
+        const skillName = 'gsd-' + path.basename(file, '.md').replace(/^gsd[:-]/, '');
+        const skillDir = path.join(skillsDir, skillName);
+        fs.mkdirSync(skillDir, { recursive: true });
+        const converted = convertClaudeCommandToCopilotSkill(content, skillName, isGlobal);
+        fs.writeFileSync(path.join(skillDir, 'SKILL.md'), converted);
+        skillCount++;
+      }
+      console.log(`  ${green}✓${reset} Installed ${skillCount} Copilot skills`);
+    }
+
+    // 3. Convert agents to Copilot .agent.md format
+    const agentsSrc = path.join(src, 'agents');
+    if (fs.existsSync(agentsSrc)) {
+      const agentsDest = path.join(targetDir, 'agents');
+      // Clean existing GSD agents
+      if (fs.existsSync(agentsDest)) {
+        for (const file of fs.readdirSync(agentsDest)) {
+          if (file.startsWith('gsd-') && file.endsWith('.agent.md')) {
+            fs.unlinkSync(path.join(agentsDest, file));
+          }
+        }
+      }
+      fs.mkdirSync(agentsDest, { recursive: true });
+
+      const agentFiles = fs.readdirSync(agentsSrc).filter(f => f.endsWith('.md'));
+      let agentCount = 0;
+      for (const file of agentFiles) {
+        const content = fs.readFileSync(path.join(agentsSrc, file), 'utf8');
+        const converted = convertClaudeAgentToCopilotAgent(content, isGlobal);
+        const agentName = path.basename(file, '.md') + '.agent.md';
+        fs.writeFileSync(path.join(agentsDest, agentName), converted);
+        agentCount++;
+      }
+      console.log(`  ${green}✓${reset} Installed ${agentCount} Copilot agents`);
+    }
+
+    // 4. Generate copilot-instructions.md
+    const templatePath = path.join(targetDir, 'gsd-ng', 'templates', 'copilot-instructions.md');
+    const instructionsPath = path.join(targetDir, 'copilot-instructions.md');
+    if (fs.existsSync(templatePath)) {
+      const template = fs.readFileSync(templatePath, 'utf8');
+      mergeCopilotInstructions(instructionsPath, template);
+      console.log(`  ${green}✓${reset} Generated copilot-instructions.md`);
+    }
+
+    // 5. Write gsd-hooks.json (SessionStart update-check hook)
+    // Note: global Copilot hooks (~/.copilot/hooks/) are not yet supported by Copilot CLI
+    // (feature request #1354). Only wire hooks for local installs.
+    if (!isGlobal) {
+      const hooksDir = path.join(targetDir, 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+      const gsdHooksPath = path.join(hooksDir, 'gsd-hooks.json');
+      const hookContent = JSON.stringify({
+        version: 1,
+        hooks: {
+          sessionStart: [
+            {
+              type: 'command',
+              bash: `node ${dirName}/gsd-ng/hooks/gsd-check-update.js`,
+              cwd: '.',
+              timeoutSec: 30,
+            }
+          ]
+        }
+      }, null, 2);
+      fs.writeFileSync(gsdHooksPath, hookContent);
+      console.log(`  ${green}✓${reset} Installed hooks/gsd-hooks.json`);
+    } else {
+      console.log(`  (hooks skipped — global Copilot hooks not yet supported by Copilot CLI)`);
+    }
+
+    // Copilot: no settings.json, no statusline, no sandbox seeding
+    if (failures.length > 0) {
+      console.log(`\n  ${yellow}⚠ ${failures.length} component(s) failed to install${reset}`);
+    }
+
+    // Write VERSION file (snapshot-aware, same as claude path) — overrides any
+    // verbatim copy from source tree so copilot installs get the same +hash
+    // suffix on dev checkouts.
+    const versionDest = path.join(targetDir, 'gsd-ng', 'VERSION');
+    fs.mkdirSync(path.dirname(versionDest), { recursive: true });
+    fs.writeFileSync(versionDest, INSTALLED_VERSION);
+    console.log(`  ${green}✓${reset} Wrote VERSION (${INSTALLED_VERSION})`);
+
+    // Persist runtime to .planning/config.json for effort-gating
+    writeRuntimeToConfig(runtime);
+
+    return { settingsPath: null, settings: null, statuslineCommand: null, runtime };
+  }
 }
 
 /**
@@ -1734,6 +1770,7 @@ function askSandboxMode(rl, callback) {
  * Install GSD and finalize (hook registration + statusline)
  */
 function installAndFinish(isGlobal, isInteractive) {
+  const isClaudeCode = runtime === 'claude';
   const result = install(isGlobal);
   if (result && result.settingsPath) {
     handleStatusline(result.settings, isInteractive, (shouldInstallStatusline) => {
@@ -1741,7 +1778,7 @@ function installAndFinish(isGlobal, isInteractive) {
     });
   } else if (result) {
     // Copilot or other runtime without settings.json
-    console.log(`\n  ${green}Done!${reset} GSD installed for ${cyan}${isCopilot ? 'Copilot CLI' : 'your runtime'}${reset}.\n`);
+    console.log(`\n  ${green}Done!${reset} GSD installed for ${cyan}${isClaudeCode ? 'Claude Code' : getRuntimeLabel(runtime)}${reset}.\n`);
   }
 }
 
@@ -1850,12 +1887,8 @@ if (hasGlobal && hasLocal) {
     // Interactive flow: runtime -> location -> sandbox (Claude only)
     promptRuntime((selectedRuntime) => {
       runtime = selectedRuntime;
-      isCopilot = runtime === 'copilot';
       promptLocation((isGlobal) => {
-        if (isCopilot) {
-          // Copilot has no sandbox model -- skip sandbox prompt
-          installAndFinish(isGlobal, true);
-        } else {
+        if (runtime === 'claude') {
           // Claude: ask about sandbox mode
           const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
           askSandboxMode(rl, (enableSandbox) => {
@@ -1865,6 +1898,9 @@ if (hasGlobal && hasLocal) {
             }
             installAndFinish(isGlobal, true);
           });
+        } else {
+          // Copilot has no sandbox model -- skip sandbox prompt
+          installAndFinish(isGlobal, true);
         }
       });
     });

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -16,6 +16,7 @@
  *   state patch --field val ...        Batch update STATE.md fields
  *   resolve-model <agent-type>         Get model for agent based on profile
  *   resolve-effort <agent-type>        Get effort for agent based on profile
+ *   sync-agents [--agents-dir <path>]  Re-sync effort: frontmatter into agent files
  *   find-phase <phase>                 Find phase directory by number
  *   commit <message> [--files f1 f2]   Commit planning docs
  *   verify-summary <path>              Verify a SUMMARY.md file
@@ -177,11 +178,12 @@ const frontmatter = require('./lib/frontmatter.cjs');
 const workspace = require('./lib/workspace.cjs');
 const guard = require('./lib/guard.cjs');
 const testBaseline = require('./lib/test-baseline.cjs');
+const effortSync = require('./lib/effort-sync.cjs');
 
 // ─── Command Registry (for typo detection) ────────────────────────────────────
 
 const ALL_COMMANDS = [
-  'state', 'resolve-model', 'resolve-effort', 'find-phase', 'commit', 'verify-summary',
+  'state', 'resolve-model', 'resolve-effort', 'sync-agents', 'find-phase', 'commit', 'verify-summary',
   'template', 'frontmatter', 'verify', 'generate-slug', 'current-timestamp',
   'list-todos', 'recurring-due', 'staleness-check', 'verify-path-exists',
   'config-ensure-section', 'config-set', 'config-set-model-profile',
@@ -322,6 +324,7 @@ const ARG_SCHEMAS = {
   'commit':             { _self: { positional: { min: 0, max: null }, flags: ['--amend', '--files'] } },
   'verify-summary':     { _self: { positional: { min: 1, max: 1 }, flags: ['--check-count'] } },
   'staleness-check':    { _self: { positional: { min: 0, max: 0 }, flags: ['--count'] } },
+  'sync-agents':        { _self: { positional: { min: 0, max: 0 }, flags: ['--agents-dir'] } },
   'config-get':         { _self: { positional: { min: 1, max: 1 }, flags: ['--default'] } },
   'update':             { _self: { positional: { min: 0, max: 0 }, flags: ['--dry-run', '--local', '--global'] } },
   'scaffold':           { _self: { positional: { min: 1, max: null }, flags: ['--phase', '--name'] } },
@@ -840,6 +843,49 @@ async function main() {
 
     case 'resolve-effort': {
       commands.cmdResolveEffort(cwd, args[1]);
+      break;
+    }
+
+    case 'sync-agents': {
+      validateArgs('sync-agents', null, args.slice(1));
+      // Optional --agents-dir override (default: <cwd>/.claude/agents).
+      const agentsDirIdx = args.indexOf('--agents-dir');
+      const customAgentsDir = agentsDirIdx !== -1 ? args[agentsDirIdx + 1] : null;
+      const agentsDir = customAgentsDir
+        ? path.resolve(customAgentsDir)
+        : path.join(cwd, '.claude', 'agents');
+
+      if (!fs.existsSync(agentsDir)) {
+        coreOutput(
+          { skipped: true, reason: 'agents-dir-missing', agentsDir, changes: [] },
+          `No agents directory found at ${agentsDir} — run the installer first.`
+        );
+        break;
+      }
+
+      const syncResult = effortSync.syncAgentEffortFrontmatter(cwd, agentsDir);
+      const changeCount = (syncResult.changes || []).length;
+
+      // Build a clean stdout summary — NO restart notice embedded here.
+      // The restart notice goes to stderr separately so JSON-mode consumers
+      // get a clean payload on stdout and the notice doesn't pollute pipelines.
+      const syncSummary = syncResult.skipped
+        ? 'Skipped — non-Claude runtime.'
+        : (changeCount === 0
+          ? 'Agents already in sync.'
+          : `Synced ${changeCount} agent${changeCount === 1 ? '' : 's'}.`);
+
+      // Emit the restart notice via stderr ONLY when the helper reports real changes.
+      // Same emission shape as Plan 04 (install.js) and Plan 05 (config.cjs) — one voice.
+      const restartNotice = effortSync.formatRestartNotice(syncResult.changes || []);
+      if (restartNotice) {
+        process.stderr.write(restartNotice + '\n');
+      }
+
+      coreOutput(
+        { ...syncResult, restartNotice },
+        syncSummary
+      );
       break;
     }
 

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error, planningPaths } = require('./core.cjs');
+const { output, error, planningPaths, loadConfig } = require('./core.cjs');
 const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 const {
   VALID_PROFILES,
@@ -14,6 +14,7 @@ const {
   formatAgentToModelMapAsTable,
   formatAgentToEffortMapAsTable,
 } = require('./model-profiles.cjs');
+const { syncAgentEffortFrontmatter, formatRestartNotice } = require('./effort-sync.cjs');
 
 const VALID_CONFIG_KEYS = new Set([
   'mode', 'granularity', 'parallelization', 'commit_docs', 'model_profile',
@@ -43,6 +44,12 @@ const VALID_CONFIG_KEYS = new Set([
 const SUBMODULE_KEY_PATTERN = /^git\.submodules\.[^.]+\.(target_branch|branching_strategy|phase_branch_template|milestone_branch_template|review_branch_template|remote|auto_push|platform|pr_template|pr_draft|commit_format|commit_template|versioning_scheme|type_aliases|ssh_check)$/;
 
 const EFFORT_OVERRIDE_KEY_PATTERN = /^effort_overrides\.[a-z][\w-]+$/;
+
+// Profile/effort keys are Claude-only surface (CONTEXT.md Area 1).
+// cmdConfigGet hides these from Copilot consumers — even if a hand-edited
+// copilot config.json contains them — so the read-side strip is robust
+// against future key additions.
+const PROFILE_EFFORT_KEY_PATTERN = /^(model_profile|model_overrides(\..+)?|effort_overrides(\..+)?)$/;
 
 const CONFIG_KEY_SUGGESTIONS = {
   'workflow.nyquist_validation_enabled': 'workflow.nyquist_validation',
@@ -220,6 +227,19 @@ function cmdConfigSet(cwd, keyPath, value) {
   else if (!isNaN(value) && value !== '') parsedValue = Number(value);
 
   const setConfigValueResult = setConfigValue(cwd, keyPath, parsedValue);
+
+  // For effort_overrides.* writes, sync deployed agent files immediately so the
+  // change takes effect on next Claude Code session restart.
+  if (EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath)) {
+    const agentsDir = path.join(cwd, '.claude', 'agents');
+    const syncResult = syncAgentEffortFrontmatter(cwd, agentsDir);
+    const restartNotice = formatRestartNotice(syncResult.changes || []);
+    if (restartNotice) {
+      process.stderr.write(restartNotice + '\n');
+    }
+    setConfigValueResult.effortChanges = syncResult.changes || [];
+  }
+
   output(setConfigValueResult, `${keyPath}=${parsedValue}`);
 }
 
@@ -232,6 +252,25 @@ function cmdConfigGet(cwd, keyPath, defaultValue) {
 
   if (keyPath === 'git.submodule.workspace_branch') {
     process.stderr.write('Warning: git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.\n');
+  }
+
+  // Phase 55 Area 1 lock: profile/effort keys are Claude-only.
+  // When runtime === 'copilot', treat these keys as not-present so callers
+  // get the same not-found / defaultValue behaviour they would on a config
+  // that simply doesn't define them.
+  if (PROFILE_EFFORT_KEY_PATTERN.test(keyPath)) {
+    const cfg = loadConfig(cwd) || {};
+    const isClaudeCode = (cfg.runtime || 'claude') === 'claude';
+    if (isClaudeCode) {
+      // fall through to the existing lookup below
+    } else {
+      if (defaultValue !== undefined) {
+        output(defaultValue, String(defaultValue));
+        return;
+      }
+      error(`Key not found: ${keyPath}`);
+      return;
+    }
   }
 
   let config = {};
@@ -300,12 +339,23 @@ function cmdConfigSetModelProfile(cwd, profile) {
   // Build result value / message and return
   const agentToModelMap = getAgentToModelMapForProfile(normalizedProfile);
   const agentToEffortMap = getAgentToEffortMapForProfile(normalizedProfile);
+
+  // Sync effort: frontmatter into deployed agent files (Claude-only).
+  // Helper short-circuits on non-claude runtimes and missing .claude/agents dir.
+  const agentsDir = path.join(cwd, '.claude', 'agents');
+  const syncResult = syncAgentEffortFrontmatter(cwd, agentsDir);
+  const restartNotice = formatRestartNotice(syncResult.changes || []);
+  if (restartNotice) {
+    process.stderr.write(restartNotice + '\n');
+  }
+
   const result = {
     updated: true,
     profile: normalizedProfile,
     previousProfile,
     agentToModelMap,
     agentToEffortMap,
+    effortChanges: syncResult.changes || [],
   };
   const rawValue = getCmdConfigSetModelProfileResultMessage(
     normalizedProfile,

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -208,6 +208,16 @@ function cmdConfigSet(cwd, keyPath, value) {
     error('git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.');
   }
 
+  // model_profile is a domain-level setting, not a flat key/value.
+  // Route users to the dedicated command so they get profile validation,
+  // agent effort sync, and the restart notice.
+  if (keyPath === 'model_profile') {
+    error(
+      "'model_profile' must be set via 'config-set-model-profile <profile>'. " +
+      "Setting it through 'config-set' skips agent effort sync, profile validation, and the restart notice."
+    );
+  }
+
   if (!VALID_CONFIG_KEYS.has(keyPath) && !SUBMODULE_KEY_PATTERN.test(keyPath) && !EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath)) {
     error(`Unknown config key: "${keyPath}". Valid keys: ${[...VALID_CONFIG_KEYS].sort().join(', ')}`);
   }

--- a/gsd-ng/bin/lib/effort-sync.cjs
+++ b/gsd-ng/bin/lib/effort-sync.cjs
@@ -1,0 +1,79 @@
+/**
+ * effort-sync — Writes resolved effort: frontmatter into deployed Claude agent files.
+ *
+ * Single call site for install.js, cmdConfigSetModelProfile, cmdConfigSet
+ * (effort_overrides.*), and the `gsd sync-agents` CLI.
+ *
+ * Trusts resolveEffortInternal's null semantics completely:
+ *   - null return → remove the `effort:` field from frontmatter
+ *   - string return → write `effort: <value>` to frontmatter
+ *
+ * Does its OWN before/after change detection because the frontmatter setter always
+ * writes the file unconditionally (no short-circuit on unchanged values).
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { loadConfig, resolveEffortInternal } = require('./core.cjs');
+const { EFFORT_PROFILES } = require('./model-profiles.cjs');
+const { extractFrontmatter, spliceFrontmatter } = require('./frontmatter.cjs');
+
+const RESTART_NOTICE = 'Restart Claude Code to apply effort changes.';
+
+/**
+ * Sync `effort:` frontmatter across all 16 GSD agent files.
+ *
+ * @param {string} cwd - Project root (where .planning/config.json lives).
+ * @param {string} agentsDir - Directory containing gsd-*.md agent files.
+ * @returns {{ changes: Array<{agent: string, effort: string|null}>, skipped?: boolean }}
+ */
+function syncAgentEffortFrontmatter(cwd, agentsDir) {
+  const config = loadConfig(cwd) || {};
+  if (config.runtime && config.runtime !== 'claude') {
+    return { skipped: true, changes: [] };
+  }
+
+  if (!agentsDir || !fs.existsSync(agentsDir)) {
+    return { changes: [] };
+  }
+
+  const changes = [];
+  for (const agentType of Object.keys(EFFORT_PROFILES)) {
+    const agentFile = path.join(agentsDir, `${agentType}.md`);
+    if (!fs.existsSync(agentFile)) continue;
+
+    const content = fs.readFileSync(agentFile, 'utf-8');
+    const fm = extractFrontmatter(content);
+    const existing = (fm.effort !== undefined && fm.effort !== null) ? fm.effort : null;
+    const resolved = resolveEffortInternal(cwd, agentType); // null means omit
+
+    if (existing === resolved) continue; // idempotent short-circuit
+
+    if (resolved === null) {
+      delete fm.effort;
+    } else {
+      fm.effort = resolved;
+    }
+    const newContent = spliceFrontmatter(content, fm);
+    fs.writeFileSync(agentFile, newContent, 'utf-8');
+    changes.push({ agent: agentType, effort: resolved });
+  }
+
+  return { changes };
+}
+
+/**
+ * Returns the canonical restart notice string, or '' when no changes occurred.
+ * Wording is locked by CONTEXT.md §"Restart-required notice UX (Area 4)".
+ */
+function formatRestartNotice(changes) {
+  if (!changes || changes.length === 0) return '';
+  return RESTART_NOTICE;
+}
+
+module.exports = {
+  syncAgentEffortFrontmatter,
+  formatRestartNotice,
+};

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -136,16 +136,16 @@ describe('config-set command', () => {
   });
 
   test('sets a top-level string value', () => {
-    const result = runGsdTools('config-set model_profile quality --json', tmpDir);
+    const result = runGsdTools('config-set mode interactive --json', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
     assert.strictEqual(output.updated, true);
-    assert.strictEqual(output.key, 'model_profile');
-    assert.strictEqual(output.value, 'quality');
+    assert.strictEqual(output.key, 'mode');
+    assert.strictEqual(output.value, 'interactive');
 
     const config = readConfig(tmpDir);
-    assert.strictEqual(config.model_profile, 'quality');
+    assert.strictEqual(config.mode, 'interactive');
   });
 
   test('coerces true to boolean', () => {
@@ -176,12 +176,12 @@ describe('config-set command', () => {
   });
 
   test('preserves plain strings', () => {
-    const result = runGsdTools('config-set model_profile hello', tmpDir);
+    const result = runGsdTools('config-set mode hello', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const config = readConfig(tmpDir);
-    assert.strictEqual(config.model_profile, 'hello');
-    assert.strictEqual(typeof config.model_profile, 'string');
+    assert.strictEqual(config.mode, 'hello');
+    assert.strictEqual(typeof config.mode, 'string');
   });
 
   test('sets nested values via dot-notation', () => {
@@ -902,5 +902,21 @@ describe('Phase 55 — effort sync wiring', () => {
       (result.stderr || result.error || '').includes('Key not found'),
       `expected 'Key not found' error, got stderr=${result.stderr} error=${result.error}`
     );
+  });
+
+  test('EFFSYNC-CONFIG-07: config-set model_profile is rejected and points users to config-set-model-profile', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'claude', model_profile: 'balanced' },
+    });
+    const result = runGsdTools(['config-set', 'model_profile', 'quality'], tmpDir);
+    assert.ok(!result.success, `expected failure, but config-set model_profile succeeded: ${result.output}`);
+    const msg = (result.stderr || result.error || '');
+    assert.ok(
+      msg.includes('config-set-model-profile'),
+      `error should name the correct command, got: ${msg}`
+    );
+    // The key must NOT have been written (value still matches the pre-seeded profile).
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmpDir, '.planning/config.json'), 'utf-8'));
+    assert.strictEqual(cfg.model_profile, 'balanced', 'config must be untouched by rejected set');
   });
 });

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -810,3 +810,97 @@ describe('set-profile effort display and effort_overrides config-set (EFF-04, EF
     );
   });
 });
+
+// ─── Phase 55 — effort sync wiring ───────────────────────────────────────────
+
+describe('Phase 55 — effort sync wiring', () => {
+  let tmpDir;
+  const { createTempProjectWithAgents } = require('./helpers.cjs');
+  afterEach(() => { if (tmpDir) cleanup(tmpDir); });
+
+  test('EFFSYNC-CONFIG-01: config-set-model-profile quality syncs agents and prints restart notice on stderr', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner', 'gsd-executor'], {
+      config: { runtime: 'claude', model_profile: 'balanced' },
+    });
+    const result = runGsdTools(['config-set-model-profile', 'quality'], tmpDir);
+    assert.ok(result.success, `command failed: ${result.error}`);
+    assert.ok(
+      result.stderr.includes('Restart Claude Code to apply effort changes.'),
+      `restart notice missing from stderr: ${result.stderr}`
+    );
+    const planner = fs.readFileSync(path.join(tmpDir, '.claude/agents/gsd-planner.md'), 'utf-8');
+    assert.match(planner, /^effort: max$/m);
+  });
+
+  test('EFFSYNC-CONFIG-02: config-set effort_overrides.gsd-executor low syncs and prints restart notice', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner', 'gsd-executor'], {
+      config: { runtime: 'claude', model_profile: 'quality' },
+    });
+    // First sync to baseline
+    runGsdTools(['config-set-model-profile', 'quality'], tmpDir);
+    const result = runGsdTools(['config-set', 'effort_overrides.gsd-executor', 'low'], tmpDir);
+    assert.ok(result.success, `command failed: ${result.error}`);
+    assert.ok(
+      result.stderr.includes('Restart Claude Code to apply effort changes.'),
+      `restart notice missing: ${result.stderr}`
+    );
+    const executor = fs.readFileSync(path.join(tmpDir, '.claude/agents/gsd-executor.md'), 'utf-8');
+    assert.match(executor, /^effort: low$/m);
+  });
+
+  test('EFFSYNC-CONFIG-03: restart notice is suppressed when no agent changed (idempotent re-set)', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'claude', model_profile: 'quality' },
+    });
+    runGsdTools(['config-set-model-profile', 'quality'], tmpDir); // baseline
+    const result = runGsdTools(['config-set-model-profile', 'quality'], tmpDir); // re-set, no change
+    assert.ok(result.success);
+    assert.ok(
+      !result.stderr.includes('Restart Claude Code'),
+      `restart notice should NOT appear when no changes: stderr was: ${result.stderr}`
+    );
+  });
+
+  test('EFFSYNC-CONFIG-04: config-get model_profile is gated to defaultValue on Copilot runtime', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      // hand-edited copilot config that includes profile keys (the strip must hide them)
+      config: { runtime: 'copilot', model_profile: 'quality', effort_overrides: { 'gsd-executor': 'high' } },
+    });
+    // With --default flag, Copilot consumer gets the default (key treated as not-present)
+    const withDefault = runGsdTools(['config-get', 'model_profile', '--default', 'balanced'], tmpDir);
+    assert.ok(withDefault.success, `expected success with --default, got: ${withDefault.error}`);
+    assert.match(
+      withDefault.output.trim(),
+      /^balanced$/,
+      `expected default 'balanced', got: ${withDefault.output}`
+    );
+    // Without --default, Copilot consumer gets a Key not found error
+    const noDefault = runGsdTools(['config-get', 'model_profile'], tmpDir);
+    assert.ok(!noDefault.success, `expected failure without --default, but command succeeded`);
+    assert.ok(
+      (noDefault.stderr || noDefault.error || '').includes('Key not found'),
+      `expected 'Key not found' error, got stderr=${noDefault.stderr} error=${noDefault.error}`
+    );
+  });
+
+  test('EFFSYNC-CONFIG-05: config-get model_profile returns the actual value on Claude runtime (no regression)', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'claude', model_profile: 'quality' },
+    });
+    const result = runGsdTools(['config-get', 'model_profile'], tmpDir);
+    assert.ok(result.success, `expected success, got: ${result.error}`);
+    assert.match(result.output.trim(), /^quality$/, `expected 'quality', got: ${result.output}`);
+  });
+
+  test('EFFSYNC-CONFIG-06: config-get effort_overrides.gsd-executor is gated on Copilot runtime', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'copilot', effort_overrides: { 'gsd-executor': 'high' } },
+    });
+    const result = runGsdTools(['config-get', 'effort_overrides.gsd-executor'], tmpDir);
+    assert.ok(!result.success, `expected failure on copilot, but command succeeded with output: ${result.output}`);
+    assert.ok(
+      (result.stderr || result.error || '').includes('Key not found'),
+      `expected 'Key not found' error, got stderr=${result.stderr} error=${result.error}`
+    );
+  });
+});

--- a/tests/dispatcher.test.cjs
+++ b/tests/dispatcher.test.cjs
@@ -453,3 +453,52 @@ requirements-completed: [TEST-01]
     assert.deepStrictEqual(parsed.requirements_completed, ['TEST-01'], 'requirements_completed should contain TEST-01');
   });
 });
+
+// ─── sync-agents command (Phase 55) ──────────────────────────────────────────
+
+describe('sync-agents command (Phase 55)', () => {
+  let tmpDir;
+  const { createTempProjectWithAgents } = require('./helpers.cjs');
+  afterEach(() => { if (tmpDir) cleanup(tmpDir); });
+
+  test('EFFSYNC-CLI-01: sync-agents writes effort: frontmatter, prints clean summary on stdout, restart notice on stderr', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'claude', model_profile: 'quality' },
+    });
+    const result = runGsdTools(['sync-agents'], tmpDir);
+    assert.ok(result.success, `command failed: ${result.error}`);
+    const planner = fs.readFileSync(path.join(tmpDir, '.claude/agents/gsd-planner.md'), 'utf-8');
+    assert.match(planner, /^effort: max$/m);
+    // Stdout: clean summary, no restart notice substring
+    assert.ok(
+      result.output.includes('Synced 1 agent'),
+      `expected 'Synced 1 agent' in stdout: ${result.output}`
+    );
+    assert.ok(
+      !result.output.includes('Restart Claude Code'),
+      `restart notice should NOT appear in stdout (one-voice consistency): ${result.output}`
+    );
+    // Stderr: restart notice
+    assert.ok(
+      result.stderr.includes('Restart Claude Code to apply effort changes.'),
+      `restart notice missing from stderr: ${result.stderr}`
+    );
+  });
+
+  test('EFFSYNC-CLI-02: sync-agents reports "already in sync" on second run, no restart notice on stderr', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'claude', model_profile: 'quality' },
+    });
+    runGsdTools(['sync-agents'], tmpDir);
+    const second = runGsdTools(['sync-agents'], tmpDir);
+    assert.ok(second.success);
+    assert.ok(
+      second.output.includes('already in sync') || second.output.includes('Synced 0'),
+      `expected idempotent confirmation: ${second.output}`
+    );
+    assert.ok(
+      !second.stderr.includes('Restart Claude Code'),
+      `restart notice should NOT appear on idempotent run: ${second.stderr}`
+    );
+  });
+});

--- a/tests/effort-sync.test.cjs
+++ b/tests/effort-sync.test.cjs
@@ -1,0 +1,83 @@
+/**
+ * Unit tests for gsd-ng/bin/lib/effort-sync.cjs
+ *
+ * RED STATE: these tests require the `effort-sync.cjs` module which is
+ * created in Plan 02. Running this file BEFORE Plan 02 lands MUST fail with
+ * MODULE_NOT_FOUND — that is the intended Nyquist gate.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const { createTempProjectWithAgents, cleanup } = require('./helpers.cjs');
+const { extractFrontmatter } = require('../gsd-ng/bin/lib/frontmatter.cjs');
+const { syncAgentEffortFrontmatter, formatRestartNotice } = require('../gsd-ng/bin/lib/effort-sync.cjs');
+
+function readEffort(agentFile) {
+  const fm = extractFrontmatter(fs.readFileSync(agentFile, 'utf-8'));
+  return fm.effort !== undefined ? fm.effort : null;
+}
+
+describe('syncAgentEffortFrontmatter', () => {
+  let tmpDir;
+  afterEach(() => { if (tmpDir) cleanup(tmpDir); });
+
+  test('writes effort: frontmatter from quality profile', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner', 'gsd-executor'], {
+      config: { runtime: 'claude', model_profile: 'quality' },
+    });
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    const result = syncAgentEffortFrontmatter(tmpDir, agentsDir);
+    assert.ok(Array.isArray(result.changes), 'changes must be an array');
+    assert.strictEqual(readEffort(path.join(agentsDir, 'gsd-planner.md')), 'max');
+    assert.strictEqual(readEffort(path.join(agentsDir, 'gsd-executor.md')), 'high');
+    assert.strictEqual(result.changes.length, 2);
+  });
+
+  test('removes effort: field when resolver returns null (balanced → inherit)', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'claude', model_profile: 'balanced' },
+    });
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    // Seed an existing effort: field that must be removed
+    const file = path.join(agentsDir, 'gsd-planner.md');
+    const orig = fs.readFileSync(file, 'utf-8');
+    fs.writeFileSync(file, orig.replace(/^---\n/, '---\neffort: high\n'));
+    syncAgentEffortFrontmatter(tmpDir, agentsDir);
+    const after = fs.readFileSync(file, 'utf-8');
+    assert.ok(!/^effort:/m.test(after.split('---')[1] || ''), 'effort field must be removed');
+  });
+
+  test('is idempotent — second call reports no changes', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner', 'gsd-executor'], {
+      config: { runtime: 'claude', model_profile: 'quality' },
+    });
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    syncAgentEffortFrontmatter(tmpDir, agentsDir);
+    const second = syncAgentEffortFrontmatter(tmpDir, agentsDir);
+    assert.strictEqual(second.changes.length, 0, 'second sync must report zero changes');
+  });
+
+  test('skips non-claude runtime and returns skipped: true', () => {
+    tmpDir = createTempProjectWithAgents(['gsd-planner'], {
+      config: { runtime: 'copilot', model_profile: 'quality' },
+    });
+    const agentsDir = path.join(tmpDir, '.claude', 'agents');
+    const result = syncAgentEffortFrontmatter(tmpDir, agentsDir);
+    assert.strictEqual(result.skipped, true);
+    assert.strictEqual(result.changes.length, 0);
+    assert.strictEqual(readEffort(path.join(agentsDir, 'gsd-planner.md')), null);
+  });
+});
+
+describe('formatRestartNotice', () => {
+  test('returns restart notice when changes exist', () => {
+    const msg = formatRestartNotice([{ agent: 'gsd-planner', effort: 'max' }]);
+    assert.strictEqual(msg, 'Restart Claude Code to apply effort changes.');
+  });
+
+  test('returns empty string when no changes', () => {
+    assert.strictEqual(formatRestartNotice([]), '');
+  });
+});

--- a/tests/helpers.cjs
+++ b/tests/helpers.cjs
@@ -69,6 +69,26 @@ function createTempProject() {
   return tmpDir;
 }
 
+// Create temp directory structure with mock .claude/agents/*.md files
+//
+// @param {string[]} [agentNames=['gsd-planner','gsd-executor','gsd-verifier']] - Agent names
+// @param {object} [opts={}] - Options
+// @param {object} [opts.config] - If provided, written to .planning/config.json
+// @returns {string} tmpDir
+function createTempProjectWithAgents(agentNames = ['gsd-planner', 'gsd-executor', 'gsd-verifier'], opts = {}) {
+  const tmpDir = createTempProject();
+  fs.mkdirSync(path.join(tmpDir, '.claude', 'agents'), { recursive: true });
+  for (const name of agentNames) {
+    const content = `---\nname: ${name}\ndescription: Mock agent for tests\ntools: Read, Bash\ncolor: blue\n---\n\n# ${name}\n\nMock body.\n`;
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'agents', `${name}.md`), content, 'utf8');
+  }
+  if (opts.config !== undefined) {
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify(opts.config, null, 2), 'utf8');
+  }
+  return tmpDir;
+}
+
 // Create temp directory with initialized git repo and at least one commit
 //
 // @param {object} [opts={}] - Optional scaffolding options
@@ -213,4 +233,4 @@ function touchSubmodule(workspaceDir, submodulePath) {
   );
 }
 
-module.exports = { runGsdTools, createTempProject, createTempGitProject, cleanup, cleanupSubdir, resolveTmpDir, TOOLS_PATH, createSubmoduleWorkspace, touchSubmodule };
+module.exports = { runGsdTools, createTempProject, createTempProjectWithAgents, createTempGitProject, cleanup, cleanupSubdir, resolveTmpDir, TOOLS_PATH, createSubmoduleWorkspace, touchSubmodule };

--- a/tests/install-js.test.cjs
+++ b/tests/install-js.test.cjs
@@ -1,5 +1,5 @@
 'use strict';
-const { test } = require('node:test');
+const { test, describe, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const { spawnSync } = require('child_process');
 const fs = require('fs');
@@ -1592,4 +1592,60 @@ test('MANIFEST-DISK-01: after single --local claude install, gsd-file-manifest.j
   } finally {
     cleanup(tmpDir);
   }
+});
+
+// ── Phase 55 effort frontmatter sync integration tests ──────────────────────
+
+describe('install.js - Phase 55 effort frontmatter sync', () => {
+  let tmpDir;
+  afterEach(() => { if (tmpDir) cleanup(tmpDir); });
+
+  test('EFFSYNC-INSTALL-01: Claude local install writes effort: max to gsd-planner.md when profile=quality', () => {
+    tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-effsync-install-'));
+    // Pre-seed config so resolveEffortInternal reads a known profile during install
+    const configDir = path.join(tmpDir, '.planning');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(path.join(configDir, 'config.json'), JSON.stringify({
+      runtime: 'claude', model_profile: 'quality',
+    }));
+    const result = spawnSync(process.execPath, [
+      INSTALLER, '--runtime', 'claude', '--local',
+      '--no-seed-permissions-config', '--no-seed-sandbox-config',
+    ], { cwd: tmpDir, encoding: 'utf-8', timeout: 30000 });
+    assert.strictEqual(result.status, 0, `install failed: ${result.stderr}`);
+    const plannerPath = path.join(tmpDir, '.claude', 'agents', 'gsd-planner.md');
+    assert.ok(fs.existsSync(plannerPath), 'gsd-planner.md must be installed');
+    const planner = fs.readFileSync(plannerPath, 'utf-8');
+    assert.match(planner, /^effort: max$/m, 'effort: max must be in frontmatter');
+    // Plan 04 emits the restart notice on stderr when changes occur
+    assert.ok(
+      result.stderr.includes('Restart Claude Code to apply effort changes.'),
+      `restart notice missing from stderr: ${result.stderr}`
+    );
+  });
+
+  test('EFFSYNC-INSTALL-02: Copilot local install does NOT write effort: to any agent file', () => {
+    tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-effsync-copilot-'));
+    const result = spawnSync(process.execPath, [
+      INSTALLER, '--runtime', 'copilot', '--local',
+    ], { cwd: tmpDir, encoding: 'utf-8', timeout: 30000 });
+    assert.strictEqual(result.status, 0, `install failed: ${result.stderr}`);
+    const agentsDir = path.join(tmpDir, '.github', 'agents');
+    assert.ok(fs.existsSync(agentsDir), 'Copilot agents directory must exist');
+    const files = fs.readdirSync(agentsDir).filter(f => f.endsWith('.agent.md'));
+    for (const file of files) {
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf-8');
+      assert.doesNotMatch(content, /^effort:/m, `${file} must not contain effort:`);
+    }
+  });
+
+  test('EFFSYNC-INSTALL-03: Copilot local install does NOT deploy gsd-set-profile skill', () => {
+    tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-effsync-copilot-skill-'));
+    const result = spawnSync(process.execPath, [
+      INSTALLER, '--runtime', 'copilot', '--local',
+    ], { cwd: tmpDir, encoding: 'utf-8', timeout: 30000 });
+    assert.strictEqual(result.status, 0, `install failed: ${result.stderr}`);
+    const setProfileSkill = path.join(tmpDir, '.github', 'skills', 'gsd-set-profile', 'SKILL.md');
+    assert.ok(!fs.existsSync(setProfileSkill), 'gsd-set-profile/SKILL.md must NOT exist for Copilot install');
+  });
 });


### PR DESCRIPTION
## Summary

Closes Phase 51's integration gap: per-agent effort values now actually land in `.claude/agents/*.md` frontmatter. Introduces a new shared helper (`bin/lib/effort-sync.cjs`) that writes resolved effort from three call sites (install, `/gsd:set-profile`, `config-set effort_overrides.*`), plus a new `gsd sync-agents` CLI for manual reconciliation. The profile/effort surface is scoped to Claude Code only — Copilot installs no longer receive the `set-profile` skill or expose profile/effort config keys.

## Changes

- **`gsd-ng/bin/lib/effort-sync.cjs`** (new) — `syncAgentEffortFrontmatter(cwd, agentsDir)` + `formatRestartNotice(changes)`. Canonical restart string lives as `const RESTART_NOTICE` in one place.
- **`bin/install.js`** — `isCopilot` → `isClaudeCode` rename (per-function `const`, positive-form guards only, `getRuntimeLabel(runtime)` extracted). Claude branch runs sync + emits stderr restart notice on real changes. Copilot branch filters `set-profile.md` from skill conversion.
- **`gsd-ng/bin/lib/config.cjs`** — `cmdConfigSetModelProfile` + `cmdConfigSet` (`effort_overrides.*` path) trigger sync + stderr notice. New `cmdConfigGet` gate hides `PROFILE_EFFORT_KEY_PATTERN` keys on `runtime === 'copilot'`.
- **`gsd-ng/bin/gsd-tools.cjs`** — new `gsd sync-agents` top-level command. Clean stdout summary; restart notice via stderr only on real changes.
- **Tests** — 6 new unit tests (effort-sync.test.cjs) + 11 new integration tests (EFFSYNC-INSTALL-01..03, EFFSYNC-CONFIG-01..06, EFFSYNC-CLI-01..02) across install-js / config / dispatcher suites.
- **Helpers** — `createTempProjectWithAgents(agentNames, options)` extension in `tests/helpers.cjs`.

## Test Plan

- [x] \`npm test\`: 1863/1863 passing (up from 1844, +19 new tests)
- [x] End-to-end verification: \`config-set-model-profile quality\` → all 16 agents get \`effort:\` frontmatter matching \`EFFORT_PROFILES\`; stderr emits the canonical restart notice; reverting to \`balanced\` removes the fields symmetrically
- [x] \`sync-agents\` smoke: idempotent run prints clean \`Agents already in sync.\` on stdout, no stderr output
- [x] Zero \`isCopilot\` occurrences in \`bin/install.js\`; zero \`if (!isClaudeCode)\` guard syntax anywhere in source tree
- [ ] Manual: restart Claude Code and confirm a spawned subagent picks up the new effort value (intrinsically unautomatable from inside the harness)

## Related

Closes source todos:
- \`2026-04-19-inject-effort-frontmatter-into-claude-agent-files.md\` (primary spec)
- \`2026-04-02-configure-effort-level-per-subagent-from-gsd-profile.md\` (Phase 51 origin — explicitly closes alongside)

---
*Generated via GSD workflow (phase plan → execute → verify → PR). Verification report: \`.planning/phases/55-claude-only-profile-system-and-effort-frontmatter/55-VERIFICATION.md\` (10/10 must-haves, status: passed).*