### PR TITLE
Phase 54: allowlist-hardening-rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Phase 54 + 54.1 — Allowlist hardening rework (ALLOW-01..22):
+  - `RW_FORMS` frozen-Set export in `allowlist.cjs`; `install.js` and `commands.cjs` consume this canonical source for bare/glob Edit/Write/Read permission forms
+  - `getReadEditWriteAllowRules(platform)` pure function down-converts to bare `Edit/Write/Read` on Linux (workaround for claude-code #16170/#6881) and keeps canonical `Edit(*)/Write(*)/Read(*)` on macOS
+  - `CLI_SUBCOMMANDS` narrowed from blanket `cli repo *` / `cli label *` patterns to explicit two-token verb entries (`view`, `list`, `clone`, `fork`, `create`, etc.) across `gh/glab/fj/tea` — destructive verbs (`delete`, `rename`, `edit`, `archive`) now fall through to prompting
+  - `fj` no longer has `label` permission patterns (corrects Phase 54 ALLOW-14 drift — the `fj` CLI has no `label` subcommand)
+  - `install.js` permission seeding split into independent `allow`/`deny`/`ask` section handlers (`deny`/`ask` infrastructure-ready for future template entries)
+  - `generate-allowlist --platform <linux|darwin>` accepts explicit platform flag; output is set-equal to `install.js --local` seeding per platform
+  - PERM-06 test strengthened to a two-sided contract (canonical forms present AND bare forms absent)
 - Phase 52 — AST safety hook with rule modernization, shared rule templates, install-time injection
 - Phase 47 — CLI output refactor and workflow bash simplification
 - Phase 46 — Discuss-phase gap detection and plan-checker coverage improvements
@@ -27,9 +35,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Branch protection rulesets for main and develop (squash-only, PR required), tag protection for `v*` and `gsd/*`
 
 ### Changed
+- `install.js` permission seeding now emits one log line per section (`Added N allow entries`, `Added N deny rules`, `Added N ask entries`) instead of a single combined `Seeded N permissions` line. The no-op path (`Permissions already up to date`) is unchanged. Any downstream tooling that screen-scrapes installer output will need to adapt.
+- Template `settings-sandbox.json` now ships canonical `Edit(*)/Write(*)/Read(*)` forms; `install.js` down-converts to bare `Edit/Write/Read` on Linux at install time via `getReadEditWriteAllowRules`. Existing user installs keep their previous forms until the Phase 57 `--clean` migration.
+- Windows (`win32`) currently ships canonical glob RW forms (same as macOS) pending Claude Code Windows permission-engine validation. If Windows users hit Linux-style permission warnings, this will be revisited.
 - Deduplicated AST safety rules into single template
 - Wired `defaults.cjs` into config, core, init, verify, workspace modules
 - Removed stale Windows references and guards
+
+### Removed
+- `install.js --config-dir` / `-c` CLI flag removed (quick task 260422-jai). Custom config directories are still supported via the `CLAUDE_CONFIG_DIR` / `COPILOT_CONFIG_DIR` environment variables. Users with `--config-dir` in install scripts must switch to the env-var form.
 
 ### Fixed
 - Debug session false positive and create-pr collision guard

--- a/bin/install.js
+++ b/bin/install.js
@@ -17,7 +17,7 @@ const reset = '\x1b[0m';
 // Get version from package.json
 const pkg = require('../package.json');
 const { processTemplate, buildContext, injectAppendToFile, fillBetweenMarkers } = require('../gsd-ng/bin/lib/template-processor.cjs');
-const { getPlatformCliPatterns, PLATFORM_TO_CLI } = require(path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'allowlist.cjs'));
+const { getPlatformCliPatterns, PLATFORM_TO_CLI, getReadEditWriteAllowRules, RW_FORMS } = require(path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'allowlist.cjs'));
 const { syncAgentEffortFrontmatter, formatRestartNotice } = require(path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'effort-sync.cjs'));
 
 // Parse args
@@ -107,18 +107,13 @@ function getConfigDirFromHome(rt, isGlobal) {
 /**
  * Get the global config directory
  * @param {string} rt - Runtime ('claude' or 'copilot')
- * @param {string|null} explicitDir - Explicit directory from --config-dir flag
  */
-function getGlobalDir(rt, explicitDir = null) {
+function getGlobalDir(rt) {
   if (rt === 'copilot') {
-    if (explicitDir) return expandTilde(explicitDir);
     if (process.env.COPILOT_CONFIG_DIR) return expandTilde(process.env.COPILOT_CONFIG_DIR);
     return path.join(os.homedir(), '.copilot');
   }
-  // Claude Code: --config-dir > CLAUDE_CONFIG_DIR > ~/.claude
-  if (explicitDir) {
-    return expandTilde(explicitDir);
-  }
+  // Claude Code: CLAUDE_CONFIG_DIR > ~/.claude
   if (process.env.CLAUDE_CONFIG_DIR) {
     return expandTilde(process.env.CLAUDE_CONFIG_DIR);
   }
@@ -145,31 +140,6 @@ function buildBanner(version) {
   '  development system for Claude Code.\n';
 }
 
-// Parse --config-dir argument
-function parseConfigDirArg() {
-  const configDirIndex = args.findIndex(arg => arg === '--config-dir' || arg === '-c');
-  if (configDirIndex !== -1) {
-    const nextArg = args[configDirIndex + 1];
-    // Error if --config-dir is provided without a value or next arg is another flag
-    if (!nextArg || nextArg.startsWith('-')) {
-      console.error(`  ${yellow}--config-dir requires a path argument${reset}`);
-      process.exit(1);
-    }
-    return nextArg;
-  }
-  // Also handle --config-dir=value format
-  const configDirArg = args.find(arg => arg.startsWith('--config-dir=') || arg.startsWith('-c='));
-  if (configDirArg) {
-    const value = configDirArg.split('=')[1];
-    if (!value) {
-      console.error(`  ${yellow}--config-dir requires a non-empty path${reset}`);
-      process.exit(1);
-    }
-    return value;
-  }
-  return null;
-}
-const explicitConfigDir = parseConfigDirArg();
 const hasHelp = args.includes('--help') || args.includes('-h');
 const forceStatusline = args.includes('--force-statusline');
 
@@ -233,7 +203,7 @@ if (hasUninstall) {
 
 // Show help if requested
 if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx gsd-ng [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}                       Install globally (to ~/.claude)\n    ${cyan}-l, --local${reset}                        Install locally (to current directory)\n    ${cyan}-u, --uninstall${reset}                    Uninstall GSD (requires --global or --local)\n    ${cyan}-c, --config-dir <path>${reset}            Specify custom config directory\n    ${cyan}-h, --help${reset}                         Show this help message\n    ${cyan}--force-statusline${reset}                 Replace existing statusline config\n    ${cyan}--snapshot${reset}                         Force +hash build metadata in VERSION (auto-detected on non-tag commits)\n    ${cyan}--no-seed-permissions-config${reset}       Skip permissions.allow seeding\n    ${cyan}--no-seed-sandbox-config${reset}           Skip sandbox.enabled seeding (permissions still seeded)\n    ${cyan}--runtime <runtime>${reset}                Select runtime: claude or copilot (REQUIRED for non-interactive)\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx gsd-ng\n\n    ${dim}# Install Claude runtime globally${reset}\n    npx gsd-ng --runtime claude --global\n\n    ${dim}# Install Claude runtime to current project only${reset}\n    npx gsd-ng --runtime claude --local\n\n    ${dim}# Install for GitHub Copilot CLI (local)${reset}\n    npx gsd-ng --runtime copilot --local\n\n    ${dim}# Install for GitHub Copilot CLI (global)${reset}\n    npx gsd-ng --runtime copilot --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx gsd-ng --runtime claude --global --config-dir ~/.claude-work\n\n    ${dim}# Uninstall GSD globally${reset}\n    npx gsd-ng --runtime claude --global --uninstall\n\n    ${dim}# Uninstall Copilot CLI runtime globally${reset}\n    npx gsd-ng --runtime copilot --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over the CLAUDE_CONFIG_DIR environment variable.\n    Sandbox mode is enabled by default. Use --no-seed-sandbox-config to skip it.\n`);
+  console.log(`  ${yellow}Usage:${reset} npx gsd-ng [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}                       Install globally (to ~/.claude)\n    ${cyan}-l, --local${reset}                        Install locally (to current directory)\n    ${cyan}-u, --uninstall${reset}                    Uninstall GSD (requires --global or --local)\n    ${cyan}-h, --help${reset}                         Show this help message\n    ${cyan}--force-statusline${reset}                 Replace existing statusline config\n    ${cyan}--snapshot${reset}                         Force +hash build metadata in VERSION (auto-detected on non-tag commits)\n    ${cyan}--no-seed-permissions-config${reset}       Skip permissions.allow seeding\n    ${cyan}--no-seed-sandbox-config${reset}           Skip sandbox.enabled seeding (permissions still seeded)\n    ${cyan}--runtime <runtime>${reset}                Select runtime: claude or copilot (REQUIRED for non-interactive)\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx gsd-ng\n\n    ${dim}# Install Claude runtime globally${reset}\n    npx gsd-ng --runtime claude --global\n\n    ${dim}# Install Claude runtime to current project only${reset}\n    npx gsd-ng --runtime claude --local\n\n    ${dim}# Install for GitHub Copilot CLI (local)${reset}\n    npx gsd-ng --runtime copilot --local\n\n    ${dim}# Install for GitHub Copilot CLI (global)${reset}\n    npx gsd-ng --runtime copilot --global\n\n    ${dim}# Uninstall GSD globally${reset}\n    npx gsd-ng --runtime claude --global --uninstall\n\n    ${dim}# Uninstall Copilot CLI runtime globally${reset}\n    npx gsd-ng --runtime copilot --global --uninstall\n\n  ${yellow}Notes:${reset}\n    Sandbox mode is enabled by default. Use --no-seed-sandbox-config to skip it.\n`);
   process.exit(0);
 }
 
@@ -292,7 +262,7 @@ function getCommitAttribution() {
   }
 
   // Claude Code: read attribution from settings.json
-  const settings = readSettings(path.join(getGlobalDir(runtime, explicitConfigDir), 'settings.json'));
+  const settings = readSettings(path.join(getGlobalDir(runtime), 'settings.json'));
   let result;
   if (!settings.attribution || settings.attribution.commit === undefined) {
     result = undefined;
@@ -382,7 +352,7 @@ function uninstall(isGlobal) {
 
   // Get the target directory based on install type
   const targetDir = isGlobal
-    ? getGlobalDir(runtime, explicitConfigDir)
+    ? getGlobalDir(runtime)
     : path.join(process.cwd(), dirName);
 
   const locationLabel = isGlobal
@@ -1099,7 +1069,7 @@ function install(isGlobal) {
 
   // Get the target directory based on install type
   const targetDir = isGlobal
-    ? getGlobalDir(runtime, explicitConfigDir)
+    ? getGlobalDir(runtime)
     : path.join(process.cwd(), dirName);
 
   const locationLabel = isGlobal
@@ -1467,14 +1437,21 @@ function install(isGlobal) {
       console.log(`  ${green}✓${reset} Configured bash command safety hook`);
     }
 
-    // Seed permissions.allow from settings-sandbox.json template
+    // Seed permissions.allow/deny/ask from settings-sandbox.json template (three-section sync)
     if (!noSeedPermissionsConfig) {
       const sandboxTemplatePath = path.join(src, 'gsd-ng', 'templates', 'settings-sandbox.json');
       try {
         const sandboxTemplate = JSON.parse(fs.readFileSync(sandboxTemplatePath, 'utf8'));
-        const templateEntries = sandboxTemplate.permissions?.allow ?? [];
 
-        // Detect platform CLIs dynamically
+        // Effective platform (override via GSD_TEST_FORCE_PLATFORM for test harnesses — test-only seam)
+        const seedPlatform = process.env.GSD_TEST_FORCE_PLATFORM || process.platform;
+
+        // -- Build templateAllow with platform-aware Read/Edit/Write forms --
+        const rawTemplateAllow = sandboxTemplate.permissions?.allow ?? [];
+        const baseTemplateAllow = rawTemplateAllow.filter(e => !RW_FORMS.has(e));
+        const platformRw = getReadEditWriteAllowRules(seedPlatform);
+
+        // Dynamic CLI entries (platform detection via which + .planning/config.json)
         const platformCLIs = ['gh', 'glab', 'fj', 'tea'];
         const dynamicEntries = [];
         for (const cli of platformCLIs) {
@@ -1485,16 +1462,13 @@ function install(isGlobal) {
             // CLI not installed — skip
           }
         }
-
-        // Also check .planning/config.json for configured platform
         const configPath = path.join(process.cwd(), '.planning', 'config.json');
         try {
           if (fs.existsSync(configPath)) {
             const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
             const platform = config.git?.platform;
             if (platform && PLATFORM_TO_CLI[platform]) {
-              const cliPatterns = getPlatformCliPatterns(PLATFORM_TO_CLI[platform]);
-              for (const entry of cliPatterns) {
+              for (const entry of getPlatformCliPatterns(PLATFORM_TO_CLI[platform])) {
                 if (!dynamicEntries.includes(entry)) dynamicEntries.push(entry);
               }
             }
@@ -1503,17 +1477,38 @@ function install(isGlobal) {
           // config.json missing or unparseable — skip
         }
 
-        // Non-destructive merge: add missing entries, keep existing
-        const allNewEntries = [...templateEntries, ...dynamicEntries];
-        const existingAllow = settings.permissions?.allow ?? [];
-        const entriesToAdd = allNewEntries.filter(e => !existingAllow.includes(e));
+        const templateAllow = [...baseTemplateAllow, ...platformRw, ...dynamicEntries];
+        const templateDeny  = sandboxTemplate.permissions?.deny ?? [];
+        const templateAsk   = sandboxTemplate.permissions?.ask  ?? [];
 
-        if (entriesToAdd.length > 0) {
+        // -- Three-section union-only sync helper --
+        const syncSection = (existing, templateEntries) => {
+          const existingSet = new Set(existing);
+          const toAdd = templateEntries.filter(e => !existingSet.has(e));
+          return { merged: [...existing, ...toAdd], added: toAdd.length };
+        };
+
+        const existingAllow = settings.permissions?.allow ?? [];
+        const existingDeny  = settings.permissions?.deny  ?? [];
+        const existingAsk   = settings.permissions?.ask   ?? [];
+
+        const allowResult = syncSection(existingAllow, templateAllow);
+        const denyResult  = syncSection(existingDeny,  templateDeny);
+        const askResult   = syncSection(existingAsk,   templateAsk);
+
+        // -- Apply merged results --
+        if (allowResult.added > 0 || denyResult.added > 0 || askResult.added > 0) {
           if (!settings.permissions) settings.permissions = {};
-          if (!settings.permissions.allow) settings.permissions.allow = [];
-          settings.permissions.allow.push(...entriesToAdd);
-          console.log(`  ${green}✓${reset} Seeded ${entriesToAdd.length} permissions`);
-        } else {
+          if (allowResult.added > 0) settings.permissions.allow = allowResult.merged;
+          if (denyResult.added  > 0) settings.permissions.deny  = denyResult.merged;
+          if (askResult.added   > 0) settings.permissions.ask   = askResult.merged;
+        }
+
+        // -- Per-section logging --
+        if (allowResult.added > 0) console.log(`  ${green}✓${reset} Added ${allowResult.added} allow entries`);
+        if (denyResult.added  > 0) console.log(`  ${green}✓${reset} Added ${denyResult.added} deny rules`);
+        if (askResult.added   > 0) console.log(`  ${green}✓${reset} Added ${askResult.added} ask entries`);
+        if (allowResult.added === 0 && denyResult.added === 0 && askResult.added === 0) {
           console.log(`  ${green}✓${reset} Permissions already up to date`);
         }
       } catch {
@@ -1839,7 +1834,7 @@ function promptLocation(callback) {
     }
   });
 
-  const globalPath = getGlobalDir(runtime, explicitConfigDir).replace(os.homedir(), '~');
+  const globalPath = getGlobalDir(runtime).replace(os.homedir(), '~');
   const localPath = './' + getDirName(runtime);
 
   console.log(`  ${yellow}Where would you like to install?${reset}\n\n  ${cyan}1${reset}) Global ${dim}(${globalPath})${reset} - available in all projects\n  ${cyan}2${reset}) Local  ${dim}(${localPath})${reset} - this project only\n`);
@@ -1856,9 +1851,6 @@ function promptLocation(callback) {
 // Main logic
 if (hasGlobal && hasLocal) {
   console.error(`  ${yellow}Cannot specify both --global and --local${reset}`);
-  process.exit(1);
-} else if (explicitConfigDir && hasLocal) {
-  console.error(`  ${yellow}Cannot use --config-dir with --local${reset}`);
   process.exit(1);
 } else if (hasUninstall) {
   if (!hasGlobal && !hasLocal) {

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -1564,7 +1564,9 @@ async function main() {
     }
 
     case 'generate-allowlist': {
-      commands.cmdGenerateAllowlist(cwd);
+      const platformIdx = args.indexOf('--platform');
+      const platformFlag = platformIdx >= 0 ? args[platformIdx + 1] : undefined;
+      commands.cmdGenerateAllowlist(cwd, platformFlag || process.platform);
       break;
     }
 

--- a/gsd-ng/bin/lib/allowlist.cjs
+++ b/gsd-ng/bin/lib/allowlist.cjs
@@ -4,14 +4,48 @@
  * Per-CLI subcommand mappings. Each CLI gets granular subcommand patterns
  * instead of blanket Bash(cli *) wildcards.
  *
+ * Phase 54.1 narrowing (ALLOW-21, ALLOW-22):
+ *   - gh repo:   view, list, clone, fork, create, sync, set-default (excludes delete, rename, edit, archive, etc.)
+ *   - gh label:  list, create, clone                                (excludes delete, edit)
+ *   - glab:      mirrors gh minus missing verbs (no sync/set-default; no label clone)
+ *   - fj:        mirrors gh minus missing verbs (no repo list; NO label subcommand exists at all — corrects Phase 54 ALLOW-14 drift)
+ *   - tea:       mirrors gh minus missing verbs (no repo view, no repo clone; retains 'repos'/'labels' plural aliases)
+ *
+ * Existing users keep their broader Bash(<cli> repo *) / Bash(<cli> label *) entries
+ * until Phase 57 delivers the --clean / manifest migration mechanism (Option B conservative).
+ *
+ * Multi-word entries (e.g. 'repo view') are emitted by getPlatformCliPatterns
+ * as literal Bash(gh repo view *) / Bash(gh repo view) permission rules — the
+ * template literal handles multi-word tokens via string substitution with no
+ * splitting or quoting.
+ *
  * NOT allowlisted: gh api, glab api (fall through to prompting),
- *                  gh extension (arbitrary code execution risk)
+ *                  gh extension (arbitrary code execution risk),
+ *                  ssh-key, gpg-key, config (account-modifying),
+ *                  any repo/label delete/rename/edit/archive verb.
  */
 const CLI_SUBCOMMANDS = {
-  gh:   ['pr', 'issue', 'release', 'workflow', 'auth', 'repo', 'search'],
-  glab: ['mr', 'issue', 'release', 'ci', 'auth', 'repo'],
-  fj:   ['pr', 'issue', 'release', 'actions', 'auth', 'repo'],
-  tea:  ['pr', 'pulls', 'issue', 'issues', 'release', 'releases', 'login', 'repo', 'repos', 'actions'],
+  gh: [
+    'pr', 'issue', 'release', 'workflow', 'auth', 'search', 'run', 'status',
+    'repo view', 'repo list', 'repo clone', 'repo fork', 'repo create', 'repo sync', 'repo set-default',
+    'label list', 'label create', 'label clone',
+  ],
+  glab: [
+    'mr', 'issue', 'release', 'ci', 'auth',
+    'repo view', 'repo list', 'repo clone', 'repo fork', 'repo create',
+    'label list', 'label create',
+  ],
+  fj: [
+    'pr', 'issue', 'release', 'actions', 'auth',
+    'repo view', 'repo clone', 'repo fork', 'repo create',
+    // NOTE: fj has no 'label' subcommand — intentionally empty (corrects Phase 54 ALLOW-14 drift)
+  ],
+  tea: [
+    'pr', 'pulls', 'issue', 'issues', 'release', 'releases', 'login', 'actions',
+    'repo list', 'repo create', 'repo fork',
+    'label list', 'label create',
+    'repos', 'labels',  // retained plural aliases (broad) — Phase 57 candidate to narrow
+  ],
 };
 
 /**
@@ -51,9 +85,48 @@ function getAllPlatformCliPatterns() {
  */
 const PLATFORM_TO_CLI = { github: 'gh', gitlab: 'glab', forgejo: 'fj', gitea: 'tea' };
 
+/**
+ * RW_FORMS — canonical Read/Edit/Write permission forms — both bare and glob.
+ * Exported as a frozen Set so install.js and commands.cjs can strip these
+ * from template entries before injecting the platform-appropriate form.
+ * Single source of truth — see ALLOW-19.
+ */
+const RW_FORMS = Object.freeze(new Set([
+  'Edit', 'Write', 'Read',
+  'Edit(*)', 'Write(*)', 'Read(*)',
+]));
+
+/**
+ * Return the Read/Edit/Write allow entries appropriate for the target platform.
+ *
+ * - Linux → bare forms ['Edit', 'Write', 'Read']
+ *   Workaround for anthropics/claude-code #16170 and #6881: the Linux
+ *   permission engine mishandles certain glob-qualified permission rules
+ *   (Edit(*), Write(*), Read(*)) and produces startup warnings or
+ *   unexpected prompts. Bare forms are the stable Linux workaround.
+ *
+ * - darwin / win32 / unknown → canonical glob forms ['Edit(*)', 'Write(*)', 'Read(*)']
+ *   Canonical macOS form. Windows defaults to canonical pending CC Windows
+ *   permission engine research (TODO: revisit if CC behavior is confirmed).
+ *
+ * Pure function — no I/O, no module state. Returns a fresh array on every
+ * call so callers can mutate without leaking into shared state.
+ *
+ * @param {string} platform  process.platform value ('linux', 'darwin', 'win32', ...)
+ * @returns {string[]}       array of permission rule strings (length 3)
+ */
+function getReadEditWriteAllowRules(platform) {
+  if (platform === 'linux') {
+    return ['Edit', 'Write', 'Read'];
+  }
+  return ['Edit(*)', 'Write(*)', 'Read(*)'];
+}
+
 module.exports = {
   CLI_SUBCOMMANDS,
   PLATFORM_TO_CLI,
+  RW_FORMS,
   getPlatformCliPatterns,
   getAllPlatformCliPatterns,
+  getReadEditWriteAllowRules,
 };

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -9,7 +9,7 @@ const { safeReadFile, loadConfig, isGitIgnored, execGit, normalizePhaseName, com
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { MODEL_PROFILES, EFFORT_PROFILES } = require('./model-profiles.cjs');
 const { validatePath, scanForInjection, wrapUntrustedContent, logSecurityEvent } = require('./security.cjs');
-const { getPlatformCliPatterns, PLATFORM_TO_CLI } = require('./allowlist.cjs');
+const { getPlatformCliPatterns, PLATFORM_TO_CLI, getReadEditWriteAllowRules, RW_FORMS } = require('./allowlist.cjs');
 
 function cmdGenerateSlug(text) {
   if (!text) {
@@ -3353,31 +3353,30 @@ function cmdBreakoutCheck(cwd, args) {
   output(detection, detection.status);
 }
 
-function cmdGenerateAllowlist(cwd) {
+function cmdGenerateAllowlist(cwd, platform = process.platform) {
   // 1. Load static template as baseline
   const templatePath = path.join(__dirname, '..', '..', 'templates', 'settings-sandbox.json');
   let template;
   try {
     template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
   } catch (e) {
-    // Fallback if template not found (installed copy might differ)
     template = {
       sandbox: { enabled: true, autoAllowBashIfSandboxed: true },
       permissions: { allow: [] }
     };
   }
 
-  const staticEntries = new Set(template.permissions?.allow || []);
+  // 2. Strip bare + canonical Read/Edit/Write from template — we append
+  //    the platform-appropriate form below, matching install.js behavior.
+  //    Uses RW_FORMS (frozen Set) from allowlist.cjs — single source of truth (ALLOW-19).
+  const baseStatic = (template.permissions?.allow || []).filter(e => !RW_FORMS.has(e));
+  const staticEntries = new Set(baseStatic);
 
-  // 2. Add config-derived entries
+  // 3. Add platform-aware Read/Edit/Write forms
+  for (const e of getReadEditWriteAllowRules(platform)) staticEntries.add(e);
+
+  // 4. Dynamic CLI entries (platform detection via which + config-derived)
   const dynamicEntries = new Set();
-
-  // SSH tools (needed by Phase 16 SSH pre-push check in execute-phase workflow)
-  dynamicEntries.add('Bash(ssh-add *)');
-  dynamicEntries.add('Bash(ssh-keygen *)');
-
-  // Platform CLI tools (from Phase 13 PR creation and import-issue workflows)
-  // These are optional — only add if the platform CLI is installed
   const platformCLIs = ['gh', 'glab', 'fj', 'tea'];
   for (const cli of platformCLIs) {
     try {
@@ -3393,24 +3392,24 @@ function cmdGenerateAllowlist(cwd) {
   try {
     if (fs.existsSync(configPath)) {
       const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-      // If a specific platform is configured, ensure its CLI is in the allowlist
-      const platform = config.git?.platform;
-      if (platform && PLATFORM_TO_CLI[platform]) {
-        for (const p of getPlatformCliPatterns(PLATFORM_TO_CLI[platform])) dynamicEntries.add(p);
+      const platformName = config.git?.platform;
+      if (platformName && PLATFORM_TO_CLI[platformName]) {
+        for (const p of getPlatformCliPatterns(PLATFORM_TO_CLI[platformName])) {
+          dynamicEntries.add(p);
+        }
       }
     }
   } catch {}
 
-  // 3. Merge static + dynamic, sort for consistency
+  // 5. Merge static + dynamic, sort for consistency
   const allEntries = [...new Set([...staticEntries, ...dynamicEntries])].sort();
 
-  // 4. Build output JSON
+  // 6. Build output JSON
   const result = {
     sandbox: template.sandbox || { enabled: true, autoAllowBashIfSandboxed: true },
     permissions: { allow: allEntries }
   };
 
-  // 5. Output
   output(result);
 }
 

--- a/gsd-ng/templates/settings-sandbox.json
+++ b/gsd-ng/templates/settings-sandbox.json
@@ -57,9 +57,9 @@
       "Bash(local *)",
       "Bash(export *)",
       "Agent(*)",
-      "Edit",
-      "Write",
-      "Read",
+      "Edit(*)",
+      "Write(*)",
+      "Read(*)",
       "Skill(gsd:*)",
       "WebFetch(*)",
       "WebSearch(*)"

--- a/tests/allowlist.test.cjs
+++ b/tests/allowlist.test.cjs
@@ -6,16 +6,18 @@ const path = require('node:path');
 const {
   getPlatformCliPatterns,
   getAllPlatformCliPatterns,
+  getReadEditWriteAllowRules,
   CLI_SUBCOMMANDS,
   PLATFORM_TO_CLI,
+  RW_FORMS,
 } = require(path.resolve(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'allowlist.cjs'));
 
-// ── ALLOW-01: getPlatformCliPatterns('gh') returns patterns for all 7 subcommands ──
+// ── ALLOW-01: getPlatformCliPatterns('gh') returns patterns for all 18 narrowed subcommands (post-54.1) ──
 
-describe('ALLOW-01: getPlatformCliPatterns(gh) returns patterns for all 7 subcommands', () => {
-  test('returns 14 patterns (2 per subcommand x 7 subcommands)', () => {
+describe('ALLOW-01: getPlatformCliPatterns(gh) returns patterns for all 18 narrowed subcommands (post-54.1)', () => {
+  test('returns 36 patterns (2 per subcommand x 18 subcommands: 8 single-token + 7 repo two-token + 3 label two-token)', () => {
     const patterns = getPlatformCliPatterns('gh');
-    assert.strictEqual(patterns.length, 14, `Expected 14 patterns, got ${patterns.length}`);
+    assert.strictEqual(patterns.length, 36, 'Expected 36 patterns (2 per subcommand x 18 subcommands)');
   });
 
   test('includes Bash(gh pr *) and Bash(gh pr)', () => {
@@ -48,16 +50,22 @@ describe('ALLOW-01: getPlatformCliPatterns(gh) returns patterns for all 7 subcom
     assert.ok(patterns.includes('Bash(gh auth)'), 'Missing Bash(gh auth)');
   });
 
-  test('includes Bash(gh repo *) and Bash(gh repo)', () => {
-    const patterns = getPlatformCliPatterns('gh');
-    assert.ok(patterns.includes('Bash(gh repo *)'), 'Missing Bash(gh repo *)');
-    assert.ok(patterns.includes('Bash(gh repo)'), 'Missing Bash(gh repo)');
-  });
-
   test('includes Bash(gh search *) and Bash(gh search)', () => {
     const patterns = getPlatformCliPatterns('gh');
     assert.ok(patterns.includes('Bash(gh search *)'), 'Missing Bash(gh search *)');
     assert.ok(patterns.includes('Bash(gh search)'), 'Missing Bash(gh search)');
+  });
+
+  test('includes Bash(gh run *) and Bash(gh run)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(patterns.includes('Bash(gh run *)'), 'Missing Bash(gh run *)');
+    assert.ok(patterns.includes('Bash(gh run)'), 'Missing Bash(gh run)');
+  });
+
+  test('includes Bash(gh status *) and Bash(gh status)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(patterns.includes('Bash(gh status *)'), 'Missing Bash(gh status *)');
+    assert.ok(patterns.includes('Bash(gh status)'), 'Missing Bash(gh status)');
   });
 });
 
@@ -115,9 +123,13 @@ describe('ALLOW-03: getPlatformCliPatterns(tea) returns patterns for canonical a
     assert.ok(patterns.includes('Bash(tea releases *)'), 'Missing Bash(tea releases *)');
   });
 
-  test('includes Bash(tea repo *) canonical form', () => {
+  test('includes narrowed two-token tea repo forms (post-54.1: no bare tea repo * — use repo list/create/fork)', () => {
     const patterns = getPlatformCliPatterns('tea');
-    assert.ok(patterns.includes('Bash(tea repo *)'), 'Missing Bash(tea repo *)');
+    // bare Bash(tea repo *) is gone — narrowed to two-token verbs
+    assert.ok(!patterns.includes('Bash(tea repo *)'), 'Broad Bash(tea repo *) must NOT be present post-narrowing');
+    assert.ok(patterns.includes('Bash(tea repo list *)'), 'Missing Bash(tea repo list *)');
+    assert.ok(patterns.includes('Bash(tea repo create *)'), 'Missing Bash(tea repo create *)');
+    assert.ok(patterns.includes('Bash(tea repo fork *)'), 'Missing Bash(tea repo fork *)');
   });
 
   test('includes Bash(tea repos *) alias form', () => {
@@ -232,5 +244,226 @@ describe('ALLOW-07: every pattern starts with Bash( and ends with )', () => {
         assert.ok(p.endsWith(')'), `${cli} pattern "${p}" must end with )`);
       }
     }
+  });
+});
+
+// ── ALLOW-14+ALLOW-21+ALLOW-22: CLI_SUBCOMMANDS narrowed verbs (post-54.1) ──
+
+describe('ALLOW-14+ALLOW-21+ALLOW-22: CLI_SUBCOMMANDS narrowed verbs (post-54.1)', () => {
+  test('gh has 18 subcommands: 8 single-token + 7 repo two-token + 3 label two-token', () => {
+    assert.strictEqual(CLI_SUBCOMMANDS.gh.length, 18);
+    assert.ok(CLI_SUBCOMMANDS.gh.includes('run'));
+    assert.ok(CLI_SUBCOMMANDS.gh.includes('status'));
+    assert.ok(CLI_SUBCOMMANDS.gh.includes('search'));
+    assert.ok(!CLI_SUBCOMMANDS.gh.includes('repo'), 'bare repo removed (narrowed)');
+    assert.ok(!CLI_SUBCOMMANDS.gh.includes('label'), 'bare label removed (narrowed)');
+  });
+  test('glab has narrowed verbs mirroring gh minus missing', () => {
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('repo'), 'glab bare repo removed');
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('label'), 'glab bare label removed');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('repo view'));
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('label create'));
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('repo sync'), 'glab has no sync');
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('label clone'), 'glab has no label-clone');
+  });
+  test('fj has no label subcommand (corrects Phase 54 ALLOW-14 drift — fj has no label CLI command)', () => {
+    assert.ok(!CLI_SUBCOMMANDS.fj.includes('label'), 'fj bare label removed');
+    assert.ok(!CLI_SUBCOMMANDS.fj.some(s => s.startsWith('label')), 'fj has NO label-prefixed entry of any form');
+    assert.ok(!CLI_SUBCOMMANDS.fj.includes('repo list'), 'fj repo has no list verb');
+    assert.ok(CLI_SUBCOMMANDS.fj.includes('repo view'));
+  });
+  test('tea retains plural aliases alongside narrowed two-token verbs', () => {
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('repos'), 'tea retains repos plural alias');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('labels'), 'tea retains labels plural alias');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('repo list'));
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('label create'));
+    assert.ok(!CLI_SUBCOMMANDS.tea.includes('repo view'), 'tea has no view verb');
+    assert.ok(!CLI_SUBCOMMANDS.tea.includes('repo clone'), 'tea has no clone verb');
+  });
+  test('gh run stays broad (Bash(gh run *) auto-approved — no narrowing to list/view/watch)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(patterns.includes('Bash(gh run *)'), 'broad Bash(gh run *) expected');
+    assert.ok(!patterns.includes('Bash(gh run list *)'), 'narrow run list form must not leak in');
+  });
+  test('broad Bash(gh repo *) and Bash(gh label *) narrowed away (flipped from Phase 54)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(!patterns.includes('Bash(gh repo *)'), 'broad Bash(gh repo *) MUST be absent post-narrowing');
+    assert.ok(!patterns.includes('Bash(gh label *)'), 'broad Bash(gh label *) MUST be absent post-narrowing');
+    assert.ok(patterns.includes('Bash(gh repo view *)'), 'narrowed Bash(gh repo view *) present');
+    assert.ok(patterns.includes('Bash(gh label create *)'), 'narrowed Bash(gh label create *) present');
+  });
+});
+
+// ── ALLOW-04: getReadEditWriteAllowRules('linux') returns bare forms ──
+
+describe('ALLOW-04: getReadEditWriteAllowRules(linux) returns bare forms', () => {
+  test('returns [Edit, Write, Read] in that order', () => {
+    assert.deepStrictEqual(getReadEditWriteAllowRules('linux'), ['Edit', 'Write', 'Read']);
+  });
+});
+
+// ── ALLOW-05: getReadEditWriteAllowRules(darwin/win32) returns canonical forms ──
+
+describe('ALLOW-05: getReadEditWriteAllowRules(darwin) returns canonical forms', () => {
+  test('darwin returns [Edit(*), Write(*), Read(*)]', () => {
+    assert.deepStrictEqual(getReadEditWriteAllowRules('darwin'), ['Edit(*)', 'Write(*)', 'Read(*)']);
+  });
+  test('win32 defaults to canonical form pending CC Win32 research', () => {
+    assert.deepStrictEqual(getReadEditWriteAllowRules('win32'), ['Edit(*)', 'Write(*)', 'Read(*)']);
+  });
+  test('unknown platform string defaults to canonical form', () => {
+    assert.deepStrictEqual(getReadEditWriteAllowRules('freebsd'), ['Edit(*)', 'Write(*)', 'Read(*)']);
+  });
+});
+
+// ── ALLOW-06: getReadEditWriteAllowRules is pure (no I/O, fresh array each call) ──
+
+describe('ALLOW-06: getReadEditWriteAllowRules is a pure function', () => {
+  test('exported as a function from allowlist.cjs', () => {
+    assert.strictEqual(typeof getReadEditWriteAllowRules, 'function');
+  });
+  test('returns fresh array on each call (callers can mutate without leaking into module state)', () => {
+    const a = getReadEditWriteAllowRules('linux');
+    const b = getReadEditWriteAllowRules('linux');
+    assert.deepStrictEqual(a, b);
+    assert.notStrictEqual(a, b, 'Each call must return a new array instance');
+  });
+});
+
+// ── ALLOW-21: gh label narrowing + glab/fj/tea mirrors ──
+
+describe('ALLOW-21: gh label narrowed — no bare label entry; two-token verbs present', () => {
+  test('gh has no bare label entry', () => {
+    assert.ok(!CLI_SUBCOMMANDS.gh.includes('label'), 'gh must NOT have bare label entry — use label list/create/clone');
+  });
+  test('gh has label list, label create, label clone two-token entries', () => {
+    assert.ok(CLI_SUBCOMMANDS.gh.includes('label list'), 'gh must include label list');
+    assert.ok(CLI_SUBCOMMANDS.gh.includes('label create'), 'gh must include label create');
+    assert.ok(CLI_SUBCOMMANDS.gh.includes('label clone'), 'gh must include label clone');
+  });
+  test('getPlatformCliPatterns(gh) includes Bash(gh label list *) and Bash(gh label create *)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(patterns.includes('Bash(gh label list *)'), 'Missing Bash(gh label list *)');
+    assert.ok(patterns.includes('Bash(gh label create *)'), 'Missing Bash(gh label create *)');
+    assert.ok(patterns.includes('Bash(gh label clone *)'), 'Missing Bash(gh label clone *)');
+  });
+  test('getPlatformCliPatterns(gh) does NOT include broad Bash(gh label *)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(!patterns.includes('Bash(gh label *)'), 'Broad Bash(gh label *) must NOT be present — narrowed to two-token verbs');
+  });
+  test('glab has no bare label entry; has label list and label create', () => {
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('label'), 'glab must NOT have bare label entry');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('label list'), 'glab must include label list');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('label create'), 'glab must include label create');
+  });
+  test('glab does NOT have label clone (glab has no label-clone verb)', () => {
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('label clone'), 'glab must NOT have label clone — glab has no label-clone verb');
+  });
+  test('fj has NO label entries of any form (fj has no label subcommand)', () => {
+    assert.ok(!CLI_SUBCOMMANDS.fj.includes('label'), 'fj must NOT have bare label entry');
+    assert.ok(!CLI_SUBCOMMANDS.fj.some(s => s.startsWith('label')), 'fj must have NO label-prefixed entries at all');
+  });
+  test('tea has no bare label entry; has label list and label create; retains labels plural alias', () => {
+    assert.ok(!CLI_SUBCOMMANDS.tea.includes('label'), 'tea must NOT have bare label entry');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('label list'), 'tea must include label list');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('label create'), 'tea must include label create');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('labels'), 'tea must retain labels plural alias');
+  });
+});
+
+// ── ALLOW-22: gh repo narrowing + glab/fj/tea mirrors ──
+
+describe('ALLOW-22: gh repo narrowed — no bare repo entry; two-token verbs present', () => {
+  test('gh has no bare repo entry', () => {
+    assert.ok(!CLI_SUBCOMMANDS.gh.includes('repo'), 'gh must NOT have bare repo entry — use two-token repo verbs');
+  });
+  test('gh has all 7 two-token repo verbs', () => {
+    for (const verb of ['repo view', 'repo list', 'repo clone', 'repo fork', 'repo create', 'repo sync', 'repo set-default']) {
+      assert.ok(CLI_SUBCOMMANDS.gh.includes(verb), `gh must include '${verb}'`);
+    }
+  });
+  test('gh CLI_SUBCOMMANDS.gh.length === 18 (8 single-token + 7 repo + 3 label)', () => {
+    assert.strictEqual(CLI_SUBCOMMANDS.gh.length, 18, `Expected 18 entries in CLI_SUBCOMMANDS.gh, got ${CLI_SUBCOMMANDS.gh.length}`);
+  });
+  test('getPlatformCliPatterns(gh) returns exactly 36 patterns (18 entries × 2 forms)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.strictEqual(patterns.length, 36, `Expected 36 patterns for gh, got ${patterns.length}`);
+  });
+  test('getPlatformCliPatterns(gh) includes Bash(gh repo view *) and Bash(gh repo set-default *)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(patterns.includes('Bash(gh repo view *)'), 'Missing Bash(gh repo view *)');
+    assert.ok(patterns.includes('Bash(gh repo view)'), 'Missing Bash(gh repo view)');
+    assert.ok(patterns.includes('Bash(gh repo set-default *)'), 'Missing Bash(gh repo set-default *)');
+  });
+  test('getPlatformCliPatterns(gh) does NOT include broad Bash(gh repo *)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(!patterns.includes('Bash(gh repo *)'), 'Broad Bash(gh repo *) must NOT be present — narrowed to two-token verbs');
+  });
+  test('getPlatformCliPatterns handles multi-word subcommand tokens (template literal safety)', () => {
+    const patterns = getPlatformCliPatterns('gh');
+    assert.ok(patterns.includes('Bash(gh repo view *)'), 'Multi-word: Bash(gh repo view *) must be emitted');
+    assert.ok(patterns.includes('Bash(gh repo view)'), 'Multi-word: Bash(gh repo view) must be emitted');
+  });
+  test('glab has no bare repo entry; has 5 two-token repo verbs (no sync/set-default)', () => {
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('repo'), 'glab must NOT have bare repo entry');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('repo view'), 'glab must include repo view');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('repo list'), 'glab must include repo list');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('repo clone'), 'glab must include repo clone');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('repo fork'), 'glab must include repo fork');
+    assert.ok(CLI_SUBCOMMANDS.glab.includes('repo create'), 'glab must include repo create');
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('repo sync'), 'glab must NOT have repo sync (glab lacks it)');
+    assert.ok(!CLI_SUBCOMMANDS.glab.includes('repo set-default'), 'glab must NOT have repo set-default (glab lacks it)');
+  });
+  test('fj has no bare repo entry; has 4 two-token repo verbs (no list)', () => {
+    assert.ok(!CLI_SUBCOMMANDS.fj.includes('repo'), 'fj must NOT have bare repo entry');
+    assert.ok(CLI_SUBCOMMANDS.fj.includes('repo view'), 'fj must include repo view');
+    assert.ok(CLI_SUBCOMMANDS.fj.includes('repo clone'), 'fj must include repo clone');
+    assert.ok(CLI_SUBCOMMANDS.fj.includes('repo fork'), 'fj must include repo fork');
+    assert.ok(CLI_SUBCOMMANDS.fj.includes('repo create'), 'fj must include repo create');
+    assert.ok(!CLI_SUBCOMMANDS.fj.includes('repo list'), 'fj must NOT have repo list (fj has no list verb)');
+  });
+  test('tea has no bare repo entry; has repo list/create/fork; no repo view or repo clone; retains repos alias', () => {
+    assert.ok(!CLI_SUBCOMMANDS.tea.includes('repo'), 'tea must NOT have bare repo entry');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('repo list'), 'tea must include repo list');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('repo create'), 'tea must include repo create');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('repo fork'), 'tea must include repo fork');
+    assert.ok(!CLI_SUBCOMMANDS.tea.includes('repo view'), 'tea must NOT have repo view (tea has no view verb)');
+    assert.ok(!CLI_SUBCOMMANDS.tea.includes('repo clone'), 'tea must NOT have repo clone (tea has no clone verb)');
+    assert.ok(CLI_SUBCOMMANDS.tea.includes('repos'), 'tea must retain repos plural alias');
+  });
+});
+
+// ── ALLOW-19: RW_FORMS frozen-Set export — single source of truth for canonical permission forms ──
+
+describe('ALLOW-19: RW_FORMS export', () => {
+  test('RW_FORMS is a Set instance', () => {
+    assert.ok(RW_FORMS instanceof Set, 'RW_FORMS must be a Set instance');
+  });
+  test('RW_FORMS has exactly 6 entries', () => {
+    assert.strictEqual(RW_FORMS.size, 6, 'RW_FORMS must contain exactly 6 entries');
+  });
+  test('RW_FORMS is frozen', () => {
+    assert.ok(Object.isFrozen(RW_FORMS), 'RW_FORMS must be frozen');
+  });
+  test('RW_FORMS contains all canonical permission forms', () => {
+    for (const e of ['Edit', 'Write', 'Read', 'Edit(*)', 'Write(*)', 'Read(*)']) {
+      assert.ok(RW_FORMS.has(e), `RW_FORMS must contain '${e}'`);
+    }
+  });
+  test('RW_FORMS freeze is documentation-only in Node 22+ (V8 does not throw on .add())', () => {
+    // RESEARCH Pitfall 6: Object.freeze(new Set(...)) in Node 22+ / V8 does NOT throw from .add().
+    // The freeze signals read-only intent; enforcement is at code-review time, not runtime.
+    // Document the actual V8 behavior using a local frozen Set so we never mutate the exported
+    // RW_FORMS singleton (which is shared with install.js/commands.cjs consumers and other tests).
+    const frozenSet = Object.freeze(new Set(['Edit', 'Write', 'Read', 'Edit(*)', 'Write(*)', 'Read(*)']));
+    assert.ok(Object.isFrozen(frozenSet), 'local documentation Set must be frozen');
+    const sizeBeforeAdd = frozenSet.size;
+    assert.strictEqual(sizeBeforeAdd, 6, 'local documentation Set size must be 6 before .add()');
+    assert.doesNotThrow(() => { frozenSet.add('bogus'); },
+      'V8 in Node 22+ does NOT throw TypeError on Object.freeze(new Set(...)).add(bogus)');
+    assert.strictEqual(frozenSet.size, sizeBeforeAdd + 1,
+      'documented V8 behavior: frozen Set still grows after .add()');
+    assert.ok(frozenSet.has('bogus'),
+      'documented V8 behavior: frozen Set still contains the newly added value');
   });
 });

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -3272,3 +3272,132 @@ describe('summary-extract --default flag', () => {
     assert.strictEqual(parsed.one_liner, 'Built the thing', 'Should return actual value');
   });
 });
+
+// ── ALLOW-15: cmdGenerateAllowlist parity with install.js seeding ─────────────
+// `gsd-tools` supports a global `--json` flag (handled before command routing),
+// so `generate-allowlist --platform <linux|darwin> --json` returns
+// { permissions: { allow: [...] } } matching install.js's settings.json structure.
+
+describe('ALLOW-15: cmdGenerateAllowlist parity with install.js seeding', () => {
+  const pathMod = require('path');
+  const osMod = require('os');
+  const fsMod = require('fs');
+  const { spawnSync: spawnSyncMod } = require('node:child_process');
+  const INSTALLER = pathMod.resolve(__dirname, '..', 'bin', 'install.js');
+
+  function runInstallAndRead(platform) {
+    const tmpCwd = fsMod.mkdtempSync(pathMod.join(osMod.tmpdir(), 'gsd-parity-'));
+    try {
+      const r = spawnSyncMod(
+        process.execPath,
+        [INSTALLER, '--runtime', 'claude', '--local'],
+        {
+          encoding: 'utf8',
+          timeout: 15000,
+          cwd: tmpCwd,
+          env: Object.assign({}, process.env, { HOME: osMod.homedir(), GSD_TEST_FORCE_PLATFORM: platform }),
+        }
+      );
+      assert.strictEqual(r.status, 0, `install.js failed on ${platform}: ${r.stderr}`);
+      return JSON.parse(fsMod.readFileSync(pathMod.join(tmpCwd, '.claude', 'settings.json'), 'utf8')).permissions.allow;
+    } finally {
+      try { fsMod.rmSync(tmpCwd, { recursive: true, force: true }); } catch {}
+    }
+  }
+
+  function runGenerateAllowlist(cwd, platform) {
+    const r = runGsdTools(`generate-allowlist --platform ${platform} --json`, cwd);
+    assert.ok(r.success, `generate-allowlist failed: ${r.error}`);
+    return JSON.parse(r.output).permissions.allow;
+  }
+
+  test('darwin: set-equal to install.js --local output', () => {
+    const cwd = createTempProject();
+    try {
+      const installAllow  = runInstallAndRead('darwin');
+      const generateAllow = runGenerateAllowlist(cwd, 'darwin');
+      assert.deepStrictEqual(new Set(installAllow), new Set(generateAllow),
+        `Set mismatch:\ninstall only: ${installAllow.filter(x => !generateAllow.includes(x)).join(', ')}\ngenerate only: ${generateAllow.filter(x => !installAllow.includes(x)).join(', ')}`);
+      // ALLOW-21/22 parity check: narrowed verbs appear in both outputs.
+      try {
+        require('child_process').execSync('which gh', { stdio: 'ignore', timeout: 2000 });
+        assert.ok(installAllow.includes('Bash(gh repo view *)'), 'install.js must seed narrowed repo view');
+        assert.ok(generateAllow.includes('Bash(gh repo view *)'), 'generateSettings must emit narrowed repo view');
+        assert.ok(!installAllow.includes('Bash(gh repo *)'), 'install.js must NOT seed broad gh repo');
+        assert.ok(!generateAllow.includes('Bash(gh repo *)'), 'generateSettings must NOT emit broad gh repo');
+      } catch { /* gh not installed — skip narrow-verb parity */ }
+    } finally {
+      cleanup(cwd);
+    }
+  });
+
+  test('linux: set-equal to install.js --local output (bare Edit/Write/Read)', () => {
+    const cwd = createTempProject();
+    try {
+      const installAllow  = runInstallAndRead('linux');
+      const generateAllow = runGenerateAllowlist(cwd, 'linux');
+      assert.deepStrictEqual(new Set(installAllow), new Set(generateAllow));
+      assert.ok(generateAllow.includes('Edit'));
+      assert.ok(!generateAllow.includes('Edit(*)'));
+      // ALLOW-21/22 parity check: narrowed verbs appear in both outputs.
+      try {
+        require('child_process').execSync('which gh', { stdio: 'ignore', timeout: 2000 });
+        assert.ok(installAllow.includes('Bash(gh repo view *)'), 'install.js must seed narrowed repo view');
+        assert.ok(generateAllow.includes('Bash(gh repo view *)'), 'generateSettings must emit narrowed repo view');
+        assert.ok(!installAllow.includes('Bash(gh repo *)'), 'install.js must NOT seed broad gh repo');
+        assert.ok(!generateAllow.includes('Bash(gh repo *)'), 'generateSettings must NOT emit broad gh repo');
+      } catch { /* gh not installed — skip narrow-verb parity */ }
+    } finally {
+      cleanup(cwd);
+    }
+  });
+
+  test('cmdGenerateAllowlist does not duplicate Bash(ssh-add *) (already in template)', () => {
+    const cwd = createTempProject();
+    try {
+      const generateAllow = runGenerateAllowlist(cwd, 'darwin');
+      const sshAddCount = generateAllow.filter(e => e === 'Bash(ssh-add *)').length;
+      assert.strictEqual(sshAddCount, 1, 'Bash(ssh-add *) must appear exactly once');
+    } finally {
+      cleanup(cwd);
+    }
+  });
+});
+
+// ── ALLOW-19: RW_FORMS dedup — commands.cjs imports from allowlist.cjs ────────
+// Verifies that commands.cjs no longer defines an inline rwForms Set literal and
+// instead imports RW_FORMS from allowlist.cjs (single source of truth).
+
+describe('ALLOW-19: commands.cjs uses RW_FORMS from allowlist.cjs (no inline Set)', () => {
+  const fsMod = require('fs');
+  const pathMod = require('path');
+  const COMMANDS_SRC = pathMod.resolve(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'commands.cjs');
+
+  test('commands.cjs require destructure includes RW_FORMS from allowlist.cjs', () => {
+    const src = fsMod.readFileSync(COMMANDS_SRC, 'utf8');
+    assert.ok(
+      /const\s*\{[^}]*RW_FORMS[^}]*\}\s*=\s*require\(['"]\.\/allowlist\.cjs['"]\)/.test(src),
+      'commands.cjs must destructure RW_FORMS from allowlist.cjs'
+    );
+  });
+
+  test('commands.cjs has no inline rwForms Set literal', () => {
+    const src = fsMod.readFileSync(COMMANDS_SRC, 'utf8');
+    assert.ok(
+      !/const\s+rwForms\s*=\s*new\s+Set\s*\(/.test(src),
+      'commands.cjs must not define an inline rwForms Set — use imported RW_FORMS'
+    );
+  });
+
+  test('commands.cjs filter uses RW_FORMS.has(e) not rwForms.has(e)', () => {
+    const src = fsMod.readFileSync(COMMANDS_SRC, 'utf8');
+    assert.ok(
+      /!RW_FORMS\.has\(e\)/.test(src),
+      'commands.cjs generateSettings filter must use !RW_FORMS.has(e)'
+    );
+    assert.ok(
+      !/!rwForms\.has\(e\)/.test(src),
+      'commands.cjs must not reference local rwForms variable in filter'
+    );
+  });
+});

--- a/tests/install-js.test.cjs
+++ b/tests/install-js.test.cjs
@@ -21,12 +21,12 @@ test('TILDE-01: install.js global install uses tilde paths in workflow files (no
   try {
     const result = spawnSync(
       process.execPath,
-      [INSTALLER, '--runtime', 'claude', '--global', '--config-dir', path.join(tmpDir, '.claude')],
+      [INSTALLER, '--runtime', 'claude', '--global'],
       {
         encoding: 'utf8',
         timeout: 15000,
         cwd: tmpDir,
-        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+        env: Object.assign({}, process.env, { HOME: os.homedir(), CLAUDE_CONFIG_DIR: path.join(tmpDir, '.claude') }),
       }
     );
 
@@ -69,12 +69,12 @@ test('UNINSTALL-01: install.js --uninstall shows Mode: Uninstall indicator in ou
   try {
     const result = spawnSync(
       process.execPath,
-      [INSTALLER, '--runtime', 'claude', '--global', '--uninstall', '--config-dir', path.join(tmpDir, '.claude')],
+      [INSTALLER, '--runtime', 'claude', '--global', '--uninstall'],
       {
         encoding: 'utf8',
         timeout: 15000,
         cwd: tmpDir,
-        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+        env: Object.assign({}, process.env, { HOME: os.homedir(), CLAUDE_CONFIG_DIR: path.join(tmpDir, '.claude') }),
       }
     );
 
@@ -189,18 +189,26 @@ test('PATH-04: install.js local install must not produce ./.claude/ paths in bas
   }
 });
 
-// ── PERM-06: settings-sandbox.json template contains Agent(*), bare Edit, bare Write, bare Read ──
+// ── PERM-06: settings-sandbox.json template contains Agent(*), canonical Edit(*)/Write(*)/Read(*),
+//            no deny rules, subshell builtins.
+//
+//            Template uses canonical macOS forms (Edit(*), Write(*), Read(*)).
+//            install.js down-converts to bare forms on Linux via getReadEditWriteAllowRules().
+//            See 54-CONTEXT.md "Template allow canonicalisation" decision.
 
-test('PERM-06: settings-sandbox.json template contains Agent(*), bare Edit/Write/Read, no deny rules, subshell builtins', () => {
+test('PERM-06: settings-sandbox.json template contains Agent(*), canonical Edit(*)/Write(*)/Read(*), excludes bare Edit/Write/Read, no deny rules, subshell builtins', () => {
   const templatePath = path.resolve(__dirname, '..', 'gsd-ng', 'templates', 'settings-sandbox.json');
   const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
   const allow = template.permissions.allow;
   assert.ok(allow.includes('Agent(*)'), 'template must include Agent(*)');
-  assert.ok(allow.includes('Edit'), 'template must include bare Edit (not Edit(*)) for Linux bubblewrap compatibility');
-  assert.ok(allow.includes('Write'), 'template must include bare Write (not Write(*)) for Linux bubblewrap compatibility');
-  assert.ok(allow.includes('Read'), 'template must include bare Read for Linux bubblewrap compatibility');
-  assert.ok(allow.indexOf('Edit(*)') === -1, 'template must NOT include Edit(*) -- use bare Edit instead');
-  assert.ok(allow.indexOf('Write(*)') === -1, 'template must NOT include Write(*) -- use bare Write instead');
+  // Template ships canonical macOS form; install.js down-converts to bare on Linux.
+  assert.ok(allow.includes('Edit(*)'), 'template must include canonical Edit(*) (down-converted to bare Edit on Linux at install time)');
+  assert.ok(allow.includes('Write(*)'), 'template must include canonical Write(*) (down-converted to bare Write on Linux at install time)');
+  assert.ok(allow.includes('Read(*)'), 'template must include canonical Read(*) (down-converted to bare Read on Linux at install time)');
+  // Two-sided contract: bare forms must NOT be present (ALLOW-17)
+  assert.ok(!allow.includes('Edit'), 'template must NOT include bare Edit — use Edit(*)');
+  assert.ok(!allow.includes('Write'), 'template must NOT include bare Write — use Write(*)');
+  assert.ok(!allow.includes('Read'), 'template must NOT include bare Read — use Read(*)');
   // Deny rules dropped per Phase 52 -- GSD-NG ships allow rules only
   assert.strictEqual(template.permissions.deny, undefined, 'template must NOT have permissions.deny section (deny rules dropped in Phase 52)');
 
@@ -487,12 +495,12 @@ test('RUNTIME-02: --global without --runtime exits non-zero with helpful error',
   try {
     const result = spawnSync(
       process.execPath,
-      [INSTALLER, '--global', '--config-dir', path.join(tmpDir, '.claude')],
+      [INSTALLER, '--global'],
       {
         encoding: 'utf8',
         timeout: 15000,
         cwd: tmpDir,
-        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+        env: Object.assign({}, process.env, { HOME: os.homedir(), CLAUDE_CONFIG_DIR: path.join(tmpDir, '.claude') }),
       }
     );
     assert.notStrictEqual(result.status, 0, '--global without --runtime must exit non-zero (RUNTIME-02)');
@@ -1372,6 +1380,95 @@ test('RUNTIME-02: install.js --runtime copilot writes "runtime":"copilot" to .pl
   }
 });
 
+// ── ALLOW-18: env var rename — GSD_TEST_FORCE_PLATFORM is the test seam ────────
+
+test('ALLOW-18: install.js seeding block uses GSD_TEST_FORCE_PLATFORM (not GSD_FORCE_PLATFORM)', () => {
+  // Static code inspection: the source must not reference the old env var name
+  const src = fs.readFileSync(INSTALLER, 'utf8');
+  assert.ok(
+    !src.includes('GSD_FORCE_PLATFORM'),
+    'install.js must not reference GSD_FORCE_PLATFORM (old name) — use GSD_TEST_FORCE_PLATFORM (ALLOW-18)'
+  );
+  assert.ok(
+    src.includes('GSD_TEST_FORCE_PLATFORM'),
+    'install.js must reference GSD_TEST_FORCE_PLATFORM at least once (ALLOW-18)'
+  );
+});
+
+// ── ALLOW-19: RW_FORMS imported from allowlist.cjs — no inline Set literal ──────
+
+test('ALLOW-19: install.js imports RW_FORMS from allowlist.cjs and uses no inline rwForms Set literal', () => {
+  const src = fs.readFileSync(INSTALLER, 'utf8');
+  // Must import RW_FORMS in the destructure
+  assert.ok(
+    src.includes('RW_FORMS'),
+    'install.js must import and reference RW_FORMS from allowlist.cjs (ALLOW-19)'
+  );
+  // Must not define an inline Set containing these canonical forms
+  assert.ok(
+    !src.includes("new Set(['Edit', 'Write', 'Read'"),
+    'install.js must not define an inline rwForms Set literal — use imported RW_FORMS (ALLOW-19)'
+  );
+});
+
+// ── ALLOW-19: GSD_TEST_FORCE_PLATFORM seam works at runtime ─────────────────────
+
+test('ALLOW-19: GSD_TEST_FORCE_PLATFORM env var controls platform detection in seeding block', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-allow19-'));
+  try {
+    // Install with GSD_TEST_FORCE_PLATFORM overriding to 'linux'
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, {
+          HOME: os.homedir(),
+          GSD_TEST_FORCE_PLATFORM: 'linux',
+        }),
+      }
+    );
+    assert.strictEqual(
+      result.status,
+      0,
+      'install.js must exit 0 when GSD_TEST_FORCE_PLATFORM=linux is set (ALLOW-19)\nstderr: ' + (result.stderr || '')
+    );
+    // settings.json must have been seeded (permissions block present)
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    assert.ok(fs.existsSync(settingsPath), 'settings.json must exist (ALLOW-19)');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.ok(
+      Array.isArray(settings.permissions && settings.permissions.allow),
+      'permissions.allow must be seeded when GSD_TEST_FORCE_PLATFORM is used (ALLOW-19)'
+    );
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+// ── ALLOW-20: syncSection uses Set.has() for O(1) membership ─────────────────
+
+test('ALLOW-20: install.js syncSection uses Set.has() — not Array.includes() — for membership check', () => {
+  const src = fs.readFileSync(INSTALLER, 'utf8');
+  // New implementation: must use Set.has()
+  assert.ok(
+    src.includes('existingSet.has(e)'),
+    'syncSection must use existingSet.has(e) for membership check (ALLOW-20)'
+  );
+  // Old implementation: must not use Array.includes()
+  assert.ok(
+    !src.includes('existing.includes(e)'),
+    'syncSection must not use existing.includes(e) — replaced by Set.has() (ALLOW-20)'
+  );
+  // Return shape: merged and added fields must still be present
+  assert.ok(
+    src.includes('merged: [...existing, ...toAdd]'),
+    'syncSection must keep merged: [...existing, ...toAdd] return shape (ALLOW-20)'
+  );
+});
+
 test('RUNTIME-03: install.js preserves existing config.json values when writing runtime field', () => {
   const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR,'gsd-js-runtime-preserve-'));
   try {
@@ -1648,4 +1745,216 @@ describe('install.js - Phase 55 effort frontmatter sync', () => {
     const setProfileSkill = path.join(tmpDir, '.github', 'skills', 'gsd-set-profile', 'SKILL.md');
     assert.ok(!fs.existsSync(setProfileSkill), 'gsd-set-profile/SKILL.md must NOT exist for Copilot install');
   });
+});
+
+// ── ALLOW-07: install.js writes bare Edit/Write/Read on Linux ─────────────
+// Force Linux seeding via GSD_TEST_FORCE_PLATFORM and verify bare Edit/Write/Read
+// permissions are written instead of the globbed forms used on non-Linux platforms.
+
+test('ALLOW-07: install.js --local on Linux writes bare Edit/Write/Read forms', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-allow-07-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir(), GSD_TEST_FORCE_PLATFORM: 'linux' }),
+      }
+    );
+    assert.strictEqual(result.status, 0, `install.js failed: ${result.stderr}`);
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    const allow = settings.permissions?.allow ?? [];
+
+    assert.ok(allow.includes('Edit'), 'Linux must include bare Edit');
+    assert.ok(allow.includes('Write'), 'Linux must include bare Write');
+    assert.ok(allow.includes('Read'), 'Linux must include bare Read');
+    assert.ok(!allow.includes('Edit(*)'), 'Linux must NOT include glob Edit(*)');
+    assert.ok(!allow.includes('Write(*)'), 'Linux must NOT include glob Write(*)');
+    assert.ok(!allow.includes('Read(*)'), 'Linux must NOT include glob Read(*)');
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+// ── ALLOW-08: install.js writes canonical Edit(*)/Write(*)/Read(*) on macOS ──
+
+test('ALLOW-08: install.js --local on macOS writes canonical glob forms', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-allow-08-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir(), GSD_TEST_FORCE_PLATFORM: 'darwin' }),
+      }
+    );
+    assert.strictEqual(result.status, 0, `install.js failed: ${result.stderr}`);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf8'));
+    const allow = settings.permissions?.allow ?? [];
+    assert.ok(allow.includes('Edit(*)'));
+    assert.ok(allow.includes('Write(*)'));
+    assert.ok(allow.includes('Read(*)'));
+    assert.ok(!allow.includes('Edit'), 'macOS must not carry bare Edit');
+    // Narrowed verbs land — gated on gh presence on host (ALLOW-22 integration)
+    try {
+      require('child_process').execSync('which gh', { stdio: 'ignore', timeout: 2000 });
+      assert.ok(allow.includes('Bash(gh repo view *)'), 'narrowed repo view must land');
+      assert.ok(allow.includes('Bash(gh label create *)'), 'narrowed label create must land');
+      assert.ok(!allow.includes('Bash(gh repo *)'), 'broad gh repo must NOT land (narrowed)');
+      assert.ok(!allow.includes('Bash(gh label *)'), 'broad gh label must NOT land (narrowed)');
+    } catch { /* gh not installed — skip narrow-verb assertions */ }
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+// ── ALLOW-16: install.js writes canonical forms + narrowed CLI verbs on win32 ──
+
+test('ALLOW-16: install.js --local on win32 writes canonical glob forms and narrowed CLI verbs', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-allow-16-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir(), GSD_TEST_FORCE_PLATFORM: 'win32' }),
+      }
+    );
+    assert.strictEqual(result.status, 0, `install.js failed: ${result.stderr}`);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf8'));
+    const allow = settings.permissions?.allow ?? [];
+
+    // Canonical forms present (win32 mirrors darwin per getReadEditWriteAllowRules)
+    assert.ok(allow.includes('Edit(*)'), 'win32 must include canonical Edit(*)');
+    assert.ok(allow.includes('Write(*)'), 'win32 must include canonical Write(*)');
+    assert.ok(allow.includes('Read(*)'), 'win32 must include canonical Read(*)');
+
+    // Bare forms absent
+    assert.ok(!allow.includes('Edit'), 'win32 must NOT carry bare Edit');
+    assert.ok(!allow.includes('Write'), 'win32 must NOT carry bare Write');
+    assert.ok(!allow.includes('Read'), 'win32 must NOT carry bare Read');
+
+    // Narrowed verbs land — gated on gh presence on host
+    try {
+      require('child_process').execSync('which gh', { stdio: 'ignore', timeout: 2000 });
+      assert.ok(allow.includes('Bash(gh repo view *)'), 'narrowed repo view must land');
+      assert.ok(allow.includes('Bash(gh label create *)'), 'narrowed label create must land');
+      assert.ok(!allow.includes('Bash(gh repo *)'), 'broad gh repo must NOT land (narrowed)');
+      assert.ok(!allow.includes('Bash(gh label *)'), 'broad gh label must NOT land (narrowed)');
+    } catch { /* gh not installed — skip narrow-verb assertions */ }
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+// ── ALLOW-09: allow section sync union preserves user entries + logs per-section count ──
+
+test('ALLOW-09: allow-section sync preserves user entries and logs "Added N allow entries"', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-allow-09-'));
+  try {
+    const configDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'settings.json'),
+      JSON.stringify({ permissions: { allow: ['Bash(custom-cmd *)'] } }, null, 2)
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir(), GSD_TEST_FORCE_PLATFORM: 'darwin' }),
+      }
+    );
+    assert.strictEqual(result.status, 0, `install.js failed: ${result.stderr}`);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(configDir, 'settings.json'), 'utf8'));
+    assert.ok(settings.permissions.allow.includes('Bash(custom-cmd *)'), 'user entry must be preserved');
+    assert.ok(settings.permissions.allow.includes('Bash(node *)'), 'template entries must be added');
+    assert.match(result.stdout, /Added \d+ allow entries/, 'must log per-section allow count');
+    // Narrowed-verb check — gated on gh presence (ALLOW-22 integration)
+    try {
+      require('child_process').execSync('which gh', { stdio: 'ignore', timeout: 2000 });
+      const allow = settings.permissions?.allow ?? [];
+      assert.ok(!allow.includes('Bash(gh repo *)'), 'linux install must not land broad gh repo (narrowed)');
+      assert.ok(allow.includes('Bash(gh repo view *)') || allow.length === 0, 'narrowed repo view lands when gh present');
+    } catch { /* gh not installed */ }
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+// ── ALLOW-10: deny section sync is no-op today (template has no deny block) ──
+
+test('ALLOW-10: deny-section sync preserves user denies and does not log deny additions', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-allow-10-'));
+  try {
+    const configDir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(configDir, 'settings.json'),
+      JSON.stringify({ permissions: { allow: [], deny: ['Bash(user-deny *)'] } }, null, 2)
+    );
+
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir(), GSD_TEST_FORCE_PLATFORM: 'darwin' }),
+      }
+    );
+    assert.strictEqual(result.status, 0);
+
+    const settings = JSON.parse(fs.readFileSync(path.join(configDir, 'settings.json'), 'utf8'));
+    assert.ok(settings.permissions.deny.includes('Bash(user-deny *)'), 'user deny must be preserved');
+    assert.doesNotMatch(result.stdout, /Added \d+ deny/, 'no deny additions expected');
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
+// ── ALLOW-11: "up to date" only after all three sections return zero additions ──
+
+test('ALLOW-11: second install logs "Permissions already up to date" (no per-section adds)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-allow-11-'));
+  try {
+    const configDir = path.join(tmpDir, '.claude');
+    const spawn = () => spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir(), GSD_TEST_FORCE_PLATFORM: 'darwin' }),
+      }
+    );
+    const first = spawn();
+    assert.strictEqual(first.status, 0);
+    const second = spawn();
+    assert.strictEqual(second.status, 0);
+    assert.match(second.stdout, /Permissions already up to date/);
+    assert.doesNotMatch(second.stdout, /Added \d+ allow entries/);
+  } finally {
+    cleanup(tmpDir);
+  }
 });


### PR DESCRIPTION
## Summary

Finish the allowlist-hardening work left over after Phase 52 shipped. Phase 52 already delivered Bug 10 fix (ALLOW-01), granular CLI patterns (ALLOW-02/03), and the `allowlist.cjs` module — those remain green in this phase. The deny-rules direction (ALLOW-13) is retired; template is allow-only, sandbox contains blast radius. Remaining scope (per revised CONTEXT.md 2026-04-19): (1) expand `CLI_SUBCOMMANDS` with `run`, `label`, `status` for gh/glab/fj/tea and decide on `repo` narrowing; (2) canonicalise template allow entries to `Edit(*)`, `Write(*)`, `Read(*)` (macOS form); (3) add `getReadEditWriteAllowRules(platform)` pure function in `allowlist.cjs` to down-convert on Linux (claude-code #16170/#6881); (4) split install.js permission sync into independent allow/deny/ask section handlers (deny no-op today but infrastructure ready for future `ask` rules); (5) bring `commands.cjs generateSettings` to full parity with install.js using shared `allowlist.cjs` exports (no inline duplicate logic). Plans are regenerated 2026-04-21 after the original 2026-04-12 set went stale.

## Changes

- **54-01**: RED test scaffolds for ALLOW-01 count (14→20), ALLOW-04/05/06/14 getReadEditWriteAllowRules, ALLOW-07..12 install.js platform/sync/cleanup, and ALLOW-15 cmdGenerateAllowlist parity — no production code touched
- **54-02**: CLI_SUBCOMMANDS expanded to 10/7/7/12 subcommands per CLI, and getReadEditWriteAllowRules(platform) added as a pure platform-branching export — all 48 allowlist tests GREEN.
- **54-03**: Bare `Edit`/`Write`/`Read` entries in settings-sandbox.json replaced with canonical macOS glob forms `Edit(*)`/`Write(*)`/`Read(*)`; JSON valid, line count unchanged, bash-hook tests green.
- **54-04**: install.js seeding block rewired to three-section allow/deny/ask union sync with platform-aware getReadEditWriteAllowRules; Linux gets bare Edit/Write/Read, macOS gets canonical glob forms; ALLOW-07/08/09/10/11 all GREEN.
- **54-05**: `generate-allowlist --platform linux|darwin` now set-equals install.js seeding via shared allowlist.cjs exports; ALLOW-15 all three subtests GREEN

## Test Plan

- [ ] Automated tests pass
- [ ] Manual verification complete

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng) from phase 54 execution*
