### PR TITLE
chore: add Prettier formatting gate

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,11 @@
+# git-blame-ignore-revs
+#
+# Commits listed here are skipped by `git blame` when the
+# `blame.ignoreRevsFile` config is set, AND by GitHub's blame UI
+# automatically.
+#
+# To opt in locally:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# One-shot Prettier format pass (Phase 56)
+1131dee62468eab8c50b24cb6f5867a8fcedb21d

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules
+bin/install.js
+hooks/dist/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "tabWidth": 2,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "semi": true,
+  "bracketSpacing": true,
+  "endOfLine": "lf"
+}

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -164,7 +164,12 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { error, output: coreOutput, setFileOutput, setJsonMode } = require('./lib/core.cjs');
+const {
+  error,
+  output: coreOutput,
+  setFileOutput,
+  setJsonMode,
+} = require('./lib/core.cjs');
 const state = require('./lib/state.cjs');
 const phase = require('./lib/phase.cjs');
 const roadmap = require('./lib/roadmap.cjs');
@@ -183,27 +188,94 @@ const effortSync = require('./lib/effort-sync.cjs');
 // ─── Command Registry (for typo detection) ────────────────────────────────────
 
 const ALL_COMMANDS = [
-  'state', 'resolve-model', 'resolve-effort', 'sync-agents', 'find-phase', 'commit', 'verify-summary',
-  'template', 'frontmatter', 'verify', 'generate-slug', 'current-timestamp',
-  'list-todos', 'recurring-due', 'staleness-check', 'verify-path-exists',
-  'config-ensure-section', 'config-set', 'config-set-model-profile',
-  'config-get', 'init-get', 'history-digest', 'phases', 'roadmap', 'requirements',
-  'phase', 'milestone', 'validate', 'progress', 'stats', 'todo', 'update',
-  'scaffold', 'init', 'phase-plan-index', 'state-snapshot', 'summary-extract',
-  'detect-platform', 'detect-workspace', 'discover-test-command', 'websearch',
-  'squash', 'version-bump', 'generate-changelog', 'generate-allowlist',
-  'resolve-type-alias', 'issue-import', 'issue-sync', 'issue-list-refs',
-  'divergence', 'pingpong-check', 'breakout-check', 'cleanup', 'help', 'guard',
+  'state',
+  'resolve-model',
+  'resolve-effort',
+  'sync-agents',
+  'find-phase',
+  'commit',
+  'verify-summary',
+  'template',
+  'frontmatter',
+  'verify',
+  'generate-slug',
+  'current-timestamp',
+  'list-todos',
+  'recurring-due',
+  'staleness-check',
+  'verify-path-exists',
+  'config-ensure-section',
+  'config-set',
+  'config-set-model-profile',
+  'config-get',
+  'init-get',
+  'history-digest',
+  'phases',
+  'roadmap',
+  'requirements',
+  'phase',
+  'milestone',
+  'validate',
+  'progress',
+  'stats',
+  'todo',
+  'update',
+  'scaffold',
+  'init',
+  'phase-plan-index',
+  'state-snapshot',
+  'summary-extract',
+  'detect-platform',
+  'detect-workspace',
+  'discover-test-command',
+  'websearch',
+  'squash',
+  'version-bump',
+  'generate-changelog',
+  'generate-allowlist',
+  'resolve-type-alias',
+  'issue-import',
+  'issue-sync',
+  'issue-list-refs',
+  'divergence',
+  'pingpong-check',
+  'breakout-check',
+  'cleanup',
+  'help',
+  'guard',
   'test',
 ];
 
 // ─── Subcommand Registry (for fuzzy subcommand matching) ─────────────────────
 
 const SUBCOMMANDS = {
-  state: ['load', 'json', 'update', 'get', 'patch', 'advance-plan', 'record-metric', 'update-progress', 'add-decision', 'add-blocker', 'resolve-blocker', 'record-session', 'begin-phase', 'adjust-quick-table', 'rebuild-frontmatter'],
+  state: [
+    'load',
+    'json',
+    'update',
+    'get',
+    'patch',
+    'advance-plan',
+    'record-metric',
+    'update-progress',
+    'add-decision',
+    'add-blocker',
+    'resolve-blocker',
+    'record-session',
+    'begin-phase',
+    'adjust-quick-table',
+    'rebuild-frontmatter',
+  ],
   template: ['select', 'fill'],
   frontmatter: ['get', 'set', 'merge', 'validate'],
-  verify: ['plan-structure', 'phase-completeness', 'references', 'commits', 'artifacts', 'key-links'],
+  verify: [
+    'plan-structure',
+    'phase-completeness',
+    'references',
+    'commits',
+    'artifacts',
+    'key-links',
+  ],
   phases: ['list'],
   roadmap: ['get-phase', 'analyze', 'update-plan-progress', 'add-phase'],
   requirements: ['mark-complete'],
@@ -211,7 +283,20 @@ const SUBCOMMANDS = {
   milestone: ['complete'],
   validate: ['consistency', 'health'],
   todo: ['complete', 'list-by-phase', 'scan-phase-linked'],
-  init: ['execute-phase', 'plan-phase', 'new-project', 'new-milestone', 'quick', 'resume', 'verify-work', 'phase-op', 'todos', 'milestone-op', 'map-codebase', 'progress'],
+  init: [
+    'execute-phase',
+    'plan-phase',
+    'new-project',
+    'new-milestone',
+    'quick',
+    'resume',
+    'verify-work',
+    'phase-op',
+    'todos',
+    'milestone-op',
+    'map-codebase',
+    'progress',
+  ],
   guard: ['sync-chain', 'init-valid'],
   test: ['capture-baseline', 'compare-baseline'],
 };
@@ -231,88 +316,121 @@ const SUBCOMMANDS = {
  */
 const ARG_SCHEMAS = {
   state: {
-    'load':             { positional: { min: 0, max: 0 }, flags: [] },
-    'json':             { positional: { min: 0, max: 0 }, flags: [] },
-    'update':           { positional: { min: 2, max: 2 }, flags: [] },
-    'get':              { positional: { min: 0, max: 1 }, flags: [] },
+    load: { positional: { min: 0, max: 0 }, flags: [] },
+    json: { positional: { min: 0, max: 0 }, flags: [] },
+    update: { positional: { min: 2, max: 2 }, flags: [] },
+    get: { positional: { min: 0, max: 1 }, flags: [] },
     // 'patch' omitted: takes dynamic --key value pairs, any flag is valid
-    'advance-plan':     { positional: { min: 0, max: 0 }, flags: [] },
-    'record-metric':    { positional: { min: 0, max: 0 }, flags: ['--phase', '--plan', '--duration', '--tasks', '--files'] },
-    'update-progress':  { positional: { min: 0, max: 0 }, flags: [] },
-    'add-decision':     { positional: { min: 0, max: 0 }, flags: ['--phase', '--summary', '--summary-file', '--rationale', '--rationale-file'] },
-    'add-blocker':      { positional: { min: 0, max: 0 }, flags: ['--text', '--text-file'] },
-    'resolve-blocker':  { positional: { min: 0, max: 0 }, flags: ['--text'] },
-    'record-session':   { positional: { min: 0, max: 0 }, flags: ['--stopped-at', '--resume-file'] },
-    'begin-phase':      { positional: { min: 0, max: 0 }, flags: ['--phase', '--name', '--plans'] },
+    'advance-plan': { positional: { min: 0, max: 0 }, flags: [] },
+    'record-metric': {
+      positional: { min: 0, max: 0 },
+      flags: ['--phase', '--plan', '--duration', '--tasks', '--files'],
+    },
+    'update-progress': { positional: { min: 0, max: 0 }, flags: [] },
+    'add-decision': {
+      positional: { min: 0, max: 0 },
+      flags: [
+        '--phase',
+        '--summary',
+        '--summary-file',
+        '--rationale',
+        '--rationale-file',
+      ],
+    },
+    'add-blocker': {
+      positional: { min: 0, max: 0 },
+      flags: ['--text', '--text-file'],
+    },
+    'resolve-blocker': { positional: { min: 0, max: 0 }, flags: ['--text'] },
+    'record-session': {
+      positional: { min: 0, max: 0 },
+      flags: ['--stopped-at', '--resume-file'],
+    },
+    'begin-phase': {
+      positional: { min: 0, max: 0 },
+      flags: ['--phase', '--name', '--plans'],
+    },
     'adjust-quick-table': { positional: { min: 0, max: 0 }, flags: [] },
   },
   template: {
-    'select': { positional: { min: 0, max: 1 }, flags: [] },
-    'fill':   { positional: { min: 1, max: 1 }, flags: ['--phase', '--plan', '--name', '--type', '--wave', '--fields'] },
+    select: { positional: { min: 0, max: 1 }, flags: [] },
+    fill: {
+      positional: { min: 1, max: 1 },
+      flags: ['--phase', '--plan', '--name', '--type', '--wave', '--fields'],
+    },
   },
   frontmatter: {
-    'get':      { positional: { min: 1, max: 1 }, flags: ['--field', '--format', '--default'] },
-    'set':      { positional: { min: 1, max: 1 }, flags: ['--field', '--value'] },
-    'merge':    { positional: { min: 1, max: 1 }, flags: ['--data'] },
-    'validate': { positional: { min: 1, max: 1 }, flags: ['--schema'] },
+    get: {
+      positional: { min: 1, max: 1 },
+      flags: ['--field', '--format', '--default'],
+    },
+    set: { positional: { min: 1, max: 1 }, flags: ['--field', '--value'] },
+    merge: { positional: { min: 1, max: 1 }, flags: ['--data'] },
+    validate: { positional: { min: 1, max: 1 }, flags: ['--schema'] },
   },
   verify: {
-    'plan-structure':     { positional: { min: 1, max: 1 }, flags: [] },
+    'plan-structure': { positional: { min: 1, max: 1 }, flags: [] },
     'phase-completeness': { positional: { min: 0, max: 1 }, flags: [] },
-    'references':         { positional: { min: 0, max: 1 }, flags: [] },
-    'commits':            { positional: { min: 0, max: null }, flags: [] },
-    'artifacts':          { positional: { min: 1, max: 1 }, flags: [] },
-    'key-links':          { positional: { min: 1, max: 1 }, flags: [] },
+    references: { positional: { min: 0, max: 1 }, flags: [] },
+    commits: { positional: { min: 0, max: null }, flags: [] },
+    artifacts: { positional: { min: 1, max: 1 }, flags: [] },
+    'key-links': { positional: { min: 1, max: 1 }, flags: [] },
   },
   phases: {
-    'list': { positional: { min: 0, max: 0 }, flags: ['--type', '--phase', '--include-archived'] },
+    list: {
+      positional: { min: 0, max: 0 },
+      flags: ['--type', '--phase', '--include-archived'],
+    },
   },
   roadmap: {
-    'get-phase':            { positional: { min: 1, max: 1 }, flags: ['--default'] },
-    'analyze':              { positional: { min: 0, max: 0 }, flags: ['--current'] },
+    'get-phase': { positional: { min: 1, max: 1 }, flags: ['--default'] },
+    analyze: { positional: { min: 0, max: 0 }, flags: ['--current'] },
     'update-plan-progress': { positional: { min: 1, max: 1 }, flags: [] },
-    'add-phase':            { positional: { min: 0, max: null }, flags: [] },
+    'add-phase': { positional: { min: 0, max: null }, flags: [] },
   },
   requirements: {
     'mark-complete': { positional: { min: 1, max: null }, flags: [] },
   },
   phase: {
     'next-decimal': { positional: { min: 1, max: 1 }, flags: [] },
-    'add':          { positional: { min: 0, max: null }, flags: [] },
-    'insert':       { positional: { min: 1, max: null }, flags: [] },
-    'remove':       { positional: { min: 1, max: 1 }, flags: ['--force'] },
-    'complete':     { positional: { min: 0, max: 1 }, flags: [] },
+    add: { positional: { min: 0, max: null }, flags: [] },
+    insert: { positional: { min: 1, max: null }, flags: [] },
+    remove: { positional: { min: 1, max: 1 }, flags: ['--force'] },
+    complete: { positional: { min: 0, max: 1 }, flags: [] },
   },
   milestone: {
     // max: null because --name can be followed by multi-word values (e.g. --name MVP Foundation)
-    'complete': { positional: { min: 0, max: null }, flags: ['--name', '--archive-phases'] },
+    complete: {
+      positional: { min: 0, max: null },
+      flags: ['--name', '--archive-phases'],
+    },
   },
   validate: {
-    'consistency': { positional: { min: 0, max: 0 }, flags: [] },
-    'health':      { positional: { min: 0, max: 0 }, flags: ['--repair'] },
+    consistency: { positional: { min: 0, max: 0 }, flags: [] },
+    health: { positional: { min: 0, max: 0 }, flags: ['--repair'] },
   },
   todo: {
-    'complete':          { positional: { min: 1, max: 1 }, flags: [] },
-    'list-by-phase':     { positional: { min: 1, max: 1 }, flags: [] },
+    complete: { positional: { min: 1, max: 1 }, flags: [] },
+    'list-by-phase': { positional: { min: 1, max: 1 }, flags: [] },
     'scan-phase-linked': { positional: { min: 1, max: 1 }, flags: [] },
   },
   init: {
     'execute-phase': { positional: { min: 1, max: 1 }, flags: [] },
-    'plan-phase':    { positional: { min: 1, max: 1 }, flags: [] },
-    'new-project':   { positional: { min: 0, max: 0 }, flags: [] },
+    'plan-phase': { positional: { min: 1, max: 1 }, flags: [] },
+    'new-project': { positional: { min: 0, max: 0 }, flags: [] },
     'new-milestone': { positional: { min: 0, max: 0 }, flags: [] },
-    'quick':         { positional: { min: 0, max: null }, flags: ['--verify'] },
-    'resume':        { positional: { min: 0, max: 0 }, flags: [] },
-    'verify-work':   { positional: { min: 1, max: 1 }, flags: [] },
-    'phase-op':      { positional: { min: 1, max: 1 }, flags: [] },
-    'todos':         { positional: { min: 0, max: 1 }, flags: [] },
-    'milestone-op':  { positional: { min: 0, max: 0 }, flags: [] },
-    'map-codebase':  { positional: { min: 0, max: 0 }, flags: [] },
-    'progress':      { positional: { min: 0, max: 0 }, flags: [] },
+    quick: { positional: { min: 0, max: null }, flags: ['--verify'] },
+    resume: { positional: { min: 0, max: 0 }, flags: [] },
+    'verify-work': { positional: { min: 1, max: 1 }, flags: [] },
+    'phase-op': { positional: { min: 1, max: 1 }, flags: [] },
+    todos: { positional: { min: 0, max: 1 }, flags: [] },
+    'milestone-op': { positional: { min: 0, max: 0 }, flags: [] },
+    'map-codebase': { positional: { min: 0, max: 0 }, flags: [] },
+    progress: { positional: { min: 0, max: 0 }, flags: [] },
   },
   guard: {
     // sync-chain omitted: takes a raw freeform arguments string, not discrete flags
-    'init-valid':  { positional: { min: 1, max: 1 }, flags: [] },
+    'init-valid': { positional: { min: 1, max: 1 }, flags: [] },
   },
   test: {
     'capture-baseline': { positional: { min: 2, max: 2 }, flags: [] },
@@ -321,29 +439,106 @@ const ARG_SCHEMAS = {
   // ─── Top-level commands with flags (_self schema convention) ─────────────
   // Only command-specific flags; global flags (--json, --file, --pick, --cwd)
   // are already stripped before dispatch.
-  'commit':             { _self: { positional: { min: 0, max: null }, flags: ['--amend', '--files'] } },
-  'verify-summary':     { _self: { positional: { min: 1, max: 1 }, flags: ['--check-count'] } },
-  'staleness-check':    { _self: { positional: { min: 0, max: 0 }, flags: ['--count'] } },
-  'sync-agents':        { _self: { positional: { min: 0, max: 0 }, flags: ['--agents-dir'] } },
-  'config-get':         { _self: { positional: { min: 1, max: 1 }, flags: ['--default'] } },
-  'update':             { _self: { positional: { min: 0, max: 0 }, flags: ['--dry-run', '--local', '--global'] } },
-  'scaffold':           { _self: { positional: { min: 1, max: null }, flags: ['--phase', '--name'] } },
-  'state-snapshot':     { _self: { positional: { min: 0, max: 0 }, flags: ['--current'] } },
-  'summary-extract':    { _self: { positional: { min: 1, max: 1 }, flags: ['--fields', '--default'] } },
-  'detect-platform':    { _self: { positional: { min: 0, max: 1 }, flags: ['--field'] } },
-  'detect-workspace':   { _self: { positional: { min: 0, max: 0 }, flags: ['--field'] } },
-  'git-context':        { _self: { positional: { min: 0, max: 0 }, flags: ['--field'] } },
-  'ssh-check':          { _self: { positional: { min: 0, max: 1 }, flags: ['--field'] } },
-  'websearch':          { _self: { positional: { min: 1, max: null }, flags: ['--limit', '--freshness'] } },
-  'squash':             { _self: { positional: { min: 0, max: 1 }, flags: ['--list-backup-tags', '--dry-run', '--allow-stable', '--strategy'] } },
-  'version-bump':       { _self: { positional: { min: 0, max: 0 }, flags: ['--level', '--scheme', '--snapshot', '--field'] } },
-  'generate-changelog': { _self: { positional: { min: 1, max: 1 }, flags: ['--date'] } },
-  'issue-import':       { _self: { positional: { min: 2, max: 2 }, flags: ['--repo'] } },
-  'issue-sync':         { _self: { positional: { min: 0, max: 1 }, flags: ['--auto'] } },
-  'divergence':         { _self: { positional: { min: 0, max: 0 }, flags: ['--refresh', '--init', '--triage', '--status', '--reason', '--branch', '--base', '--remote', '--remote-branch'] } },
-  'pingpong-check':     { _self: { positional: { min: 0, max: 0 }, flags: ['--window'] } },
-  'breakout-check':     { _self: { positional: { min: 0, max: 0 }, flags: ['--plan', '--declared-files'] } },
-  'cleanup':            { _self: { positional: { min: 0, max: 0 }, flags: ['--dry-run'] } },
+  commit: {
+    _self: { positional: { min: 0, max: null }, flags: ['--amend', '--files'] },
+  },
+  'verify-summary': {
+    _self: { positional: { min: 1, max: 1 }, flags: ['--check-count'] },
+  },
+  'staleness-check': {
+    _self: { positional: { min: 0, max: 0 }, flags: ['--count'] },
+  },
+  'sync-agents': {
+    _self: { positional: { min: 0, max: 0 }, flags: ['--agents-dir'] },
+  },
+  'config-get': {
+    _self: { positional: { min: 1, max: 1 }, flags: ['--default'] },
+  },
+  update: {
+    _self: {
+      positional: { min: 0, max: 0 },
+      flags: ['--dry-run', '--local', '--global'],
+    },
+  },
+  scaffold: {
+    _self: { positional: { min: 1, max: null }, flags: ['--phase', '--name'] },
+  },
+  'state-snapshot': {
+    _self: { positional: { min: 0, max: 0 }, flags: ['--current'] },
+  },
+  'summary-extract': {
+    _self: { positional: { min: 1, max: 1 }, flags: ['--fields', '--default'] },
+  },
+  'detect-platform': {
+    _self: { positional: { min: 0, max: 1 }, flags: ['--field'] },
+  },
+  'detect-workspace': {
+    _self: { positional: { min: 0, max: 0 }, flags: ['--field'] },
+  },
+  'git-context': {
+    _self: { positional: { min: 0, max: 0 }, flags: ['--field'] },
+  },
+  'ssh-check': {
+    _self: { positional: { min: 0, max: 1 }, flags: ['--field'] },
+  },
+  websearch: {
+    _self: {
+      positional: { min: 1, max: null },
+      flags: ['--limit', '--freshness'],
+    },
+  },
+  squash: {
+    _self: {
+      positional: { min: 0, max: 1 },
+      flags: [
+        '--list-backup-tags',
+        '--dry-run',
+        '--allow-stable',
+        '--strategy',
+      ],
+    },
+  },
+  'version-bump': {
+    _self: {
+      positional: { min: 0, max: 0 },
+      flags: ['--level', '--scheme', '--snapshot', '--field'],
+    },
+  },
+  'generate-changelog': {
+    _self: { positional: { min: 1, max: 1 }, flags: ['--date'] },
+  },
+  'issue-import': {
+    _self: { positional: { min: 2, max: 2 }, flags: ['--repo'] },
+  },
+  'issue-sync': {
+    _self: { positional: { min: 0, max: 1 }, flags: ['--auto'] },
+  },
+  divergence: {
+    _self: {
+      positional: { min: 0, max: 0 },
+      flags: [
+        '--refresh',
+        '--init',
+        '--triage',
+        '--status',
+        '--reason',
+        '--branch',
+        '--base',
+        '--remote',
+        '--remote-branch',
+      ],
+    },
+  },
+  'pingpong-check': {
+    _self: { positional: { min: 0, max: 0 }, flags: ['--window'] },
+  },
+  'breakout-check': {
+    _self: {
+      positional: { min: 0, max: 0 },
+      flags: ['--plan', '--declared-files'],
+    },
+  },
+  cleanup: { _self: { positional: { min: 0, max: 0 }, flags: ['--dry-run'] } },
 };
 
 /**
@@ -369,7 +564,7 @@ function validateArgs(command, subcommand, remainingArgs) {
     if (arg && !arg.startsWith('--') && /^[a-zA-Z][\w-]*=/.test(arg)) {
       error(
         `'${arg}' looks like a key=value assignment — positional args don't use '=' syntax.\n` +
-        `${usageHint}`
+          `${usageHint}`,
       );
     }
   }
@@ -389,7 +584,9 @@ function validateArgs(command, subcommand, remainingArgs) {
       }
     }
   }
-  const actualPositionals = remainingArgs.filter((a, i) => a && !a.startsWith('--') && !flagValueConsumed.has(i));
+  const actualPositionals = remainingArgs.filter(
+    (a, i) => a && !a.startsWith('--') && !flagValueConsumed.has(i),
+  );
 
   // 3. Flag handling: distinguish "flag where positional expected" vs "unknown flag"
   //    - If positional requirements are NOT met and schema accepts no flags:
@@ -398,35 +595,43 @@ function validateArgs(command, subcommand, remainingArgs) {
   //      an unrecognized --flag gets "Unknown flag"
   for (const arg of remainingArgs) {
     if (arg && arg.startsWith('--') && !schema.flags.includes(arg)) {
-      const positionalsSatisfied = actualPositionals.length >= schema.positional.min;
+      const positionalsSatisfied =
+        actualPositionals.length >= schema.positional.min;
       if (!positionalsSatisfied && schema.flags.length === 0) {
         // User passed a flag where a positional was required and no flags are valid
         error(
           `Positional argument expected, got '${arg}'.\n` +
-          `${usageHint}\n` +
-          `Example: ${cmdLabel}${schema.positional.min > 0 ? ' 40' : ''}`
+            `${usageHint}\n` +
+            `Example: ${cmdLabel}${schema.positional.min > 0 ? ' 40' : ''}`,
         );
       } else {
         // Unknown flag (positionals satisfied, or schema has some known flags)
-        const suggestion = schema.flags.length > 0
-          ? (() => {
-              // Simple closest-match by character overlap (good enough for small flag sets)
-              let best = null;
-              let bestScore = -1;
-              for (const f of schema.flags) {
-                const shorter = arg.length < f.length ? arg : f;
-                const longer = arg.length >= f.length ? arg : f;
-                let score = 0;
-                for (let i = 0; i < shorter.length; i++) {
-                  if (longer.includes(shorter[i])) score++;
+        const suggestion =
+          schema.flags.length > 0
+            ? (() => {
+                // Simple closest-match by character overlap (good enough for small flag sets)
+                let best = null;
+                let bestScore = -1;
+                for (const f of schema.flags) {
+                  const shorter = arg.length < f.length ? arg : f;
+                  const longer = arg.length >= f.length ? arg : f;
+                  let score = 0;
+                  for (let i = 0; i < shorter.length; i++) {
+                    if (longer.includes(shorter[i])) score++;
+                  }
+                  if (score > bestScore) {
+                    bestScore = score;
+                    best = f;
+                  }
                 }
-                if (score > bestScore) { bestScore = score; best = f; }
-              }
-              return bestScore > 2 ? ` Did you mean '${best}'?` : '';
-            })()
-          : '';
-        const knownList = schema.flags.length > 0 ? schema.flags.join(', ') : 'none';
-        error(`Unknown flag '${arg}' for '${cmdLabel}'.${suggestion} Known flags: ${knownList}`);
+                return bestScore > 2 ? ` Did you mean '${best}'?` : '';
+              })()
+            : '';
+        const knownList =
+          schema.flags.length > 0 ? schema.flags.join(', ') : 'none';
+        error(
+          `Unknown flag '${arg}' for '${cmdLabel}'.${suggestion} Known flags: ${knownList}`,
+        );
       }
     }
   }
@@ -435,13 +640,16 @@ function validateArgs(command, subcommand, remainingArgs) {
   if (actualPositionals.length < schema.positional.min) {
     error(
       `Too few arguments for '${cmdLabel}': expected at least ${schema.positional.min}, got ${actualPositionals.length}.\n` +
-      `${usageHint}`
+        `${usageHint}`,
     );
   }
-  if (schema.positional.max !== null && actualPositionals.length > schema.positional.max) {
+  if (
+    schema.positional.max !== null &&
+    actualPositionals.length > schema.positional.max
+  ) {
     error(
       `Too many arguments for '${cmdLabel}': expected at most ${schema.positional.max}, got ${actualPositionals.length}.\n` +
-      `${usageHint}`
+        `${usageHint}`,
     );
   }
 }
@@ -449,14 +657,17 @@ function validateArgs(command, subcommand, remainingArgs) {
 // ─── Levenshtein Distance (for typo detection) ────────────────────────────────
 
 function levenshtein(a, b) {
-  const m = a.length, n = b.length;
+  const m = a.length,
+    n = b.length;
   const dp = Array.from({ length: m + 1 }, (_, i) => Array(n + 1).fill(0));
   for (let i = 0; i <= m; i++) dp[i][0] = i;
   for (let j = 0; j <= n; j++) dp[0][j] = j;
   for (let i = 1; i <= m; i++)
     for (let j = 1; j <= n; j++)
-      dp[i][j] = a[i - 1] === b[j - 1] ? dp[i - 1][j - 1]
-        : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
+      dp[i][j] =
+        a[i - 1] === b[j - 1]
+          ? dp[i - 1][j - 1]
+          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
   return dp[m][n];
 }
 
@@ -482,7 +693,8 @@ function suggestSubcommand(input, currentCommand) {
   const sameResults = [];
   const crossResults = [];
 
-  const distThreshold = (sub) => sub.dist <= 2 && sub.dist < Math.ceil(sub.sub.length / 2);
+  const distThreshold = (sub) =>
+    sub.dist <= 2 && sub.dist < Math.ceil(sub.sub.length / 2);
 
   // 1. Same-namespace matching
   const sameSubcmds = SUBCOMMANDS[currentCommand] || [];
@@ -502,14 +714,22 @@ function suggestSubcommand(input, currentCommand) {
       const suggestion = `${ns} ${sub}`;
       // Direct levenshtein match against the subcommand alone
       const dist = levenshtein(input, sub);
-      if (dist <= 2 && dist < Math.ceil(sub.length / 2) && !crossSeen.has(suggestion)) {
+      if (
+        dist <= 2 &&
+        dist < Math.ceil(sub.length / 2) &&
+        !crossSeen.has(suggestion)
+      ) {
         crossResults.push({ suggestion, dist });
         crossSeen.add(suggestion);
       }
       // Also try matching against the full "ns subcommand" compound form (e.g., "phase complete" vs "complete-phase")
       const fullForm = `${ns}-${sub}`;
       const fullDist = levenshtein(input, fullForm);
-      if (fullDist <= 3 && fullDist < Math.ceil(fullForm.length / 2) && !crossSeen.has(suggestion)) {
+      if (
+        fullDist <= 3 &&
+        fullDist < Math.ceil(fullForm.length / 2) &&
+        !crossSeen.has(suggestion)
+      ) {
         crossResults.push({ suggestion, dist: fullDist });
         crossSeen.add(suggestion);
       }
@@ -560,8 +780,8 @@ function suggestSubcommand(input, currentCommand) {
   crossResults.sort((a, b) => a.dist - b.dist);
 
   return {
-    sameNamespace: sameResults.map(r => r.sub),
-    crossNamespace: crossResults.map(r => r.suggestion),
+    sameNamespace: sameResults.map((r) => r.sub),
+    crossNamespace: crossResults.map((r) => r.suggestion),
   };
 }
 
@@ -571,8 +791,14 @@ function printHelp({ exitCode = 0 } = {}) {
   const src = fs.readFileSync(__filename, 'utf8');
   const match = src.match(/\/\*\*([\s\S]*?)\*\//);
   const out = exitCode !== 0 ? process.stderr : process.stdout;
-  if (!match) { out.write('No help available.\n'); process.exit(exitCode); }
-  const lines = match[1].split('\n').map(l => l.replace(/^\s*\*\s?/, '')).filter((_, i, arr) => i > 0 || arr[i].trim());
+  if (!match) {
+    out.write('No help available.\n');
+    process.exit(exitCode);
+  }
+  const lines = match[1]
+    .split('\n')
+    .map((l) => l.replace(/^\s*\*\s?/, ''))
+    .filter((_, i, arr) => i > 0 || arr[i].trim());
   out.write(lines.join('\n').trim() + '\n');
   process.exit(exitCode);
 }
@@ -591,7 +817,7 @@ async function main() {
 
   // Optional cwd override for sandboxed subagents running outside project root.
   let cwd = process.cwd();
-  const cwdEqArg = args.find(arg => arg.startsWith('--cwd='));
+  const cwdEqArg = args.find((arg) => arg.startsWith('--cwd='));
   const cwdIdx = args.indexOf('--cwd');
   if (cwdEqArg) {
     const value = cwdEqArg.slice('--cwd='.length).trim();
@@ -646,7 +872,8 @@ async function main() {
   let pickField = null;
   if (pickIdx !== -1) {
     pickField = args[pickIdx + 1];
-    if (!pickField || pickField.startsWith('--')) error('Missing value for --pick');
+    if (!pickField || pickField.startsWith('--'))
+      error('Missing value for --pick');
     args.splice(pickIdx, 2);
   }
 
@@ -661,7 +888,7 @@ async function main() {
   // so we intercept at the fs layer; also intercept process.stdout.write for any
   // non-output() paths (printHelp, etc.).
   if (pickField) {
-    setJsonMode(true);  // --pick needs JSON to extract fields
+    setJsonMode(true); // --pick needs JSON to extract fields
     _origFsWriteSync = fs.writeSync.bind(fs);
     _origStdoutWrite = process.stdout.write.bind(process.stdout);
 
@@ -688,14 +915,21 @@ async function main() {
         const captured = _pickStdoutChunks.join('');
         let jsonStr = captured;
         if (jsonStr.startsWith('@file:')) {
-          try { jsonStr = fs.readFileSync(jsonStr.slice(6), 'utf-8'); } catch { jsonStr = captured; }
+          try {
+            jsonStr = fs.readFileSync(jsonStr.slice(6), 'utf-8');
+          } catch {
+            jsonStr = captured;
+          }
         }
         try {
           const obj = JSON.parse(jsonStr);
           const value = extractField(obj, pickField);
-          const result = value === null || value === undefined ? '' : String(value);
+          const result =
+            value === null || value === undefined ? '' : String(value);
           _origFsWriteSync(1, result);
-        } catch { _origFsWriteSync(1, captured); }
+        } catch {
+          _origFsWriteSync(1, captured);
+        }
       }
       origExit(code);
     };
@@ -703,10 +937,18 @@ async function main() {
 
   // Flag-style argument support: --phase 36.3 -> phase 36.3
   // Allows callers to use --command style (common mistake). Emits info hint to stderr.
-  if (command && command.startsWith('--') && command !== '--help' && command !== '-h') {
+  if (
+    command &&
+    command.startsWith('--') &&
+    command !== '--help' &&
+    command !== '-h'
+  ) {
     const flagName = command.slice(2); // strip --
     if (ALL_COMMANDS.includes(flagName)) {
-      fs.writeSync(2, `[info] Interpreted --${flagName} as command '${flagName}'. Canonical usage: gsd-tools ${flagName} ${args.slice(1).join(' ')}\n`);
+      fs.writeSync(
+        2,
+        `[info] Interpreted --${flagName} as command '${flagName}'. Canonical usage: gsd-tools ${flagName} ${args.slice(1).join(' ')}\n`,
+      );
       args[0] = flagName;
       command = flagName;
     }
@@ -730,20 +972,35 @@ async function main() {
         if (fieldIdx !== -1 || valueIdx !== -1) {
           // Named flag mode: --field NAME --value VALUE
           if (fieldIdx === -1 || valueIdx === -1) {
-            process.stderr.write(JSON.stringify({ error: '--field and --value must be used together. Usage: state patch --field <name> --value <val>' }) + '\n');
+            process.stderr.write(
+              JSON.stringify({
+                error:
+                  '--field and --value must be used together. Usage: state patch --field <name> --value <val>',
+              }) + '\n',
+            );
             process.exit(1);
           }
           const key = args[fieldIdx + 1];
           const val = args[valueIdx + 1];
           if (!key || key.startsWith('--') || !val) {
-            process.stderr.write(JSON.stringify({ error: '--field and --value require arguments. Usage: state patch --field <name> --value <val>' }) + '\n');
+            process.stderr.write(
+              JSON.stringify({
+                error:
+                  '--field and --value require arguments. Usage: state patch --field <name> --value <val>',
+              }) + '\n',
+            );
             process.exit(1);
           }
           patches[key] = val;
         } else {
           // Legacy positional mode: --key value pairs (strip -- prefix)
           if (args.length < 4) {
-            process.stderr.write(JSON.stringify({ error: 'state patch requires at least one field-value pair. Usage: state patch --<field> <value> OR state patch --field <name> --value <val>' }) + '\n');
+            process.stderr.write(
+              JSON.stringify({
+                error:
+                  'state patch requires at least one field-value pair. Usage: state patch --<field> <value> OR state patch --field <name> --value <val>',
+              }) + '\n',
+            );
             process.exit(1);
           }
           for (let i = 2; i < args.length; i += 2) {
@@ -755,7 +1012,10 @@ async function main() {
           }
         }
         if (Object.keys(patches).length === 0) {
-          process.stderr.write(JSON.stringify({ error: 'No valid field-value pairs provided' }) + '\n');
+          process.stderr.write(
+            JSON.stringify({ error: 'No valid field-value pairs provided' }) +
+              '\n',
+          );
           process.exit(1);
         }
         state.cmdStatePatch(cwd, patches);
@@ -787,7 +1047,8 @@ async function main() {
           summary: summaryIdx !== -1 ? args[summaryIdx + 1] : null,
           summary_file: summaryFileIdx !== -1 ? args[summaryFileIdx + 1] : null,
           rationale: rationaleIdx !== -1 ? args[rationaleIdx + 1] : '',
-          rationale_file: rationaleFileIdx !== -1 ? args[rationaleFileIdx + 1] : null,
+          rationale_file:
+            rationaleFileIdx !== -1 ? args[rationaleFileIdx + 1] : null,
         });
       } else if (subcommand === 'add-blocker') {
         const textIdx = args.indexOf('--text');
@@ -798,7 +1059,10 @@ async function main() {
         });
       } else if (subcommand === 'resolve-blocker') {
         const textIdx = args.indexOf('--text');
-        state.cmdStateResolveBlocker(cwd, textIdx !== -1 ? args[textIdx + 1] : null);
+        state.cmdStateResolveBlocker(
+          cwd,
+          textIdx !== -1 ? args[textIdx + 1] : null,
+        );
       } else if (subcommand === 'record-session') {
         const stoppedIdx = args.indexOf('--stopped-at');
         const resumeIdx = args.indexOf('--resume-file');
@@ -814,7 +1078,7 @@ async function main() {
           cwd,
           phaseIdx !== -1 ? args[phaseIdx + 1] : null,
           nameIdx !== -1 ? args[nameIdx + 1] : null,
-          plansIdx !== -1 ? parseInt(args[plansIdx + 1], 10) : null
+          plansIdx !== -1 ? parseInt(args[plansIdx + 1], 10) : null,
         );
       } else if (subcommand === 'adjust-quick-table') {
         state.cmdStateAdjustQuickTable(cwd);
@@ -824,13 +1088,22 @@ async function main() {
         state.cmdStateLoad(cwd);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'state');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`state ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown state subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.state.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`state ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown state subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.state.join(', ')}`,
+          );
         } else {
-          error(`Unknown state subcommand '${subcommand}'. Available: ${SUBCOMMANDS.state.join(', ')}`);
+          error(
+            `Unknown state subcommand '${subcommand}'. Available: ${SUBCOMMANDS.state.join(', ')}`,
+          );
         }
       }
       break;
@@ -850,15 +1123,21 @@ async function main() {
       validateArgs('sync-agents', null, args.slice(1));
       // Optional --agents-dir override (default: <cwd>/.claude/agents).
       const agentsDirIdx = args.indexOf('--agents-dir');
-      const customAgentsDir = agentsDirIdx !== -1 ? args[agentsDirIdx + 1] : null;
+      const customAgentsDir =
+        agentsDirIdx !== -1 ? args[agentsDirIdx + 1] : null;
       const agentsDir = customAgentsDir
         ? path.resolve(customAgentsDir)
         : path.join(cwd, '.claude', 'agents');
 
       if (!fs.existsSync(agentsDir)) {
         coreOutput(
-          { skipped: true, reason: 'agents-dir-missing', agentsDir, changes: [] },
-          `No agents directory found at ${agentsDir} — run the installer first.`
+          {
+            skipped: true,
+            reason: 'agents-dir-missing',
+            agentsDir,
+            changes: [],
+          },
+          `No agents directory found at ${agentsDir} — run the installer first.`,
         );
         break;
       }
@@ -871,21 +1150,20 @@ async function main() {
       // get a clean payload on stdout and the notice doesn't pollute pipelines.
       const syncSummary = syncResult.skipped
         ? 'Skipped — non-Claude runtime.'
-        : (changeCount === 0
+        : changeCount === 0
           ? 'Agents already in sync.'
-          : `Synced ${changeCount} agent${changeCount === 1 ? '' : 's'}.`);
+          : `Synced ${changeCount} agent${changeCount === 1 ? '' : 's'}.`;
 
       // Emit the restart notice via stderr ONLY when the helper reports real changes.
       // Same emission shape as Plan 04 (install.js) and Plan 05 (config.cjs) — one voice.
-      const restartNotice = effortSync.formatRestartNotice(syncResult.changes || []);
+      const restartNotice = effortSync.formatRestartNotice(
+        syncResult.changes || [],
+      );
       if (restartNotice) {
         process.stderr.write(restartNotice + '\n');
       }
 
-      coreOutput(
-        { ...syncResult, restartNotice },
-        syncSummary
-      );
+      coreOutput({ ...syncResult, restartNotice }, syncSummary);
       break;
     }
 
@@ -902,9 +1180,14 @@ async function main() {
       // then join them — handles both quoted ("multi word msg") and
       // unquoted (multi word msg) invocations from different shells
       const endIndex = filesIndex !== -1 ? filesIndex : args.length;
-      const messageArgs = args.slice(1, endIndex).filter(a => !a.startsWith('--'));
+      const messageArgs = args
+        .slice(1, endIndex)
+        .filter((a) => !a.startsWith('--'));
       const message = messageArgs.join(' ') || undefined;
-      const files = filesIndex !== -1 ? args.slice(filesIndex + 1).filter(a => !a.startsWith('--')) : [];
+      const files =
+        filesIndex !== -1
+          ? args.slice(filesIndex + 1).filter((a) => !a.startsWith('--'))
+          : [];
       commands.cmdCommit(cwd, message, files, amend);
       break;
     }
@@ -913,7 +1196,8 @@ async function main() {
       validateArgs('verify-summary', null, args.slice(1));
       const summaryPath = args[1];
       const countIndex = args.indexOf('--check-count');
-      const checkCount = countIndex !== -1 ? parseInt(args[countIndex + 1], 10) : 2;
+      const checkCount =
+        countIndex !== -1 ? parseInt(args[countIndex + 1], 10) : 2;
       verify.cmdVerifySummary(cwd, summaryPath, checkCount);
       break;
     }
@@ -941,13 +1225,22 @@ async function main() {
         });
       } else {
         const suggestions = suggestSubcommand(subcommand, 'template');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`template ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown template subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.template.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`template ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown template subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.template.join(', ')}`,
+          );
         } else {
-          error(`Unknown template subcommand '${subcommand}'. Available: ${SUBCOMMANDS.template.join(', ')}`);
+          error(
+            `Unknown template subcommand '${subcommand}'. Available: ${SUBCOMMANDS.template.join(', ')}`,
+          );
         }
       }
       break;
@@ -961,27 +1254,56 @@ async function main() {
         const fieldIdx = args.indexOf('--field');
         const formatIdx = args.indexOf('--format');
         const defaultIdx = args.indexOf('--default');
-        const defaultValue = defaultIdx !== -1 ? args[defaultIdx + 1] : undefined;
-        frontmatter.cmdFrontmatterGet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, formatIdx !== -1 ? args[formatIdx + 1] : null, defaultValue);
+        const defaultValue =
+          defaultIdx !== -1 ? args[defaultIdx + 1] : undefined;
+        frontmatter.cmdFrontmatterGet(
+          cwd,
+          file,
+          fieldIdx !== -1 ? args[fieldIdx + 1] : null,
+          formatIdx !== -1 ? args[formatIdx + 1] : null,
+          defaultValue,
+        );
       } else if (subcommand === 'set') {
         const fieldIdx = args.indexOf('--field');
         const valueIdx = args.indexOf('--value');
-        frontmatter.cmdFrontmatterSet(cwd, file, fieldIdx !== -1 ? args[fieldIdx + 1] : null, valueIdx !== -1 ? args[valueIdx + 1] : undefined);
+        frontmatter.cmdFrontmatterSet(
+          cwd,
+          file,
+          fieldIdx !== -1 ? args[fieldIdx + 1] : null,
+          valueIdx !== -1 ? args[valueIdx + 1] : undefined,
+        );
       } else if (subcommand === 'merge') {
         const dataIdx = args.indexOf('--data');
-        frontmatter.cmdFrontmatterMerge(cwd, file, dataIdx !== -1 ? args[dataIdx + 1] : null);
+        frontmatter.cmdFrontmatterMerge(
+          cwd,
+          file,
+          dataIdx !== -1 ? args[dataIdx + 1] : null,
+        );
       } else if (subcommand === 'validate') {
         const schemaIdx = args.indexOf('--schema');
-        frontmatter.cmdFrontmatterValidate(cwd, file, schemaIdx !== -1 ? args[schemaIdx + 1] : null);
+        frontmatter.cmdFrontmatterValidate(
+          cwd,
+          file,
+          schemaIdx !== -1 ? args[schemaIdx + 1] : null,
+        );
       } else {
         const suggestions = suggestSubcommand(subcommand, 'frontmatter');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`frontmatter ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown frontmatter subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.frontmatter.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`frontmatter ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown frontmatter subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.frontmatter.join(', ')}`,
+          );
         } else {
-          error(`Unknown frontmatter subcommand '${subcommand}'. Available: ${SUBCOMMANDS.frontmatter.join(', ')}`);
+          error(
+            `Unknown frontmatter subcommand '${subcommand}'. Available: ${SUBCOMMANDS.frontmatter.join(', ')}`,
+          );
         }
       }
       break;
@@ -1004,13 +1326,22 @@ async function main() {
         verify.cmdVerifyKeyLinks(cwd, args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'verify');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`verify ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown verify subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.verify.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`verify ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown verify subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.verify.join(', ')}`,
+          );
         } else {
-          error(`Unknown verify subcommand '${subcommand}'. Available: ${SUBCOMMANDS.verify.join(', ')}`);
+          error(
+            `Unknown verify subcommand '${subcommand}'. Available: ${SUBCOMMANDS.verify.join(', ')}`,
+          );
         }
       }
       break;
@@ -1059,7 +1390,7 @@ async function main() {
       break;
     }
 
-    case "config-set-model-profile": {
+    case 'config-set-model-profile': {
       config.cmdConfigSetModelProfile(cwd, args[1]);
       break;
     }
@@ -1096,13 +1427,22 @@ async function main() {
         phase.cmdPhasesList(cwd, options);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'phases');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`phases ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown phases subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.phases.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`phases ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown phases subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.phases.join(', ')}`,
+          );
         } else {
-          error(`Unknown phases subcommand '${subcommand}'. Available: ${SUBCOMMANDS.phases.join(', ')}`);
+          error(
+            `Unknown phases subcommand '${subcommand}'. Available: ${SUBCOMMANDS.phases.join(', ')}`,
+          );
         }
       }
       break;
@@ -1113,7 +1453,8 @@ async function main() {
       validateArgs('roadmap', subcommand, args.slice(2));
       if (subcommand === 'get-phase') {
         const defaultIdx = args.indexOf('--default');
-        const defaultValue = defaultIdx !== -1 ? args[defaultIdx + 1] : undefined;
+        const defaultValue =
+          defaultIdx !== -1 ? args[defaultIdx + 1] : undefined;
         roadmap.cmdRoadmapGetPhase(cwd, args[2], defaultValue);
       } else if (subcommand === 'analyze') {
         const analyzeCurrentFilter = args.slice(2).includes('--current');
@@ -1125,7 +1466,8 @@ async function main() {
             const fmMatch = stateContent.match(/^---\n([\s\S]*?)\n---/);
             if (fmMatch) {
               const cpMatch = fmMatch[1].match(/^current_phase:\s*(.+)$/m);
-              if (cpMatch) analyzePhaseFilter = cpMatch[1].trim().replace(/['"]/g, '');
+              if (cpMatch)
+                analyzePhaseFilter = cpMatch[1].trim().replace(/['"]/g, '');
             }
           } catch {}
         }
@@ -1137,13 +1479,22 @@ async function main() {
         phase.cmdPhaseAdd(cwd, args.slice(2).join(' '));
       } else {
         const suggestions = suggestSubcommand(subcommand, 'roadmap');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`roadmap ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown roadmap subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.roadmap.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`roadmap ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown roadmap subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.roadmap.join(', ')}`,
+          );
         } else {
-          error(`Unknown roadmap subcommand '${subcommand}'. Available: ${SUBCOMMANDS.roadmap.join(', ')}`);
+          error(
+            `Unknown roadmap subcommand '${subcommand}'. Available: ${SUBCOMMANDS.roadmap.join(', ')}`,
+          );
         }
       }
       break;
@@ -1156,13 +1507,22 @@ async function main() {
         milestone.cmdRequirementsMarkComplete(cwd, args.slice(2));
       } else {
         const suggestions = suggestSubcommand(subcommand, 'requirements');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`requirements ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown requirements subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.requirements.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`requirements ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown requirements subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.requirements.join(', ')}`,
+          );
         } else {
-          error(`Unknown requirements subcommand '${subcommand}'. Available: ${SUBCOMMANDS.requirements.join(', ')}`);
+          error(
+            `Unknown requirements subcommand '${subcommand}'. Available: ${SUBCOMMANDS.requirements.join(', ')}`,
+          );
         }
       }
       break;
@@ -1177,13 +1537,22 @@ async function main() {
         testBaseline.compareBaseline(args[2], args[3]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'test');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`test ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown test subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.test.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`test ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown test subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.test.join(', ')}`,
+          );
         } else {
-          error(`Unknown test subcommand '${subcommand}'. Available: ${SUBCOMMANDS.test.join(', ')}`);
+          error(
+            `Unknown test subcommand '${subcommand}'. Available: ${SUBCOMMANDS.test.join(', ')}`,
+          );
         }
       }
       break;
@@ -1205,13 +1574,22 @@ async function main() {
         phase.cmdPhaseComplete(cwd, args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'phase');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`phase ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown phase subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.phase.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`phase ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown phase subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.phase.join(', ')}`,
+          );
         } else {
-          error(`Unknown phase subcommand '${subcommand}'. Available: ${SUBCOMMANDS.phase.join(', ')}`);
+          error(
+            `Unknown phase subcommand '${subcommand}'. Available: ${SUBCOMMANDS.phase.join(', ')}`,
+          );
         }
       }
       break;
@@ -1233,16 +1611,28 @@ async function main() {
           }
           milestoneName = nameArgs.join(' ') || null;
         }
-        milestone.cmdMilestoneComplete(cwd, args[2], { name: milestoneName, archivePhases });
+        milestone.cmdMilestoneComplete(cwd, args[2], {
+          name: milestoneName,
+          archivePhases,
+        });
       } else {
         const suggestions = suggestSubcommand(subcommand, 'milestone');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`milestone ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown milestone subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.milestone.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`milestone ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown milestone subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.milestone.join(', ')}`,
+          );
         } else {
-          error(`Unknown milestone subcommand '${subcommand}'. Available: ${SUBCOMMANDS.milestone.join(', ')}`);
+          error(
+            `Unknown milestone subcommand '${subcommand}'. Available: ${SUBCOMMANDS.milestone.join(', ')}`,
+          );
         }
       }
       break;
@@ -1258,13 +1648,22 @@ async function main() {
         verify.cmdValidateHealth(cwd, { repair: repairFlag });
       } else {
         const suggestions = suggestSubcommand(subcommand, 'validate');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`validate ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown validate subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.validate.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`validate ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown validate subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.validate.join(', ')}`,
+          );
         } else {
-          error(`Unknown validate subcommand '${subcommand}'. Available: ${SUBCOMMANDS.validate.join(', ')}`);
+          error(
+            `Unknown validate subcommand '${subcommand}'. Available: ${SUBCOMMANDS.validate.join(', ')}`,
+          );
         }
       }
       break;
@@ -1293,13 +1692,22 @@ async function main() {
         commands.cmdTodoScanPhaseLinked(cwd, args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'todo');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`todo ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown todo subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.todo.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`todo ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown todo subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.todo.join(', ')}`,
+          );
         } else {
-          error(`Unknown todo subcommand '${subcommand}'. Available: ${SUBCOMMANDS.todo.join(', ')}`);
+          error(
+            `Unknown todo subcommand '${subcommand}'. Available: ${SUBCOMMANDS.todo.join(', ')}`,
+          );
         }
       }
       break;
@@ -1310,7 +1718,11 @@ async function main() {
       const dryRun = args.includes('--dry-run');
       const localInstall = args.includes('--local');
       const globalInstall = args.includes('--global');
-      commands.cmdUpdate(cwd, { dryRun, local: localInstall, global: globalInstall });
+      commands.cmdUpdate(cwd, {
+        dryRun,
+        local: localInstall,
+        global: globalInstall,
+      });
       break;
     }
 
@@ -1347,7 +1759,9 @@ async function main() {
           const verifyFlagIdx = args.indexOf('--verify');
           const verifyMode = verifyFlagIdx !== -1;
           // Remove --verify from args before joining as description
-          const descArgs = args.slice(2).filter((_, i) => i + 2 !== verifyFlagIdx);
+          const descArgs = args
+            .slice(2)
+            .filter((_, i) => i + 2 !== verifyFlagIdx);
           init.cmdInitQuick(cwd, descArgs.join(' '), verifyMode);
           break;
         }
@@ -1372,18 +1786,28 @@ async function main() {
         case 'progress':
           init.cmdInitProgress(cwd);
           break;
-        default:
-          {
-            const suggestions = workflow ? suggestSubcommand(workflow, 'init') : { sameNamespace: [], crossNamespace: [] };
-            if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
-              const parts = [];
-              if (suggestions.sameNamespace.length > 0) parts.push(`init ${suggestions.sameNamespace[0]}`);
-              if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-              error(`Unknown init workflow '${workflow}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.init.join(', ')}`);
-            } else {
-              error(`Unknown init workflow '${workflow}'. Available: ${SUBCOMMANDS.init.join(', ')}`);
-            }
+        default: {
+          const suggestions = workflow
+            ? suggestSubcommand(workflow, 'init')
+            : { sameNamespace: [], crossNamespace: [] };
+          if (
+            suggestions.sameNamespace.length > 0 ||
+            suggestions.crossNamespace.length > 0
+          ) {
+            const parts = [];
+            if (suggestions.sameNamespace.length > 0)
+              parts.push(`init ${suggestions.sameNamespace[0]}`);
+            if (suggestions.crossNamespace.length > 0)
+              parts.push(...suggestions.crossNamespace.slice(0, 2));
+            error(
+              `Unknown init workflow '${workflow}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.init.join(', ')}`,
+            );
+          } else {
+            error(
+              `Unknown init workflow '${workflow}'. Available: ${SUBCOMMANDS.init.join(', ')}`,
+            );
           }
+        }
       }
       break;
     }
@@ -1404,7 +1828,8 @@ async function main() {
           const fmMatch = stateContent.match(/^---\n([\s\S]*?)\n---/);
           if (fmMatch) {
             const cpMatch = fmMatch[1].match(/^current_phase:\s*(.+)$/m);
-            if (cpMatch) phaseForFilter = cpMatch[1].trim().replace(/['"]/g, '');
+            if (cpMatch)
+              phaseForFilter = cpMatch[1].trim().replace(/['"]/g, '');
           }
         } catch {}
       }
@@ -1416,9 +1841,11 @@ async function main() {
       validateArgs('summary-extract', null, args.slice(1));
       const summaryPath = args[1];
       const fieldsIndex = args.indexOf('--fields');
-      const fields = fieldsIndex !== -1 ? args[fieldsIndex + 1].split(',') : null;
+      const fields =
+        fieldsIndex !== -1 ? args[fieldsIndex + 1].split(',') : null;
       const seDefaultIdx = args.indexOf('--default');
-      const seDefaultValue = seDefaultIdx !== -1 ? args[seDefaultIdx + 1] : undefined;
+      const seDefaultValue =
+        seDefaultIdx !== -1 ? args[seDefaultIdx + 1] : undefined;
       commands.cmdSummaryExtract(cwd, summaryPath, fields, seDefaultValue);
       break;
     }
@@ -1535,11 +1962,15 @@ async function main() {
       const vbField = vbFieldIdx !== -1 ? args[vbFieldIdx + 1] : null;
       if (vbField) {
         // silent=true: returns result without calling output()/process.exit()
-        const vbResult = commands.cmdVersionBump(cwd, {
-          level: levelIdx >= 0 ? args[levelIdx + 1] : null,
-          scheme: schemeIdx >= 0 ? args[schemeIdx + 1] : null,
-          snapshot,
-        }, true);
+        const vbResult = commands.cmdVersionBump(
+          cwd,
+          {
+            level: levelIdx >= 0 ? args[levelIdx + 1] : null,
+            scheme: schemeIdx >= 0 ? args[schemeIdx + 1] : null,
+            snapshot,
+          },
+          true,
+        );
         if (vbResult && vbResult[vbField] !== undefined) {
           coreOutput(vbResult[vbField]);
         }
@@ -1577,14 +2008,20 @@ async function main() {
       // git.type_aliases is nested in config.json under the git section.
       // loadConfig() returns a flat object so we read the raw config file directly.
       const rtaConfigPath = path.join(cwd, '.planning', 'config.json');
-      let rtaAliases = { feat: 'feature', fix: 'bugfix', chore: 'chore', refactor: 'refactor' };
+      let rtaAliases = {
+        feat: 'feature',
+        fix: 'bugfix',
+        chore: 'chore',
+        refactor: 'refactor',
+      };
       try {
         const rtaCfg = JSON.parse(fs.readFileSync(rtaConfigPath, 'utf-8'));
         if (rtaCfg.git && rtaCfg.git.type_aliases) {
           rtaAliases = rtaCfg.git.type_aliases;
         }
       } catch {}
-      const resolvedAlias = rtaAliases[typeArg] !== undefined ? rtaAliases[typeArg] : typeArg;
+      const resolvedAlias =
+        rtaAliases[typeArg] !== undefined ? rtaAliases[typeArg] : typeArg;
       coreOutput({ type: typeArg, alias: resolvedAlias }, resolvedAlias);
       break;
     }
@@ -1641,7 +2078,10 @@ async function main() {
     case 'pingpong-check': {
       validateArgs('pingpong-check', null, args.slice(1));
       const windowIdx = args.indexOf('--window');
-      commands.cmdPingpongCheck(cwd, windowIdx !== -1 ? ['--window', args[windowIdx + 1]] : []);
+      commands.cmdPingpongCheck(
+        cwd,
+        windowIdx !== -1 ? ['--window', args[windowIdx + 1]] : [],
+      );
       break;
     }
 
@@ -1650,8 +2090,12 @@ async function main() {
       const planIdx = args.indexOf('--plan');
       const filesIdx = args.indexOf('--declared-files');
       const checkArgs = [];
-      if (planIdx !== -1) { checkArgs.push('--plan', args[planIdx + 1]); }
-      if (filesIdx !== -1) { checkArgs.push('--declared-files', args[filesIdx + 1]); }
+      if (planIdx !== -1) {
+        checkArgs.push('--plan', args[planIdx + 1]);
+      }
+      if (filesIdx !== -1) {
+        checkArgs.push('--declared-files', args[filesIdx + 1]);
+      }
       commands.cmdBreakoutCheck(cwd, checkArgs);
       break;
     }
@@ -1681,13 +2125,22 @@ async function main() {
         guard.cmdGuardInitValid(args[2]);
       } else {
         const suggestions = suggestSubcommand(subcommand, 'guard');
-        if (suggestions.sameNamespace.length > 0 || suggestions.crossNamespace.length > 0) {
+        if (
+          suggestions.sameNamespace.length > 0 ||
+          suggestions.crossNamespace.length > 0
+        ) {
           const parts = [];
-          if (suggestions.sameNamespace.length > 0) parts.push(`guard ${suggestions.sameNamespace[0]}`);
-          if (suggestions.crossNamespace.length > 0) parts.push(...suggestions.crossNamespace.slice(0, 2));
-          error(`Unknown guard subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.guard.join(', ')}`);
+          if (suggestions.sameNamespace.length > 0)
+            parts.push(`guard ${suggestions.sameNamespace[0]}`);
+          if (suggestions.crossNamespace.length > 0)
+            parts.push(...suggestions.crossNamespace.slice(0, 2));
+          error(
+            `Unknown guard subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.guard.join(', ')}`,
+          );
         } else {
-          error(`Unknown guard subcommand '${subcommand}'. Available: ${SUBCOMMANDS.guard.join(', ')}`);
+          error(
+            `Unknown guard subcommand '${subcommand}'. Available: ${SUBCOMMANDS.guard.join(', ')}`,
+          );
         }
       }
       break;
@@ -1695,16 +2148,20 @@ async function main() {
 
     default: {
       // Typo detection: suggest close matches using Levenshtein distance
-      const candidates = ALL_COMMANDS
-        .map(cmd => ({ cmd, dist: levenshtein(command, cmd) }))
-        .filter(c => c.dist <= 2 && c.dist < Math.ceil(c.cmd.length / 2))
+      const candidates = ALL_COMMANDS.map((cmd) => ({
+        cmd,
+        dist: levenshtein(command, cmd),
+      }))
+        .filter((c) => c.dist <= 2 && c.dist < Math.ceil(c.cmd.length / 2))
         .sort((a, b) => a.dist - b.dist);
 
       if (candidates.length > 0) {
-        const suggestions = candidates.map(c => c.cmd).join(', ');
+        const suggestions = candidates.map((c) => c.cmd).join(', ');
         error(`Unknown command '${command}'. Did you mean: ${suggestions}?`);
       } else {
-        error(`Unknown command '${command}'. Available commands: ${ALL_COMMANDS.join(', ')}`);
+        error(
+          `Unknown command '${command}'. Available commands: ${ALL_COMMANDS.join(', ')}`,
+        );
       }
     }
   }
@@ -1741,27 +2198,34 @@ const _pickFieldForPostRun = (() => {
   return i !== -1 ? process.argv[i + 1] : null;
 })();
 
-main().then(() => {
-  if (_pickFieldForPostRun && _pickStdoutChunks.length > 0) {
-    // Normal success path: output() wrote via fs.writeSync interception; process.exit not called.
-    // Restore originals first, then extract and write the requested field to real stdout.
-    if (_origFsWriteSync) fs.writeSync = _origFsWriteSync;
-    if (_origStdoutWrite) process.stdout.write = _origStdoutWrite;
+main()
+  .then(() => {
+    if (_pickFieldForPostRun && _pickStdoutChunks.length > 0) {
+      // Normal success path: output() wrote via fs.writeSync interception; process.exit not called.
+      // Restore originals first, then extract and write the requested field to real stdout.
+      if (_origFsWriteSync) fs.writeSync = _origFsWriteSync;
+      if (_origStdoutWrite) process.stdout.write = _origStdoutWrite;
 
-    let captured = _pickStdoutChunks.join('');
-    if (captured.startsWith('@file:')) {
-      try { captured = fs.readFileSync(captured.slice(6), 'utf-8'); } catch { /* keep as-is */ }
+      let captured = _pickStdoutChunks.join('');
+      if (captured.startsWith('@file:')) {
+        try {
+          captured = fs.readFileSync(captured.slice(6), 'utf-8');
+        } catch {
+          /* keep as-is */
+        }
+      }
+      try {
+        const obj = JSON.parse(captured);
+        const value = extractField(obj, _pickFieldForPostRun);
+        const result =
+          value === null || value === undefined ? '' : String(value);
+        process.stdout.write(result);
+      } catch {
+        process.stdout.write(captured);
+      }
     }
-    try {
-      const obj = JSON.parse(captured);
-      const value = extractField(obj, _pickFieldForPostRun);
-      const result = value === null || value === undefined ? '' : String(value);
-      process.stdout.write(result);
-    } catch {
-      process.stdout.write(captured);
-    }
-  }
-}).catch((err) => {
-  process.stderr.write((err && err.message) || String(err));
-  process.exit(1);
-});
+  })
+  .catch((err) => {
+    process.stderr.write((err && err.message) || String(err));
+    process.exit(1);
+  });

--- a/gsd-ng/bin/lib/allowlist.cjs
+++ b/gsd-ng/bin/lib/allowlist.cjs
@@ -26,25 +26,67 @@
  */
 const CLI_SUBCOMMANDS = {
   gh: [
-    'pr', 'issue', 'release', 'workflow', 'auth', 'search', 'run', 'status',
-    'repo view', 'repo list', 'repo clone', 'repo fork', 'repo create', 'repo sync', 'repo set-default',
-    'label list', 'label create', 'label clone',
+    'pr',
+    'issue',
+    'release',
+    'workflow',
+    'auth',
+    'search',
+    'run',
+    'status',
+    'repo view',
+    'repo list',
+    'repo clone',
+    'repo fork',
+    'repo create',
+    'repo sync',
+    'repo set-default',
+    'label list',
+    'label create',
+    'label clone',
   ],
   glab: [
-    'mr', 'issue', 'release', 'ci', 'auth',
-    'repo view', 'repo list', 'repo clone', 'repo fork', 'repo create',
-    'label list', 'label create',
+    'mr',
+    'issue',
+    'release',
+    'ci',
+    'auth',
+    'repo view',
+    'repo list',
+    'repo clone',
+    'repo fork',
+    'repo create',
+    'label list',
+    'label create',
   ],
   fj: [
-    'pr', 'issue', 'release', 'actions', 'auth',
-    'repo view', 'repo clone', 'repo fork', 'repo create',
+    'pr',
+    'issue',
+    'release',
+    'actions',
+    'auth',
+    'repo view',
+    'repo clone',
+    'repo fork',
+    'repo create',
     // NOTE: fj has no 'label' subcommand — intentionally empty (corrects Phase 54 ALLOW-14 drift)
   ],
   tea: [
-    'pr', 'pulls', 'issue', 'issues', 'release', 'releases', 'login', 'actions',
-    'repo list', 'repo create', 'repo fork',
-    'label list', 'label create',
-    'repos', 'labels',  // retained plural aliases (broad) — Phase 57 candidate to narrow
+    'pr',
+    'pulls',
+    'issue',
+    'issues',
+    'release',
+    'releases',
+    'login',
+    'actions',
+    'repo list',
+    'repo create',
+    'repo fork',
+    'label list',
+    'label create',
+    'repos',
+    'labels', // retained plural aliases (broad) — Phase 57 candidate to narrow
   ],
 };
 
@@ -83,7 +125,12 @@ function getAllPlatformCliPatterns() {
  * Platform name to CLI binary mapping.
  * Matches PLATFORM_CLI in commands.cjs.
  */
-const PLATFORM_TO_CLI = { github: 'gh', gitlab: 'glab', forgejo: 'fj', gitea: 'tea' };
+const PLATFORM_TO_CLI = {
+  github: 'gh',
+  gitlab: 'glab',
+  forgejo: 'fj',
+  gitea: 'tea',
+};
 
 /**
  * RW_FORMS — canonical Read/Edit/Write permission forms — both bare and glob.
@@ -91,10 +138,9 @@ const PLATFORM_TO_CLI = { github: 'gh', gitlab: 'glab', forgejo: 'fj', gitea: 't
  * from template entries before injecting the platform-appropriate form.
  * Single source of truth — see ALLOW-19.
  */
-const RW_FORMS = Object.freeze(new Set([
-  'Edit', 'Write', 'Read',
-  'Edit(*)', 'Write(*)', 'Read(*)',
-]));
+const RW_FORMS = Object.freeze(
+  new Set(['Edit', 'Write', 'Read', 'Edit(*)', 'Write(*)', 'Read(*)']),
+);
 
 /**
  * Return the Read/Edit/Write allow entries appropriate for the target platform.

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -5,11 +5,41 @@ const fs = require('fs');
 const path = require('path');
 const { execSync, spawnSync } = require('child_process');
 const os = require('os');
-const { safeReadFile, loadConfig, isGitIgnored, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, resolveModelInternal, resolveEffortInternal, extractCurrentMilestone, getPhaseCompletionStatus, toPosixPath, output, error, findPhaseInternal, planningPaths } = require('./core.cjs');
+const {
+  safeReadFile,
+  loadConfig,
+  isGitIgnored,
+  execGit,
+  normalizePhaseName,
+  comparePhaseNum,
+  getArchivedPhaseDirs,
+  generateSlugInternal,
+  getMilestoneInfo,
+  getMilestonePhaseFilter,
+  resolveModelInternal,
+  resolveEffortInternal,
+  extractCurrentMilestone,
+  getPhaseCompletionStatus,
+  toPosixPath,
+  output,
+  error,
+  findPhaseInternal,
+  planningPaths,
+} = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { MODEL_PROFILES, EFFORT_PROFILES } = require('./model-profiles.cjs');
-const { validatePath, scanForInjection, wrapUntrustedContent, logSecurityEvent } = require('./security.cjs');
-const { getPlatformCliPatterns, PLATFORM_TO_CLI, getReadEditWriteAllowRules, RW_FORMS } = require('./allowlist.cjs');
+const {
+  validatePath,
+  scanForInjection,
+  wrapUntrustedContent,
+  logSecurityEvent,
+} = require('./security.cjs');
+const {
+  getPlatformCliPatterns,
+  PLATFORM_TO_CLI,
+  getReadEditWriteAllowRules,
+  RW_FORMS,
+} = require('./allowlist.cjs');
 
 function cmdGenerateSlug(text) {
   if (!text) {
@@ -52,7 +82,7 @@ function cmdListTodos(cwd, area) {
   const todos = [];
 
   try {
-    const files = fs.readdirSync(pendingDir).filter(f => f.endsWith('.md'));
+    const files = fs.readdirSync(pendingDir).filter((f) => f.endsWith('.md'));
 
     for (const file of files) {
       try {
@@ -96,11 +126,17 @@ function cmdVerifyPathExists(cwd, targetPath) {
     }
   }
 
-  const fullPath = path.isAbsolute(targetPath) ? targetPath : path.join(cwd, targetPath);
+  const fullPath = path.isAbsolute(targetPath)
+    ? targetPath
+    : path.join(cwd, targetPath);
 
   try {
     const stats = fs.statSync(fullPath);
-    const type = stats.isDirectory() ? 'directory' : stats.isFile() ? 'file' : 'other';
+    const type = stats.isDirectory()
+      ? 'directory'
+      : stats.isFile()
+        ? 'file'
+        : 'other';
     const result = { exists: true, type };
     output(result, 'true');
   } catch {
@@ -119,18 +155,27 @@ function cmdHistoryDigest(cwd) {
   // Add archived phases first (oldest milestones first)
   const archived = getArchivedPhaseDirs(cwd);
   for (const a of archived) {
-    allPhaseDirs.push({ name: a.name, fullPath: a.fullPath, milestone: a.milestone });
+    allPhaseDirs.push({
+      name: a.name,
+      fullPath: a.fullPath,
+      milestone: a.milestone,
+    });
   }
 
   // Add current phases
   if (fs.existsSync(phasesDir)) {
     try {
-      const currentDirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-        .filter(e => e.isDirectory())
-        .map(e => e.name)
+      const currentDirs = fs
+        .readdirSync(phasesDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
         .sort();
       for (const dir of currentDirs) {
-        allPhaseDirs.push({ name: dir, fullPath: path.join(phasesDir, dir), milestone: null });
+        allPhaseDirs.push({
+          name: dir,
+          fullPath: path.join(phasesDir, dir),
+          milestone: null,
+        });
       }
     } catch {}
   }
@@ -143,7 +188,9 @@ function cmdHistoryDigest(cwd) {
 
   try {
     for (const { name: dir, fullPath: dirPath } of allPhaseDirs) {
-      const summaries = fs.readdirSync(dirPath).filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+      const summaries = fs
+        .readdirSync(dirPath)
+        .filter((f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
 
       for (const summary of summaries) {
         try {
@@ -163,33 +210,40 @@ function cmdHistoryDigest(cwd) {
 
           // Merge provides
           if (fm['dependency-graph'] && fm['dependency-graph'].provides) {
-            fm['dependency-graph'].provides.forEach(p => digest.phases[phaseNum].provides.add(p));
+            fm['dependency-graph'].provides.forEach((p) =>
+              digest.phases[phaseNum].provides.add(p),
+            );
           } else if (fm.provides) {
-            fm.provides.forEach(p => digest.phases[phaseNum].provides.add(p));
+            fm.provides.forEach((p) => digest.phases[phaseNum].provides.add(p));
           }
 
           // Merge affects
           if (fm['dependency-graph'] && fm['dependency-graph'].affects) {
-            fm['dependency-graph'].affects.forEach(a => digest.phases[phaseNum].affects.add(a));
+            fm['dependency-graph'].affects.forEach((a) =>
+              digest.phases[phaseNum].affects.add(a),
+            );
           }
 
           // Merge patterns
           if (fm['patterns-established']) {
-            fm['patterns-established'].forEach(p => digest.phases[phaseNum].patterns.add(p));
+            fm['patterns-established'].forEach((p) =>
+              digest.phases[phaseNum].patterns.add(p),
+            );
           }
 
           // Merge decisions
           if (fm['key-decisions']) {
-            fm['key-decisions'].forEach(d => {
+            fm['key-decisions'].forEach((d) => {
               digest.decisions.push({ phase: phaseNum, decision: d });
             });
           }
 
           // Merge tech stack
           if (fm['tech-stack'] && fm['tech-stack'].added) {
-            fm['tech-stack'].added.forEach(t => digest.tech_stack.add(typeof t === 'string' ? t : t.name));
+            fm['tech-stack'].added.forEach((t) =>
+              digest.tech_stack.add(typeof t === 'string' ? t : t.name),
+            );
           }
-
         } catch (e) {
           // Skip malformed summaries
         }
@@ -197,7 +251,7 @@ function cmdHistoryDigest(cwd) {
     }
 
     // Convert Sets to Arrays for JSON output
-    Object.keys(digest.phases).forEach(p => {
+    Object.keys(digest.phases).forEach((p) => {
       digest.phases[p].provides = [...digest.phases[p].provides];
       digest.phases[p].affects = [...digest.phases[p].affects];
       digest.phases[p].patterns = [...digest.phases[p].patterns];
@@ -272,7 +326,7 @@ function applyCommitFormat(message, config, context) {
 
 function appendIssueTrailers(message, trailers) {
   if (!trailers || trailers.length === 0) return message;
-  const lines = trailers.map(t => `${t.action} #${t.number}`);
+  const lines = trailers.map((t) => `${t.action} #${t.number}`);
   return message + '\n\n' + lines.join('\n');
 }
 
@@ -285,14 +339,22 @@ function cmdCommit(cwd, message, files, amend) {
 
   // Check commit_docs config
   if (!config.commit_docs) {
-    const result = { committed: false, hash: null, reason: 'skipped_commit_docs_false' };
+    const result = {
+      committed: false,
+      hash: null,
+      reason: 'skipped_commit_docs_false',
+    };
     output(result, 'skipped');
     return;
   }
 
   // Check if .planning is gitignored
   if (isGitIgnored(cwd, '.planning')) {
-    const result = { committed: false, hash: null, reason: 'skipped_gitignored' };
+    const result = {
+      committed: false,
+      hash: null,
+      reason: 'skipped_gitignored',
+    };
     output(result, 'skipped');
     return;
   }
@@ -309,15 +371,29 @@ function cmdCommit(cwd, message, files, amend) {
   }
 
   // Commit
-  const commitArgs = amend ? ['commit', '--amend', '--no-edit'] : ['commit', '-m', message];
+  const commitArgs = amend
+    ? ['commit', '--amend', '--no-edit']
+    : ['commit', '-m', message];
   const commitResult = execGit(cwd, commitArgs);
   if (commitResult.exitCode !== 0) {
-    if (commitResult.stdout.includes('nothing to commit') || commitResult.stderr.includes('nothing to commit')) {
-      const result = { committed: false, hash: null, reason: 'nothing_to_commit' };
+    if (
+      commitResult.stdout.includes('nothing to commit') ||
+      commitResult.stderr.includes('nothing to commit')
+    ) {
+      const result = {
+        committed: false,
+        hash: null,
+        reason: 'nothing_to_commit',
+      };
       output(result, 'nothing');
       return;
     }
-    const result = { committed: false, hash: null, reason: 'nothing_to_commit', error: commitResult.stderr };
+    const result = {
+      committed: false,
+      hash: null,
+      reason: 'nothing_to_commit',
+      error: commitResult.stderr,
+    };
     output(result, 'nothing');
     return;
   }
@@ -337,7 +413,10 @@ function cmdSummaryExtract(cwd, summaryPath, fields, defaultValue) {
   const fullPath = path.join(cwd, summaryPath);
 
   if (!fs.existsSync(fullPath)) {
-    if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+    if (defaultValue !== undefined) {
+      output(defaultValue, String(defaultValue));
+      return;
+    }
     output({ error: 'File not found', path: summaryPath });
     return;
   }
@@ -348,7 +427,7 @@ function cmdSummaryExtract(cwd, summaryPath, fields, defaultValue) {
   // Parse key-decisions into structured format
   const parseDecisions = (decisionsList) => {
     if (!decisionsList || !Array.isArray(decisionsList)) return [];
-    return decisionsList.map(d => {
+    return decisionsList.map((d) => {
       const colonIdx = d.indexOf(':');
       if (colonIdx > 0) {
         return {
@@ -413,7 +492,7 @@ async function cmdWebsearch(query, options) {
     count: String(options.limit || 10),
     country: 'us',
     search_lang: 'en',
-    text_decorations: 'false'
+    text_decorations: 'false',
   });
 
   if (options.freshness) {
@@ -425,10 +504,10 @@ async function cmdWebsearch(query, options) {
       `https://api.search.brave.com/res/v1/web/search?${params}`,
       {
         headers: {
-          'Accept': 'application/json',
-          'X-Subscription-Token': apiKey
-        }
-      }
+          Accept: 'application/json',
+          'X-Subscription-Token': apiKey,
+        },
+      },
     );
 
     if (!response.ok) {
@@ -438,19 +517,22 @@ async function cmdWebsearch(query, options) {
 
     const data = await response.json();
 
-    const results = (data.web?.results || []).map(r => ({
+    const results = (data.web?.results || []).map((r) => ({
       title: r.title,
       url: r.url,
       description: r.description,
-      age: r.age || null
+      age: r.age || null,
     }));
 
-    output({
-      available: true,
-      query,
-      count: results.length,
-      results
-    }, results.map(r => `${r.title}\n${r.url}\n${r.description}`).join('\n\n'));
+    output(
+      {
+        available: true,
+        query,
+        count: results.length,
+        results,
+      },
+      results.map((r) => `${r.title}\n${r.url}\n${r.description}`).join('\n\n'),
+    );
   } catch (err) {
     output({ available: false, error: err.message }, '');
   }
@@ -466,15 +548,22 @@ function cmdProgressRender(cwd, format) {
 
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => comparePhaseNum(a, b));
 
     for (const dir of dirs) {
       const dm = dir.match(/^(\d+(?:\.\d+)*)-?(.*)/);
       const phaseNum = dm ? dm[1] : dir;
       const phaseName = dm && dm[2] ? dm[2].replace(/-/g, ' ') : '';
       const phaseFiles = fs.readdirSync(path.join(phasesDir, dir));
-      const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').length;
-      const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md').length;
+      const plans = phaseFiles.filter(
+        (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md',
+      ).length;
+      const summaries = phaseFiles.filter(
+        (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+      ).length;
 
       totalPlans += plans;
       totalSummaries += summaries;
@@ -482,17 +571,30 @@ function cmdProgressRender(cwd, format) {
       let status;
       if (plans === 0) status = 'Pending';
       else {
-        const { isComplete, status: cs } = getPhaseCompletionStatus(path.join(phasesDir, dir));
-        if (isComplete) status = cs === 'complete (verified)' ? 'Complete (verified)' : 'Complete';
+        const { isComplete, status: cs } = getPhaseCompletionStatus(
+          path.join(phasesDir, dir),
+        );
+        if (isComplete)
+          status =
+            cs === 'complete (verified)' ? 'Complete (verified)' : 'Complete';
         else if (summaries > 0) status = 'In Progress';
         else status = 'Planned';
       }
 
-      phases.push({ number: phaseNum, name: phaseName, plans, summaries, status });
+      phases.push({
+        number: phaseNum,
+        name: phaseName,
+        plans,
+        summaries,
+        status,
+      });
     }
   } catch {}
 
-  const percent = totalPlans > 0 ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100)) : 0;
+  const percent =
+    totalPlans > 0
+      ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100))
+      : 0;
 
   if (format === 'table') {
     // Render markdown table
@@ -512,7 +614,10 @@ function cmdProgressRender(cwd, format) {
     const filled = Math.round((percent / 100) * barWidth);
     const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(barWidth - filled);
     const text = `[${bar}] ${totalSummaries}/${totalPlans} plans (${percent}%)`;
-    output({ bar: text, percent, completed: totalSummaries, total: totalPlans }, text);
+    output(
+      { bar: text, percent, completed: totalSummaries, total: totalPlans },
+      text,
+    );
   } else {
     // JSON format
     output({
@@ -537,7 +642,12 @@ function parseDuration(interval) {
   const match = String(interval || '').match(/^(\d+)([dwmy])$/i);
   if (!match) return null;
   const [, n, unit] = match;
-  const multipliers = { d: 86400000, w: 604800000, m: 2592000000, y: 31536000000 };
+  const multipliers = {
+    d: 86400000,
+    w: 604800000,
+    m: 2592000000,
+    y: 31536000000,
+  };
   return parseInt(n, 10) * (multipliers[unit.toLowerCase()] || 0);
 }
 
@@ -553,8 +663,10 @@ function isRecurringDue(todoData) {
   if (!recurring || String(recurring) === 'false') return false;
   const intervalMs = parseDuration(todoData.interval);
   if (!intervalMs) return true; // No valid interval = always due
-  const lastCompleted = todoData.last_completed ? new Date(todoData.last_completed).getTime() : 0;
-  return (Date.now() - lastCompleted) >= intervalMs;
+  const lastCompleted = todoData.last_completed
+    ? new Date(todoData.last_completed).getTime()
+    : 0;
+  return Date.now() - lastCompleted >= intervalMs;
 }
 
 function cmdTodoComplete(cwd, filename) {
@@ -562,7 +674,8 @@ function cmdTodoComplete(cwd, filename) {
     error('filename required for todo complete');
   }
 
-  const { todosPending: pendingDir, todosCompleted: completedDir } = planningPaths(cwd);
+  const { todosPending: pendingDir, todosCompleted: completedDir } =
+    planningPaths(cwd);
   const sourcePath = path.join(pendingDir, filename);
 
   if (!fs.existsSync(sourcePath)) {
@@ -584,17 +697,26 @@ function cmdTodoComplete(cwd, filename) {
       // Replace existing last_completed value
       updatedContent = content.replace(
         /^last_completed:.*$/m,
-        `last_completed: ${today}`
+        `last_completed: ${today}`,
       );
     } else {
       // Add last_completed before closing ---
-      updatedContent = content.replace(/\n---/, `\nlast_completed: ${today}\n---`);
+      updatedContent = content.replace(
+        /\n---/,
+        `\nlast_completed: ${today}\n---`,
+      );
     }
 
     fs.writeFileSync(sourcePath, updatedContent, 'utf-8');
     output(
-      { completed: true, recurring: true, file: filename, date: todayDate, next_due: fm.interval || 'unknown' },
-      `recurring-reset: ${filename}`
+      {
+        completed: true,
+        recurring: true,
+        file: filename,
+        date: todayDate,
+        next_due: fm.interval || 'unknown',
+      },
+      `recurring-reset: ${filename}`,
     );
     return;
   }
@@ -606,7 +728,11 @@ function cmdTodoComplete(cwd, filename) {
   const today = new Date().toISOString().split('T')[0];
   const completedContent = `completed: ${today}\n` + content;
 
-  fs.writeFileSync(path.join(completedDir, filename), completedContent, 'utf-8');
+  fs.writeFileSync(
+    path.join(completedDir, filename),
+    completedContent,
+    'utf-8',
+  );
   fs.unlinkSync(sourcePath);
 
   // Inline issue-sync for non-recurring completions with external_ref
@@ -615,14 +741,25 @@ function cmdTodoComplete(cwd, filename) {
     // object and does not expose the raw issue_tracker section.
     let itConfig = {};
     try {
-      const rawConfig = JSON.parse(fs.readFileSync(planningPaths(cwd).config, 'utf-8'));
+      const rawConfig = JSON.parse(
+        fs.readFileSync(planningPaths(cwd).config, 'utf-8'),
+      );
       itConfig = rawConfig.issue_tracker || {};
-    } catch { /* no config.json, use empty defaults */ }
+    } catch {
+      /* no config.json, use empty defaults */
+    }
     if (itConfig.auto_sync !== false) {
       try {
         const commitHash = getLatestCommitHash(cwd);
-        const syncResults = syncSingleRef(fm.external_ref, { commitHash }, itConfig);
-        output({ completed: true, file: filename, date: today, synced: syncResults }, 'completed');
+        const syncResults = syncSingleRef(
+          fm.external_ref,
+          { commitHash },
+          itConfig,
+        );
+        output(
+          { completed: true, file: filename, date: today, synced: syncResults },
+          'completed',
+        );
         return;
       } catch (_e) {
         // Sync failure is non-fatal — fall through to normal completion output
@@ -644,7 +781,7 @@ function cmdTodoListByPhase(cwd, phase) {
   const { todosPending } = planningPaths(cwd);
   let files = [];
   try {
-    files = fs.readdirSync(todosPending).filter(f => f.endsWith('.md'));
+    files = fs.readdirSync(todosPending).filter((f) => f.endsWith('.md'));
   } catch (_e) {
     // Directory doesn't exist — return empty
     output([]);
@@ -683,7 +820,10 @@ function cmdTodoScanPhaseLinked(cwd, phase) {
     }
     const content = fs.readFileSync(roadmapPath, 'utf-8');
     const escapedPhase = String(phase).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const phasePattern = new RegExp(`#{2,4}\\s*Phase\\s+${escapedPhase}:\\s*[^\\n]+`, 'i');
+    const phasePattern = new RegExp(
+      `#{2,4}\\s*Phase\\s+${escapedPhase}:\\s*[^\\n]+`,
+      'i',
+    );
     const headerMatch = content.match(phasePattern);
     if (!headerMatch) {
       output([]);
@@ -691,8 +831,12 @@ function cmdTodoScanPhaseLinked(cwd, phase) {
     }
     const sectionStart = headerMatch.index;
     const restOfContent = content.slice(sectionStart);
-    const nextHeaderMatch = restOfContent.match(/\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i);
-    const sectionEnd = nextHeaderMatch ? sectionStart + nextHeaderMatch.index : content.length;
+    const nextHeaderMatch = restOfContent.match(
+      /\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i,
+    );
+    const sectionEnd = nextHeaderMatch
+      ? sectionStart + nextHeaderMatch.index
+      : content.length;
     const section = content.slice(sectionStart, sectionEnd);
     const sourceTodosMatch = section.match(/\*\*Source Todos\*\*:\s*([^\n]+)/i);
     if (sourceTodosMatch) sourceTodosStr = sourceTodosMatch[1].trim();
@@ -708,10 +852,13 @@ function cmdTodoScanPhaseLinked(cwd, phase) {
 
   // Parse source_todos string: backtick-wrapped, comma-separated
   const todoFiles = sourceTodosStr
-    .replace(/`/g, '').split(',').map(s => s.trim()).filter(Boolean);
+    .replace(/`/g, '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
 
   // Return only files that exist in pending dir
-  const existing = todoFiles.filter(f => {
+  const existing = todoFiles.filter((f) => {
     try {
       return fs.existsSync(path.join(todosPending, f));
     } catch (_e) {
@@ -731,7 +878,7 @@ function cmdRecurringDue(cwd) {
   const due = [];
 
   try {
-    const files = fs.readdirSync(pendingDir).filter(f => f.endsWith('.md'));
+    const files = fs.readdirSync(pendingDir).filter((f) => f.endsWith('.md'));
     for (const file of files) {
       try {
         const content = fs.readFileSync(path.join(pendingDir, file), 'utf-8');
@@ -743,7 +890,9 @@ function cmdRecurringDue(cwd) {
               title: fm.title || 'Untitled',
               interval: fm.interval || 'unknown',
               last_completed: fm.last_completed || 'never',
-              path: toPosixPath(path.join('.planning', 'todos', 'pending', file)),
+              path: toPosixPath(
+                path.join('.planning', 'todos', 'pending', file),
+              ),
             });
           }
         }
@@ -757,7 +906,7 @@ function cmdRecurringDue(cwd) {
 
   output(
     { count: due.length, todos: due },
-    due.length > 0 ? due.map(d => d.file).join(', ') : 'none due'
+    due.length > 0 ? due.map((d) => d.file).join(', ') : 'none due',
   );
 }
 
@@ -802,15 +951,27 @@ function cmdScaffold(cwd, type, options) {
       fs.mkdirSync(phasesParent, { recursive: true });
       const dirPath = path.join(phasesParent, dirName);
       fs.mkdirSync(dirPath, { recursive: true });
-      output({ created: true, directory: `.planning/phases/${dirName}`, path: dirPath }, dirPath);
+      output(
+        {
+          created: true,
+          directory: `.planning/phases/${dirName}`,
+          path: dirPath,
+        },
+        dirPath,
+      );
       return;
     }
     default:
-      error(`Unknown scaffold type: ${type}. Available: context, uat, verification, phase-dir`);
+      error(
+        `Unknown scaffold type: ${type}. Available: context, uat, verification, phase-dir`,
+      );
   }
 
   if (fs.existsSync(filePath)) {
-    output({ created: false, reason: 'already_exists', path: filePath }, 'exists');
+    output(
+      { created: false, reason: 'already_exists', path: filePath },
+      'exists',
+    );
     return;
   }
 
@@ -820,7 +981,12 @@ function cmdScaffold(cwd, type, options) {
 }
 
 function cmdStats(cwd, format) {
-  const { phases: phasesDir, roadmap: roadmapPath, requirements: reqPath, state: statePath } = planningPaths(cwd);
+  const {
+    phases: phasesDir,
+    roadmap: roadmapPath,
+    requirements: reqPath,
+    state: statePath,
+  } = planningPaths(cwd);
   const milestone = getMilestoneInfo(cwd);
   const isDirInMilestone = getMilestonePhaseFilter(cwd);
 
@@ -830,8 +996,11 @@ function cmdStats(cwd, format) {
   let totalSummaries = 0;
 
   try {
-    const roadmapContent = extractCurrentMilestone(fs.readFileSync(roadmapPath, 'utf-8'));
-    const headingPattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+    const roadmapContent = extractCurrentMilestone(
+      fs.readFileSync(roadmapPath, 'utf-8'),
+    );
+    const headingPattern =
+      /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
     let match;
     while ((match = headingPattern.exec(roadmapContent)) !== null) {
       phasesByNumber.set(match[1], {
@@ -847,8 +1016,8 @@ function cmdStats(cwd, format) {
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
     const dirs = entries
-      .filter(e => e.isDirectory())
-      .map(e => e.name)
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
       .filter(isDirInMilestone)
       .sort((a, b) => comparePhaseNum(a, b));
 
@@ -857,8 +1026,12 @@ function cmdStats(cwd, format) {
       const phaseNum = dm ? dm[1] : dir;
       const phaseName = dm && dm[2] ? dm[2].replace(/-/g, ' ') : '';
       const phaseFiles = fs.readdirSync(path.join(phasesDir, dir));
-      const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').length;
-      const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md').length;
+      const plans = phaseFiles.filter(
+        (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md',
+      ).length;
+      const summaries = phaseFiles.filter(
+        (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+      ).length;
 
       totalPlans += plans;
       totalSummaries += summaries;
@@ -866,8 +1039,12 @@ function cmdStats(cwd, format) {
       let status;
       if (plans === 0) status = 'Not Started';
       else {
-        const { isComplete, status: cs } = getPhaseCompletionStatus(path.join(phasesDir, dir));
-        if (isComplete) status = cs === 'complete (verified)' ? 'Complete (verified)' : 'Complete';
+        const { isComplete, status: cs } = getPhaseCompletionStatus(
+          path.join(phasesDir, dir),
+        );
+        if (isComplete)
+          status =
+            cs === 'complete (verified)' ? 'Complete (verified)' : 'Complete';
         else if (summaries > 0) status = 'In Progress';
         else status = 'Planned';
       }
@@ -883,10 +1060,20 @@ function cmdStats(cwd, format) {
     }
   } catch {}
 
-  const phases = [...phasesByNumber.values()].sort((a, b) => comparePhaseNum(a.number, b.number));
-  const completedPhases = phases.filter(p => p.status === 'Complete' || p.status === 'Complete (verified)').length;
-  const planPercent = totalPlans > 0 ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100)) : 0;
-  const percent = phases.length > 0 ? Math.min(100, Math.round((completedPhases / phases.length) * 100)) : 0;
+  const phases = [...phasesByNumber.values()].sort((a, b) =>
+    comparePhaseNum(a.number, b.number),
+  );
+  const completedPhases = phases.filter(
+    (p) => p.status === 'Complete' || p.status === 'Complete (verified)',
+  ).length;
+  const planPercent =
+    totalPlans > 0
+      ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100))
+      : 0;
+  const percent =
+    phases.length > 0
+      ? Math.min(100, Math.round((completedPhases / phases.length) * 100))
+      : 0;
 
   // Requirements stats
   let requirementsTotal = 0;
@@ -897,7 +1084,8 @@ function cmdStats(cwd, format) {
       const checked = reqContent.match(/^- \[x\] \*\*/gm);
       const unchecked = reqContent.match(/^- \[ \] \*\*/gm);
       requirementsComplete = checked ? checked.length : 0;
-      requirementsTotal = requirementsComplete + (unchecked ? unchecked.length : 0);
+      requirementsTotal =
+        requirementsComplete + (unchecked ? unchecked.length : 0);
     }
   } catch {}
 
@@ -906,10 +1094,11 @@ function cmdStats(cwd, format) {
   try {
     if (fs.existsSync(statePath)) {
       const stateContent = fs.readFileSync(statePath, 'utf-8');
-      const activityMatch = stateContent.match(/^last_activity:\s*(.+)$/im)
-        || stateContent.match(/\*\*Last Activity:\*\*\s*(.+)/i)
-        || stateContent.match(/^Last Activity:\s*(.+)$/im)
-        || stateContent.match(/^Last activity:\s*(.+)$/im);
+      const activityMatch =
+        stateContent.match(/^last_activity:\s*(.+)$/im) ||
+        stateContent.match(/\*\*Last Activity:\*\*\s*(.+)/i) ||
+        stateContent.match(/^Last Activity:\s*(.+)$/im) ||
+        stateContent.match(/^Last activity:\s*(.+)$/im);
       if (activityMatch) lastActivity = activityMatch[1].trim();
     }
   } catch {}
@@ -1005,7 +1194,12 @@ const PLATFORM_CLI_URLS = {
 const ISSUE_COMMANDS = {
   github: {
     list: (repo, opts) => {
-      const args = ['issue', 'list', '--json', 'number,title,body,labels,state'];
+      const args = [
+        'issue',
+        'list',
+        '--json',
+        'number,title,body,labels,state',
+      ];
       if (repo) args.push('--repo', repo);
       if (opts.label) args.push('--label', opts.label);
       if (opts.milestone) args.push('--milestone', opts.milestone);
@@ -1013,7 +1207,13 @@ const ISSUE_COMMANDS = {
       return { cli: 'gh', args };
     },
     view: (number, repo) => {
-      const args = ['issue', 'view', String(number), '--json', 'number,title,body,labels,state'];
+      const args = [
+        'issue',
+        'view',
+        String(number),
+        '--json',
+        'number,title,body,labels,state',
+      ];
       if (repo) args.push('--repo', repo);
       return { cli: 'gh', args };
     },
@@ -1146,13 +1346,26 @@ const ISSUE_COMMANDS = {
       return { cli: 'tea', args };
     },
     create: (repo, title, body, labels) => {
-      const args = ['issues', 'create', '--title', title, '--description', body];
+      const args = [
+        'issues',
+        'create',
+        '--title',
+        title,
+        '--description',
+        body,
+      ];
       if (repo) args.push('--repo', repo);
       if (labels && labels.length) args.push('--label', labels.join(','));
       return { cli: 'tea', args };
     },
     label: (number, repo, labelName) => {
-      const args = ['issues', 'edit', String(number), '--add-labels', labelName];
+      const args = [
+        'issues',
+        'edit',
+        String(number),
+        '--add-labels',
+        labelName,
+      ];
       if (repo) args.push('--repo', repo);
       return { cli: 'tea', args };
     },
@@ -1175,26 +1388,31 @@ const ISSUE_COMMANDS = {
  */
 function parseExternalRef(refStr, defaultRepo) {
   if (!refStr) return [];
-  const refs = refStr.split(',').map(r => r.trim()).filter(Boolean);
-  return refs.map(ref => {
-    const actionMatch = ref.match(/^([^:]+):(.+):(\w+)$/);
-    let action = null;
-    let remainder = ref;
-    if (actionMatch && ['close', 'comment'].includes(actionMatch[3])) {
-      remainder = `${actionMatch[1]}:${actionMatch[2]}`;
-      action = actionMatch[3];
-    }
-    const match = remainder.match(/^([^:]+):(?:([^#]+)?#)(\d+)$/);
-    if (!match) return null;
-    const [, platform, repo, number] = match;
-    return {
-      platform,
-      repo: repo || defaultRepo || null,
-      number: parseInt(number, 10),
-      action: action || null,
-      raw: ref,
-    };
-  }).filter(Boolean);
+  const refs = refStr
+    .split(',')
+    .map((r) => r.trim())
+    .filter(Boolean);
+  return refs
+    .map((ref) => {
+      const actionMatch = ref.match(/^([^:]+):(.+):(\w+)$/);
+      let action = null;
+      let remainder = ref;
+      if (actionMatch && ['close', 'comment'].includes(actionMatch[3])) {
+        remainder = `${actionMatch[1]}:${actionMatch[2]}`;
+        action = actionMatch[3];
+      }
+      const match = remainder.match(/^([^:]+):(?:([^#]+)?#)(\d+)$/);
+      if (!match) return null;
+      const [, platform, repo, number] = match;
+      return {
+        platform,
+        repo: repo || defaultRepo || null,
+        number: parseInt(number, 10),
+        action: action || null,
+        raw: ref,
+      };
+    })
+    .filter(Boolean);
 }
 
 /**
@@ -1209,18 +1427,37 @@ function parseExternalRef(refStr, defaultRepo) {
 function invokeIssueCli(platform, operation, args) {
   const { spawnSync } = require('child_process');
   const platformCmds = ISSUE_COMMANDS[platform];
-  if (!platformCmds) return { success: false, error: `Unknown platform: ${platform}` };
-  if (!platformCmds[operation]) return { success: false, error: `Unknown operation: ${operation}` };
+  if (!platformCmds)
+    return { success: false, error: `Unknown platform: ${platform}` };
+  if (!platformCmds[operation])
+    return { success: false, error: `Unknown operation: ${operation}` };
   const cmdSpec = platformCmds[operation](...args);
   if (process.env.GSD_TEST_MODE) {
-    return { success: true, data: null, dry_run: true, cli: cmdSpec.cli, args: cmdSpec.args };
+    return {
+      success: true,
+      data: null,
+      dry_run: true,
+      cli: cmdSpec.cli,
+      args: cmdSpec.args,
+    };
   }
-  const result = spawnSync(cmdSpec.cli, cmdSpec.args, { stdio: 'pipe', encoding: 'utf-8' });
+  const result = spawnSync(cmdSpec.cli, cmdSpec.args, {
+    stdio: 'pipe',
+    encoding: 'utf-8',
+  });
   if (result.status !== 0) {
-    return { success: false, error: (result.stderr || result.stdout || '').trim(), exitCode: result.status };
+    return {
+      success: false,
+      error: (result.stderr || result.stdout || '').trim(),
+      exitCode: result.status,
+    };
   }
   let parsed = null;
-  try { parsed = JSON.parse(result.stdout); } catch { parsed = result.stdout.trim(); }
+  try {
+    parsed = JSON.parse(result.stdout);
+  } catch {
+    parsed = result.stdout.trim();
+  }
   return { success: true, data: parsed };
 }
 
@@ -1241,10 +1478,13 @@ function buildSyncComment(style, context) {
     if (ctx.prNumber) parts.push(`PR: #${ctx.prNumber}`);
     if (ctx.branchName) parts.push(`Branch: ${ctx.branchName}`);
     if (ctx.todoTitle) parts.push(`Todo: ${ctx.todoTitle}`);
-    return parts.length ? `Resolved via GSD. ${parts.join(', ')}.` : 'Resolved via GSD.';
+    return parts.length
+      ? `Resolved via GSD. ${parts.join(', ')}.`
+      : 'Resolved via GSD.';
   }
   if (ctx.prNumber) return `Resolved in PR #${ctx.prNumber}.`;
-  if (ctx.commitHash) return `Resolved in commit ${ctx.commitHash.slice(0, 7)}.`;
+  if (ctx.commitHash)
+    return `Resolved in commit ${ctx.commitHash.slice(0, 7)}.`;
   if (ctx.branchName) return `Resolved in branch ${ctx.branchName}.`;
   return 'Resolved.';
 }
@@ -1326,7 +1566,7 @@ function cmdDetectPlatform(cwd, remote, silent) {
     remote_url: remoteUrl,
     cli,
     cli_installed: cliInstalled,
-    cli_install_url: cli ? (PLATFORM_CLI_URLS[cli] || null) : null,
+    cli_install_url: cli ? PLATFORM_CLI_URLS[cli] || null : null,
   };
 
   // When called in silent mode (field extraction path), skip output/exit and return the result.
@@ -1341,9 +1581,10 @@ function cmdSquash(cwd, phase, options) {
   // Handle --list-backup-tags subcommand
   if (listTags) {
     const tagResult = execGit(cwd, ['tag', '--list', 'gsd/backup/*']);
-    const tags = tagResult.exitCode === 0 && tagResult.stdout
-      ? tagResult.stdout.split('\n').filter(Boolean)
-      : [];
+    const tags =
+      tagResult.exitCode === 0 && tagResult.stdout
+        ? tagResult.stdout.split('\n').filter(Boolean)
+        : [];
     output({ tags }, tags.join('\n'));
     return;
   }
@@ -1352,7 +1593,8 @@ function cmdSquash(cwd, phase, options) {
   if (!strategy) error('--strategy required: single, per-plan, or logical');
 
   const config = loadConfig(cwd);
-  const targetBranch = config.target_branch || (config.git && config.git.target_branch) || 'main';
+  const targetBranch =
+    config.target_branch || (config.git && config.git.target_branch) || 'main';
 
   // Get current branch name
   const branchResult = execGit(cwd, ['branch', '--show-current']);
@@ -1362,9 +1604,13 @@ function cmdSquash(cwd, phase, options) {
   const { phases: phasesDir } = planningPaths(cwd);
   let phaseDir = null;
   try {
-    const dirs = fs.readdirSync(phasesDir).filter(d =>
-      d.startsWith(String(phase).padStart(2, '0') + '-') || d.startsWith(String(phase) + '-')
-    );
+    const dirs = fs
+      .readdirSync(phasesDir)
+      .filter(
+        (d) =>
+          d.startsWith(String(phase).padStart(2, '0') + '-') ||
+          d.startsWith(String(phase) + '-'),
+      );
     if (dirs.length > 0) {
       phaseDir = path.join(phasesDir, dirs[0]);
     }
@@ -1374,14 +1620,19 @@ function cmdSquash(cwd, phase, options) {
   const summaries = [];
   if (phaseDir) {
     try {
-      const files = fs.readdirSync(phaseDir).filter(f => f.endsWith('-SUMMARY.md')).sort();
+      const files = fs
+        .readdirSync(phaseDir)
+        .filter((f) => f.endsWith('-SUMMARY.md'))
+        .sort();
       for (const file of files) {
         const content = fs.readFileSync(path.join(phaseDir, file), 'utf-8');
         // Extract bold one-liner from body (line starting with **)
         const oneLinerMatch = content.match(/^\*\*(.+)\*\*$/m);
         const oneLiner = oneLinerMatch ? oneLinerMatch[1] : null;
         const planMatch = file.match(/(\d+-\d+)/);
-        const planId = planMatch ? planMatch[1] : file.replace('-SUMMARY.md', '');
+        const planId = planMatch
+          ? planMatch[1]
+          : file.replace('-SUMMARY.md', '');
         summaries.push({ planId, oneLiner: oneLiner || `Plan ${planId}` });
       }
     } catch {}
@@ -1390,37 +1641,63 @@ function cmdSquash(cwd, phase, options) {
   // Build squash groups based on strategy
   let groups;
   if (strategy === 'single') {
-    const message = summaries.length > 0
-      ? summaries.map(s => `- ${s.planId}: ${s.oneLiner}`).join('\n')
-      : `Phase ${phase} squash`;
-    groups = [{ name: `Phase ${phase}`, commits: 'all', message: `feat: Phase ${phase}\n\n${message}` }];
+    const message =
+      summaries.length > 0
+        ? summaries.map((s) => `- ${s.planId}: ${s.oneLiner}`).join('\n')
+        : `Phase ${phase} squash`;
+    groups = [
+      {
+        name: `Phase ${phase}`,
+        commits: 'all',
+        message: `feat: Phase ${phase}\n\n${message}`,
+      },
+    ];
   } else if (strategy === 'per-plan') {
-    groups = summaries.map(s => ({
+    groups = summaries.map((s) => ({
       name: `Plan ${s.planId}`,
       commits: s.planId,
       message: `feat(${s.planId}): ${s.oneLiner}`,
     }));
     if (groups.length === 0) {
-      groups = [{ name: `Phase ${phase}`, commits: 'all', message: `feat: Phase ${phase}` }];
+      groups = [
+        {
+          name: `Phase ${phase}`,
+          commits: 'all',
+          message: `feat: Phase ${phase}`,
+        },
+      ];
     }
   } else if (strategy === 'logical') {
     // Logical = same as single for CLI; workflow presents interactive grouping
-    groups = [{ name: `Phase ${phase}`, commits: 'all', message: `feat: Phase ${phase}` }];
+    groups = [
+      {
+        name: `Phase ${phase}`,
+        commits: 'all',
+        message: `feat: Phase ${phase}`,
+      },
+    ];
   } else {
     error(`Unknown strategy: ${strategy}. Use: single, per-plan, logical`);
   }
 
   // Dry run: return plan without executing (safe even on stable branches)
   if (dryRun) {
-    output({ dry_run: true, strategy, phase, groups, executed: false },
-      `DRY RUN (${strategy}):\n` + groups.map(g => `  ${g.name}: ${g.message.split('\n')[0]}`).join('\n'));
+    output(
+      { dry_run: true, strategy, phase, groups, executed: false },
+      `DRY RUN (${strategy}):\n` +
+        groups
+          .map((g) => `  ${g.name}: ${g.message.split('\n')[0]}`)
+          .join('\n'),
+    );
     return;
   }
 
   // Safety: refuse to operate on stable branches without explicit flag (not applicable to dry-run)
   const stableBranches = ['main', 'master', 'develop'];
   if (stableBranches.includes(currentBranch) && !allowStable) {
-    error(`Refusing to squash on stable branch '${currentBranch}'. Use --allow-stable to override, or operate on a work/review branch.`);
+    error(
+      `Refusing to squash on stable branch '${currentBranch}'. Use --allow-stable to override, or operate on a work/review branch.`,
+    );
   }
 
   // Create backup tag BEFORE any rewrite
@@ -1455,7 +1732,9 @@ function cmdSquash(cwd, phase, options) {
     }
 
     if (!baseRef) {
-      error(`Cannot find squash base — neither merge-base with ${targetBranch} nor root commit found`);
+      error(
+        `Cannot find squash base — neither merge-base with ${targetBranch} nor root commit found`,
+      );
     }
 
     execGit(cwd, ['reset', '--soft', baseRef]);
@@ -1467,16 +1746,21 @@ function cmdSquash(cwd, phase, options) {
 
   // Verify backup tag exists
   const verifyTag = execGit(cwd, ['tag', '--list', 'gsd/backup/*']);
-  const backupTags = verifyTag.stdout ? verifyTag.stdout.split('\n').filter(Boolean) : [];
+  const backupTags = verifyTag.stdout
+    ? verifyTag.stdout.split('\n').filter(Boolean)
+    : [];
 
-  output({
-    squashed: true,
-    strategy,
-    phase,
-    groups: groups.length,
-    backup_tag: backupTags[backupTags.length - 1] || backupTag,
-    executed: true,
-  }, `Squashed (${strategy}): ${groups.length} group(s), backup: ${backupTag}`);
+  output(
+    {
+      squashed: true,
+      strategy,
+      phase,
+      groups: groups.length,
+      backup_tag: backupTags[backupTags.length - 1] || backupTag,
+      executed: true,
+    },
+    `Squashed (${strategy}): ${groups.length} group(s), backup: ${backupTag}`,
+  );
 }
 
 /**
@@ -1500,8 +1784,10 @@ function categorizeCommitType(oneLiner) {
  */
 function deriveVersionBump(summaries) {
   if (!summaries || summaries.length === 0) return 'patch';
-  if (summaries.some(s => s.oneLiner && /BREAKING CHANGE/i.test(s.oneLiner))) return 'major';
-  if (summaries.some(s => s.oneLiner && /^feat[\s(:]/i.test(s.oneLiner))) return 'minor';
+  if (summaries.some((s) => s.oneLiner && /BREAKING CHANGE/i.test(s.oneLiner)))
+    return 'major';
+  if (summaries.some((s) => s.oneLiner && /^feat[\s(:]/i.test(s.oneLiner)))
+    return 'minor';
   return 'patch';
 }
 
@@ -1575,7 +1861,10 @@ function generateChangelog(version, date, summaries) {
     const category = categorizeCommitType(s.oneLiner);
     // Strip type prefix for cleaner entry
     let description = s.oneLiner || `Plan ${s.planId}`;
-    description = description.replace(/^(feat|fix|refactor|perf|revert|chore|docs|test)\s*(\([^)]*\))?\s*:\s*/i, '');
+    description = description.replace(
+      /^(feat|fix|refactor|perf|revert|chore|docs|test)\s*(\([^)]*\))?\s*:\s*/i,
+      '',
+    );
     // Capitalize first letter
     description = description.charAt(0).toUpperCase() + description.slice(1);
     categories[category].push(`- ${description} [Plan ${s.planId}]`);
@@ -1623,13 +1912,19 @@ function cmdVersionBump(cwd, options, silent) {
     const { phases: phasesDir } = planningPaths(cwd);
     const summaries = [];
     try {
-      const dirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-        .filter(e => e.isDirectory()).map(e => e.name);
+      const dirs = fs
+        .readdirSync(phasesDir, { withFileTypes: true })
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
       for (const dir of dirs) {
-        const files = fs.readdirSync(path.join(phasesDir, dir))
-          .filter(f => f.endsWith('-SUMMARY.md'));
+        const files = fs
+          .readdirSync(path.join(phasesDir, dir))
+          .filter((f) => f.endsWith('-SUMMARY.md'));
         for (const file of files) {
-          const content = fs.readFileSync(path.join(phasesDir, dir, file), 'utf-8');
+          const content = fs.readFileSync(
+            path.join(phasesDir, dir, file),
+            'utf-8',
+          );
           const oneLinerMatch = content.match(/^\*\*(.+)\*\*$/m);
           summaries.push({ oneLiner: oneLinerMatch ? oneLinerMatch[1] : null });
         }
@@ -1685,17 +1980,30 @@ function cmdGenerateChangelog(cwd, version, options) {
   const { phases: phasesDir } = planningPaths(cwd);
   const summaries = [];
   try {
-    const dirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-      .filter(e => e.isDirectory()).map(e => e.name).sort();
+    const dirs = fs
+      .readdirSync(phasesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
     for (const dir of dirs) {
-      const files = fs.readdirSync(path.join(phasesDir, dir))
-        .filter(f => f.endsWith('-SUMMARY.md')).sort();
+      const files = fs
+        .readdirSync(path.join(phasesDir, dir))
+        .filter((f) => f.endsWith('-SUMMARY.md'))
+        .sort();
       for (const file of files) {
-        const content = fs.readFileSync(path.join(phasesDir, dir, file), 'utf-8');
+        const content = fs.readFileSync(
+          path.join(phasesDir, dir, file),
+          'utf-8',
+        );
         const oneLinerMatch = content.match(/^\*\*(.+)\*\*$/m);
         const planMatch = file.match(/(\d+(?:\.\d+)?-\d+)/);
-        const planId = planMatch ? planMatch[1] : file.replace('-SUMMARY.md', '');
-        summaries.push({ planId, oneLiner: oneLinerMatch ? oneLinerMatch[1] : null });
+        const planId = planMatch
+          ? planMatch[1]
+          : file.replace('-SUMMARY.md', '');
+        summaries.push({
+          planId,
+          oneLiner: oneLinerMatch ? oneLinerMatch[1] : null,
+        });
       }
     }
   } catch {}
@@ -1715,9 +2023,17 @@ function cmdGenerateChangelog(cwd, version, options) {
     const unreleasedIdx = existingContent.indexOf('## [Unreleased]');
     if (unreleasedIdx >= 0) {
       // Find the next ## header after [Unreleased]
-      const afterUnreleased = existingContent.indexOf('\n## [', unreleasedIdx + 1);
+      const afterUnreleased = existingContent.indexOf(
+        '\n## [',
+        unreleasedIdx + 1,
+      );
       if (afterUnreleased >= 0) {
-        updatedContent = existingContent.slice(0, afterUnreleased) + '\n' + block + '\n' + existingContent.slice(afterUnreleased + 1);
+        updatedContent =
+          existingContent.slice(0, afterUnreleased) +
+          '\n' +
+          block +
+          '\n' +
+          existingContent.slice(afterUnreleased + 1);
       } else {
         // No version after Unreleased — append at end
         updatedContent = existingContent.trimEnd() + '\n\n' + block;
@@ -1726,7 +2042,12 @@ function cmdGenerateChangelog(cwd, version, options) {
       // No Unreleased section — insert after first blank line after heading
       const firstNewline = existingContent.indexOf('\n\n');
       if (firstNewline >= 0) {
-        updatedContent = existingContent.slice(0, firstNewline) + '\n\n' + block + '\n' + existingContent.slice(firstNewline + 2);
+        updatedContent =
+          existingContent.slice(0, firstNewline) +
+          '\n\n' +
+          block +
+          '\n' +
+          existingContent.slice(firstNewline + 2);
       } else {
         updatedContent = existingContent + '\n\n' + block;
       }
@@ -1744,18 +2065,24 @@ function cmdGenerateChangelog(cwd, version, options) {
   if (unreleasedStart >= 0) {
     const unreleasedEnd = finalContent.indexOf('\n## [', unreleasedStart + 15);
     if (unreleasedEnd >= 0) {
-      finalContent = finalContent.slice(0, unreleasedStart + '## [Unreleased]'.length) + '\n' + finalContent.slice(unreleasedEnd);
+      finalContent =
+        finalContent.slice(0, unreleasedStart + '## [Unreleased]'.length) +
+        '\n' +
+        finalContent.slice(unreleasedEnd);
       fs.writeFileSync(changelogPath, finalContent, 'utf-8');
     }
   }
 
-  output({
-    generated: true,
-    version,
-    date,
-    entries: summaries.length,
-    path: 'CHANGELOG.md',
-  }, `CHANGELOG.md updated with ${summaries.length} entries for v${version}`);
+  output(
+    {
+      generated: true,
+      version,
+      date,
+      entries: summaries.length,
+      path: 'CHANGELOG.md',
+    },
+    `CHANGELOG.md updated with ${summaries.length} entries for v${version}`,
+  );
 }
 
 /**
@@ -1792,9 +2119,13 @@ function cmdIssueImport(cwd, platform, number, repo) {
   // returns a flat structured object and does not expose the raw issue_tracker section.
   let itConfig = {};
   try {
-    const rawConfig = JSON.parse(fs.readFileSync(planningPaths(cwd).config, 'utf-8'));
+    const rawConfig = JSON.parse(
+      fs.readFileSync(planningPaths(cwd).config, 'utf-8'),
+    );
     itConfig = rawConfig.issue_tracker || {};
-  } catch { /* no config.json, use empty defaults */ }
+  } catch {
+    /* no config.json, use empty defaults */
+  }
   const commentStyle = itConfig.comment_style || 'external';
   const commentOnImport = commentStyle === 'verbose';
 
@@ -1805,13 +2136,15 @@ function cmdIssueImport(cwd, platform, number, repo) {
     const labels = process.env.GSD_TEST_LABELS
       ? JSON.parse(process.env.GSD_TEST_LABELS)
       : [];
-    const iid = process.env.GSD_TEST_IID ? parseInt(process.env.GSD_TEST_IID, 10) : null;
+    const iid = process.env.GSD_TEST_IID
+      ? parseInt(process.env.GSD_TEST_IID, 10)
+      : null;
     issueData = {
       number: iid || parseInt(String(number), 10),
       iid: iid || null,
       title: 'Test issue ' + number,
       body: process.env.GSD_TEST_BODY || 'Test body',
-      labels: labels.map(l => (typeof l === 'string' ? { name: l } : l)),
+      labels: labels.map((l) => (typeof l === 'string' ? { name: l } : l)),
       state: 'open',
     };
   } else {
@@ -1831,8 +2164,8 @@ function cmdIssueImport(cwd, platform, number, repo) {
   const title = issueData.title || `Issue #${issueNumber}`;
   const body = issueData.body || '';
   const rawLabels = issueData.labels || [];
-  const labelNames = rawLabels.map(l =>
-    typeof l === 'string' ? l.toLowerCase() : (l.name || '').toLowerCase()
+  const labelNames = rawLabels.map((l) =>
+    typeof l === 'string' ? l.toLowerCase() : (l.name || '').toLowerCase(),
   );
 
   // Map first matching label to area, or 'general'
@@ -1858,17 +2191,29 @@ function cmdIssueImport(cwd, platform, number, repo) {
 
   // Log all findings regardless of tier
   if (!titleScan.clean) {
-    logSecurityEvent(cwd, { source: `issue-import:${externalRef}:title`, tier: titleScan.tier, blocked: titleScan.blocked, findings: titleScan.findings });
+    logSecurityEvent(cwd, {
+      source: `issue-import:${externalRef}:title`,
+      tier: titleScan.tier,
+      blocked: titleScan.blocked,
+      findings: titleScan.findings,
+    });
   }
   if (!bodyScan.clean) {
-    logSecurityEvent(cwd, { source: `issue-import:${externalRef}:body`, tier: bodyScan.tier, blocked: bodyScan.blocked, findings: bodyScan.findings });
+    logSecurityEvent(cwd, {
+      source: `issue-import:${externalRef}:body`,
+      tier: bodyScan.tier,
+      blocked: bodyScan.blocked,
+      findings: bodyScan.findings,
+    });
   }
 
   // Block on high-confidence detection (unambiguous attack indicators in external content)
   const highTier = titleScan.tier === 'high' || bodyScan.tier === 'high';
   if (highTier) {
     const allBlocked = [...titleScan.blocked, ...bodyScan.blocked];
-    error(`[SECURITY] High-confidence injection detected in issue ${externalRef}. Detected: ${allBlocked.join('; ')}. Re-run with --force-unsafe to override.`);
+    error(
+      `[SECURITY] High-confidence injection detected in issue ${externalRef}. Detected: ${allBlocked.join('; ')}. Re-run with --force-unsafe to override.`,
+    );
   }
 
   // Wrap body in untrusted-content tags for all non-blocked writes
@@ -1919,7 +2264,9 @@ function cmdIssueImport(cwd, platform, number, repo) {
   let commented = false;
   if (commentOnImport) {
     try {
-      const importComment = buildImportComment(commentStyle, { todoFile: filename });
+      const importComment = buildImportComment(commentStyle, {
+        todoFile: filename,
+      });
       invokeIssueCli(platform, 'comment', [issueNumber, repo, importComment]);
       commented = true;
     } catch (_e) {
@@ -1963,17 +2310,24 @@ function parseRequirementsExternalRefs(content) {
       continue;
     }
 
-    const cells = line.split('|').map(c => c.trim()).filter(Boolean);
+    const cells = line
+      .split('|')
+      .map((c) => c.trim())
+      .filter(Boolean);
 
     // Detect header row
     if (!inTable) {
-      const lowerCells = cells.map(c => c.toLowerCase());
-      const hasExternalRef = lowerCells.some(c => c.includes('external_ref') || c === 'external ref');
+      const lowerCells = cells.map((c) => c.toLowerCase());
+      const hasExternalRef = lowerCells.some(
+        (c) => c.includes('external_ref') || c === 'external ref',
+      );
       if (hasExternalRef) {
         inTable = true;
-        externalRefCol = lowerCells.findIndex(c => c.includes('external_ref') || c === 'external ref');
-        statusCol = lowerCells.findIndex(c => c === 'status');
-        idCol = lowerCells.findIndex(c => c === 'id');
+        externalRefCol = lowerCells.findIndex(
+          (c) => c.includes('external_ref') || c === 'external ref',
+        );
+        statusCol = lowerCells.findIndex((c) => c === 'status');
+        idCol = lowerCells.findIndex((c) => c === 'id');
         continue;
       }
     }
@@ -1981,7 +2335,7 @@ function parseRequirementsExternalRefs(content) {
     if (!inTable) continue;
 
     // Skip separator rows
-    if (cells.every(c => /^[-:]+$/.test(c))) continue;
+    if (cells.every((c) => /^[-:]+$/.test(c))) continue;
 
     if (externalRefCol >= 0 && externalRefCol < cells.length) {
       const extRef = cells[externalRefCol];
@@ -2024,13 +2378,16 @@ function applyVerifyLabel(platform, number, repo, verifyLabel) {
   let result = invokeIssueCli(platform, 'label', [number, repo, verifyLabel]);
   if (!result.success) {
     // Try to auto-create the label first, then retry
-    const createResult = invokeIssueCli(platform, 'label_create', [repo, verifyLabel]);
+    const createResult = invokeIssueCli(platform, 'label_create', [
+      repo,
+      verifyLabel,
+    ]);
     if (createResult.success) {
       result = invokeIssueCli(platform, 'label', [number, repo, verifyLabel]);
     }
     if (!result.success) {
       process.stderr.write(
-        `Warning: Could not apply verify label '${verifyLabel}' to ${platform}:#${number}. ${result.error || ''}. Continuing without label.\n`
+        `Warning: Could not apply verify label '${verifyLabel}' to ${platform}:#${number}. ${result.error || ''}. Continuing without label.\n`,
       );
     }
   }
@@ -2071,32 +2428,67 @@ function syncSingleRef(refStr, commentContext, itConfig) {
     let cliResult;
     if (action === 'close' && closeState === 'verify') {
       // Apply verify label only — leave issue open for manual sign-off
-      const labeled = applyVerifyLabel(ref.platform, ref.number, ref.repo, verifyLabel);
+      const labeled = applyVerifyLabel(
+        ref.platform,
+        ref.number,
+        ref.repo,
+        verifyLabel,
+      );
       cliResult = { success: labeled, action: 'verify' };
     } else if (action === 'close' && closeState === 'verify_then_close') {
       // Apply verify label, then close
       applyVerifyLabel(ref.platform, ref.number, ref.repo, verifyLabel);
-      const supportsInlineComment = ref.platform === 'github' || ref.platform === 'forgejo';
+      const supportsInlineComment =
+        ref.platform === 'github' || ref.platform === 'forgejo';
       if (supportsInlineComment) {
-        cliResult = invokeIssueCli(ref.platform, 'close', [ref.number, ref.repo, comment]);
+        cliResult = invokeIssueCli(ref.platform, 'close', [
+          ref.number,
+          ref.repo,
+          comment,
+        ]);
       } else {
-        invokeIssueCli(ref.platform, 'comment', [ref.number, ref.repo, comment]);
-        cliResult = invokeIssueCli(ref.platform, 'close', [ref.number, ref.repo, null]);
+        invokeIssueCli(ref.platform, 'comment', [
+          ref.number,
+          ref.repo,
+          comment,
+        ]);
+        cliResult = invokeIssueCli(ref.platform, 'close', [
+          ref.number,
+          ref.repo,
+          null,
+        ]);
       }
     } else if (action === 'close') {
       // Default close behavior (close_state=close or no config)
       // GitHub and Forgejo support inline comments on close; GitLab and
       // Gitea ignore the comment parameter. Post a separate comment first
       // for platforms that would lose the reference, then close.
-      const supportsInlineComment = ref.platform === 'github' || ref.platform === 'forgejo';
+      const supportsInlineComment =
+        ref.platform === 'github' || ref.platform === 'forgejo';
       if (supportsInlineComment) {
-        cliResult = invokeIssueCli(ref.platform, 'close', [ref.number, ref.repo, comment]);
+        cliResult = invokeIssueCli(ref.platform, 'close', [
+          ref.number,
+          ref.repo,
+          comment,
+        ]);
       } else {
-        invokeIssueCli(ref.platform, 'comment', [ref.number, ref.repo, comment]);
-        cliResult = invokeIssueCli(ref.platform, 'close', [ref.number, ref.repo, null]);
+        invokeIssueCli(ref.platform, 'comment', [
+          ref.number,
+          ref.repo,
+          comment,
+        ]);
+        cliResult = invokeIssueCli(ref.platform, 'close', [
+          ref.number,
+          ref.repo,
+          null,
+        ]);
       }
     } else {
-      cliResult = invokeIssueCli(ref.platform, 'comment', [ref.number, ref.repo, comment]);
+      cliResult = invokeIssueCli(ref.platform, 'comment', [
+        ref.number,
+        ref.repo,
+        comment,
+      ]);
     }
 
     results.push({
@@ -2119,7 +2511,9 @@ function cmdIssueSync(cwd, phase, options) {
   try {
     const rawConfig = JSON.parse(fs.readFileSync(paths.config, 'utf-8'));
     itConfig = rawConfig.issue_tracker || {};
-  } catch { /* no config.json, use empty defaults */ }
+  } catch {
+    /* no config.json, use empty defaults */
+  }
 
   const synced = [];
   const conflicts = [];
@@ -2136,7 +2530,11 @@ function cmdIssueSync(cwd, phase, options) {
     const rows = parseRequirementsExternalRefs(reqContent);
     for (const row of rows) {
       if (row.status === 'Complete') {
-        const refResults = syncSingleRef(row.externalRef, commentContext, itConfig);
+        const refResults = syncSingleRef(
+          row.externalRef,
+          commentContext,
+          itConfig,
+        );
         synced.push(...refResults);
       } else if (row.externalRef && row.externalRef !== '-') {
         skipped++;
@@ -2148,7 +2546,9 @@ function cmdIssueSync(cwd, phase, options) {
   const doneTodosDir = paths.todosCompleted;
   let doneTodoFiles = [];
   try {
-    doneTodoFiles = fs.readdirSync(doneTodosDir).filter(f => f.endsWith('.md'));
+    doneTodoFiles = fs
+      .readdirSync(doneTodosDir)
+      .filter((f) => f.endsWith('.md'));
   } catch (_e) {
     // Directory may not exist
   }
@@ -2163,11 +2563,18 @@ function cmdIssueSync(cwd, phase, options) {
         // Security: scan todo content for injection before processing (external data was written on import)
         const scanResult = scanForInjection(content, { external: true });
         if (!scanResult.clean) {
-          logSecurityEvent(cwd, { source: `issue-sync:${refStr}`, tier: scanResult.tier, blocked: scanResult.blocked, findings: scanResult.findings });
+          logSecurityEvent(cwd, {
+            source: `issue-sync:${refStr}`,
+            tier: scanResult.tier,
+            blocked: scanResult.blocked,
+            findings: scanResult.findings,
+          });
         }
         if (scanResult.tier === 'high') {
           // Log warning but don't block sync (batch operation — log and continue)
-          process.stderr.write(`[security] High-confidence injection detected in sync for ${refStr}. Logged to security-events.log.\n`);
+          process.stderr.write(
+            `[security] High-confidence injection detected in sync for ${refStr}. Logged to security-events.log.\n`,
+          );
         }
 
         const refResults = syncSingleRef(refStr, commentContext, itConfig);
@@ -2186,8 +2593,9 @@ function cmdIssueSync(cwd, phase, options) {
   }
 
   const result = { synced, conflicts, skipped };
-  output(result, 
-    `Synced ${synced.length} ref(s), ${conflicts.length} conflict(s), ${skipped} skipped`
+  output(
+    result,
+    `Synced ${synced.length} ref(s), ${conflicts.length} conflict(s), ${skipped} skipped`,
   );
   return result;
 }
@@ -2211,14 +2619,21 @@ function cmdIssueListRefs(cwd) {
   }
 
   // 1. Scan REQUIREMENTS.md
-  const { requirements: reqPath, todosPending, todosCompleted } = planningPaths(cwd);
+  const {
+    requirements: reqPath,
+    todosPending,
+    todosCompleted,
+  } = planningPaths(cwd);
   const reqContent = safeReadFile(reqPath);
   if (reqContent) {
     const rows = parseRequirementsExternalRefs(reqContent);
     for (const row of rows) {
       if (row.externalRef) {
         // externalRef may be comma-separated
-        const parts = row.externalRef.split(',').map(r => r.trim()).filter(Boolean);
+        const parts = row.externalRef
+          .split(',')
+          .map((r) => r.trim())
+          .filter(Boolean);
         for (const part of parts) {
           addRef('requirements', part);
         }
@@ -2227,10 +2642,13 @@ function cmdIssueListRefs(cwd) {
   }
 
   // 2. Scan todos/pending and todos/completed
-  for (const [subDir, dir] of [['pending', todosPending], ['completed', todosCompleted]]) {
+  for (const [subDir, dir] of [
+    ['pending', todosPending],
+    ['completed', todosCompleted],
+  ]) {
     let files = [];
     try {
-      files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
+      files = fs.readdirSync(dir).filter((f) => f.endsWith('.md'));
     } catch (_e) {
       continue;
     }
@@ -2239,7 +2657,10 @@ function cmdIssueListRefs(cwd) {
         const content = fs.readFileSync(path.join(dir, file), 'utf-8');
         const fm = extractFrontmatter(content);
         if (fm && fm.external_ref) {
-          const parts = fm.external_ref.split(',').map(r => r.trim()).filter(Boolean);
+          const parts = fm.external_ref
+            .split(',')
+            .map((r) => r.trim())
+            .filter(Boolean);
           for (const part of parts) {
             addRef(`todos/${subDir}/${file}`, part);
           }
@@ -2266,7 +2687,7 @@ function cmdStalenessCheck(cwd, countOnly = false) {
     return;
   }
 
-  const docs = fs.readdirSync(codebaseDir).filter(f => f.endsWith('.md'));
+  const docs = fs.readdirSync(codebaseDir).filter((f) => f.endsWith('.md'));
   const stale = [];
 
   for (const doc of docs) {
@@ -2285,10 +2706,12 @@ function cmdStalenessCheck(cwd, countOnly = false) {
       }
       const hash = hashMatch[1];
       try {
-        const changed = execSync(
-          `git diff --name-only ${hash}..HEAD`,
-          { encoding: 'utf8', cwd, timeout: 5000, stdio: ['pipe', 'pipe', 'ignore'] }
-        ).trim();
+        const changed = execSync(`git diff --name-only ${hash}..HEAD`, {
+          encoding: 'utf8',
+          cwd,
+          timeout: 5000,
+          stdio: ['pipe', 'pipe', 'ignore'],
+        }).trim();
         if (changed) {
           stale.push({
             doc,
@@ -2311,7 +2734,7 @@ function cmdStalenessCheck(cwd, countOnly = false) {
   const allStale = stale.length === docs.length;
   output(
     { stale, all_stale: allStale, total_docs: docs.length },
-    stale.length > 0 ? stale.map(s => s.doc).join(', ') : 'none'
+    stale.length > 0 ? stale.map((s) => s.doc).join(', ') : 'none',
   );
 }
 
@@ -2320,16 +2743,16 @@ function cmdHelp(cwd, args) {
   let commands = [];
 
   try {
-    const files = fs.readdirSync(commandsDir).filter(f => f.endsWith('.md'));
+    const files = fs.readdirSync(commandsDir).filter((f) => f.endsWith('.md'));
 
     for (const file of files) {
       try {
         const content = fs.readFileSync(path.join(commandsDir, file), 'utf-8');
         const fm = extractFrontmatter(content);
         commands.push({
-          name: (fm && fm.name) ? fm.name : 'gsd:' + path.basename(file, '.md'),
-          description: (fm && fm.description) ? fm.description : '',
-          argument_hint: (fm && fm['argument-hint']) ? fm['argument-hint'] : '',
+          name: fm && fm.name ? fm.name : 'gsd:' + path.basename(file, '.md'),
+          description: fm && fm.description ? fm.description : '',
+          argument_hint: fm && fm['argument-hint'] ? fm['argument-hint'] : '',
         });
       } catch {}
     }
@@ -2364,7 +2787,15 @@ function cmdHelp(cwd, args) {
  * Valid triage status values for divergence tracking.
  * Includes upstream states plus branch-tracking states needs-adaptation and already-covered.
  */
-const VALID_TRIAGE_STATES = ['picked', 'skipped', 'deferred', 'pending', 'needs-adaptation', 'already-covered', 'adapted'];
+const VALID_TRIAGE_STATES = [
+  'picked',
+  'skipped',
+  'deferred',
+  'pending',
+  'needs-adaptation',
+  'already-covered',
+  'adapted',
+];
 
 /**
  * Classify a commit subject by conventional commit prefix.
@@ -2375,9 +2806,11 @@ const VALID_TRIAGE_STATES = ['picked', 'skipped', 'deferred', 'pending', 'needs-
  */
 function classifyCommit(subject) {
   if (/^BREAKING[\s_]CHANGE/i.test(subject)) return 'fix';
-  if (/^(fix|security|hotfix|bugfix|revert)[\(!:\s]/i.test(subject)) return 'fix';
+  if (/^(fix|security|hotfix|bugfix|revert)[\(!:\s]/i.test(subject))
+    return 'fix';
   if (/^feat[\(!:\s]/i.test(subject)) return 'feat';
-  if (/^(docs|chore|test|refactor|style|ci|build|perf)[\(!:\s]/i.test(subject)) return 'other';
+  if (/^(docs|chore|test|refactor|style|ci|build|perf)[\(!:\s]/i.test(subject))
+    return 'other';
   return 'unknown';
 }
 
@@ -2414,7 +2847,10 @@ function extractPrNumber(subject) {
 function normalizeForMatch(subject) {
   return subject
     .replace(/#\d+/g, '')
-    .replace(/^(fix|feat|docs|chore|refactor|test|style|ci|build|perf|revert|security|hotfix|bugfix)(\([^)]*\))?[!:]?\s*/i, '')
+    .replace(
+      /^(fix|feat|docs|chore|refactor|test|style|ci|build|perf|revert|security|hotfix|bugfix)(\([^)]*\))?[!:]?\s*/i,
+      '',
+    )
     .replace(/[^a-z0-9\s]/gi, ' ')
     .replace(/\s+/g, ' ')
     .trim()
@@ -2433,7 +2869,11 @@ function parseDivergenceBranchSection(filePath, sectionKey) {
   if (!fs.existsSync(filePath)) return result;
 
   let content;
-  try { content = fs.readFileSync(filePath, 'utf-8'); } catch { return result; }
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {
+    return result;
+  }
 
   const sectionHeader = `## Branch Tracking: ${sectionKey}`;
   const sectionIdx = content.indexOf(sectionHeader);
@@ -2442,9 +2882,10 @@ function parseDivergenceBranchSection(filePath, sectionKey) {
   // Find the next ## heading or end of file
   const afterHeader = content.substring(sectionIdx + sectionHeader.length);
   const nextSectionIdx = afterHeader.indexOf('\n## ');
-  const sectionContent = nextSectionIdx !== -1
-    ? afterHeader.substring(0, nextSectionIdx)
-    : afterHeader;
+  const sectionContent =
+    nextSectionIdx !== -1
+      ? afterHeader.substring(0, nextSectionIdx)
+      : afterHeader;
 
   const lines = sectionContent.split('\n');
   let inTable = false;
@@ -2457,9 +2898,12 @@ function parseDivergenceBranchSection(filePath, sectionKey) {
       if (inTable) break;
       continue;
     }
-    const cells = trimmed.split('|').map(c => c.trim()).filter(Boolean);
+    const cells = trimmed
+      .split('|')
+      .map((c) => c.trim())
+      .filter(Boolean);
     if (!headerSeen) {
-      const lowerCells = cells.map(c => c.toLowerCase());
+      const lowerCells = cells.map((c) => c.toLowerCase());
       if (lowerCells.includes('hash')) {
         headerSeen = true;
         inTable = true;
@@ -2468,7 +2912,7 @@ function parseDivergenceBranchSection(filePath, sectionKey) {
       }
     }
     if (!inTable) continue;
-    if (cells.every(c => /^[-:]+$/.test(c))) continue;
+    if (cells.every((c) => /^[-:]+$/.test(c))) continue;
     if (hasClassificationCol ? cells.length >= 5 : cells.length >= 4) {
       // Branch table: hash | date | subject | classification | status | reason
       // Legacy table: hash | date | subject | status | reason
@@ -2503,9 +2947,12 @@ function parseDivergenceBranchSection(filePath, sectionKey) {
 function writeDivergenceBranchSection(filePath, sectionKey, commits) {
   const today = new Date().toISOString().split('T')[0];
   const sectionHeader = `## Branch Tracking: ${sectionKey}`;
-  const rows = commits.map(c =>
-    `| ${c.hash} | ${c.date} | ${c.subject} | ${c.classification || ''} | ${c.status} | ${c.reason} |`
-  ).join('\n');
+  const rows = commits
+    .map(
+      (c) =>
+        `| ${c.hash} | ${c.date} | ${c.subject} | ${c.classification || ''} | ${c.status} | ${c.reason} |`,
+    )
+    .join('\n');
 
   const newSection = [
     '',
@@ -2520,7 +2967,9 @@ function writeDivergenceBranchSection(filePath, sectionKey, commits) {
   ].join('\n');
 
   let content = '';
-  try { content = fs.readFileSync(filePath, 'utf-8'); } catch {}
+  try {
+    content = fs.readFileSync(filePath, 'utf-8');
+  } catch {}
 
   if (!content) {
     // Create minimal DIVERGENCE.md with just this section
@@ -2534,7 +2983,8 @@ function writeDivergenceBranchSection(filePath, sectionKey, commits) {
     const afterHeader = content.substring(existingSectionIdx);
     const nextSectionIdx = afterHeader.indexOf('\n## ', sectionHeader.length);
     const beforeSection = content.substring(0, existingSectionIdx);
-    const afterSection = nextSectionIdx !== -1 ? afterHeader.substring(nextSectionIdx) : '';
+    const afterSection =
+      nextSectionIdx !== -1 ? afterHeader.substring(nextSectionIdx) : '';
     content = beforeSection.trimEnd() + newSection + afterSection;
   } else {
     // Append new section
@@ -2573,11 +3023,14 @@ function parseDivergenceFile(filePath) {
       continue;
     }
 
-    const cells = trimmed.split('|').map(c => c.trim()).filter(Boolean);
+    const cells = trimmed
+      .split('|')
+      .map((c) => c.trim())
+      .filter(Boolean);
 
     // Detect header row (first table row with text cells)
     if (!headerSeen) {
-      const lowerCells = cells.map(c => c.toLowerCase());
+      const lowerCells = cells.map((c) => c.toLowerCase());
       if (lowerCells[0] === 'hash' || lowerCells.includes('hash')) {
         headerSeen = true;
         inTable = true;
@@ -2588,7 +3041,7 @@ function parseDivergenceFile(filePath) {
     if (!inTable) continue;
 
     // Skip separator rows
-    if (cells.every(c => /^[-:]+$/.test(c))) continue;
+    if (cells.every((c) => /^[-:]+$/.test(c))) continue;
 
     // Data row: | hash | date | subject | status | reason |
     if (cells.length >= 4) {
@@ -2613,11 +3066,19 @@ function parseDivergenceFile(filePath) {
  * @param {string} upstreamUrl - URL of upstream remote
  * @param {Array<{hash, date, subject, status, reason}>} commits
  */
-function writeDivergenceFile(filePath, upstreamUrl, commits, remoteName = 'upstream') {
+function writeDivergenceFile(
+  filePath,
+  upstreamUrl,
+  commits,
+  remoteName = 'upstream',
+) {
   const today = new Date().toISOString().split('T')[0];
-  const rows = commits.map(c =>
-    `| ${c.hash} | ${c.date} | ${c.subject} | ${c.status} | ${c.reason} |`
-  ).join('\n');
+  const rows = commits
+    .map(
+      (c) =>
+        `| ${c.hash} | ${c.date} | ${c.subject} | ${c.status} | ${c.reason} |`,
+    )
+    .join('\n');
 
   const content = [
     '# Divergence Tracking',
@@ -2651,23 +3112,39 @@ function rewriteDivergenceTable(filePath, triageState) {
   } catch {
     // File doesn't exist — create from scratch
     const commits = [...triageState.entries()].map(([hash, e]) => ({
-      hash, date: e.date || '', subject: e.subject || '', status: e.status || 'pending', reason: e.reason || '',
+      hash,
+      date: e.date || '',
+      subject: e.subject || '',
+      status: e.status || 'pending',
+      reason: e.reason || '',
     }));
     writeDivergenceFile(filePath, 'unknown', commits);
     return;
   }
 
   // Update "Last checked" date
-  content = content.replace(/\*\*Last checked:\*\*\s*.+/, `**Last checked:** ${today}`);
+  content = content.replace(
+    /\*\*Last checked:\*\*\s*.+/,
+    `**Last checked:** ${today}`,
+  );
 
   // Find the table section and replace it
-  const tableHeaderIdx = content.indexOf('| Hash | Date | Subject | Status | Reason |');
+  const tableHeaderIdx = content.indexOf(
+    '| Hash | Date | Subject | Status | Reason |',
+  );
   if (tableHeaderIdx === -1) {
     // No existing table — append it
-    const rows = [...triageState.entries()].map(([hash, e]) =>
-      `| ${hash} | ${e.date || ''} | ${e.subject || ''} | ${e.status || 'pending'} | ${e.reason || ''} |`
-    ).join('\n');
-    content = content.trimEnd() + '\n\n## Commit Triage\n\n| Hash | Date | Subject | Status | Reason |\n|------|------|---------|--------|--------|\n' + rows + '\n';
+    const rows = [...triageState.entries()]
+      .map(
+        ([hash, e]) =>
+          `| ${hash} | ${e.date || ''} | ${e.subject || ''} | ${e.status || 'pending'} | ${e.reason || ''} |`,
+      )
+      .join('\n');
+    content =
+      content.trimEnd() +
+      '\n\n## Commit Triage\n\n| Hash | Date | Subject | Status | Reason |\n|------|------|---------|--------|--------|\n' +
+      rows +
+      '\n';
     fs.writeFileSync(filePath, content, 'utf-8');
     return;
   }
@@ -2675,11 +3152,17 @@ function rewriteDivergenceTable(filePath, triageState) {
   // Find the end of the separator row and rebuild from there
   const sepRow = '|------|------|---------|--------|--------|';
   const sepIdx = content.indexOf(sepRow, tableHeaderIdx);
-  const afterSep = sepIdx !== -1 ? sepIdx + sepRow.length : tableHeaderIdx + '| Hash | Date | Subject | Status | Reason |'.length;
+  const afterSep =
+    sepIdx !== -1
+      ? sepIdx + sepRow.length
+      : tableHeaderIdx + '| Hash | Date | Subject | Status | Reason |'.length;
 
-  const rows = [...triageState.entries()].map(([hash, e]) =>
-    `| ${hash} | ${e.date || ''} | ${e.subject || ''} | ${e.status || 'pending'} | ${e.reason || ''} |`
-  ).join('\n');
+  const rows = [...triageState.entries()]
+    .map(
+      ([hash, e]) =>
+        `| ${hash} | ${e.date || ''} | ${e.subject || ''} | ${e.status || 'pending'} | ${e.reason || ''} |`,
+    )
+    .join('\n');
 
   const beforeTable = content.slice(0, afterSep);
   content = beforeTable + '\n' + rows + '\n';
@@ -2724,13 +3207,16 @@ function cmdDivergence(cwd, opts) {
       try {
         const log = execSync(
           `git log ${sectionKey} --format="%H|%ad|%s" --date=short`,
-          { cwd, encoding: 'utf8', stdio: 'pipe' }
+          { cwd, encoding: 'utf8', stdio: 'pipe' },
         ).trim();
         if (log) {
           // Load existing section to detect already-triaged commits
-          const existingTriage = parseDivergenceBranchSection(divergencePath, sectionKey);
+          const existingTriage = parseDivergenceBranchSection(
+            divergencePath,
+            sectionKey,
+          );
 
-          allCommits = log.split('\n').map(line => {
+          allCommits = log.split('\n').map((line) => {
             const [hash, date, ...subjectParts] = line.split('|');
             const subject = subjectParts.join('|').substring(0, 80);
             const shortHash = hash.substring(0, 7);
@@ -2740,7 +3226,14 @@ function cmdDivergence(cwd, opts) {
             // Check if already triaged
             const existing = existingTriage.get(shortHash);
             if (existing) {
-              return { hash: shortHash, date, subject, classification, status: existing.status, reason: existing.reason };
+              return {
+                hash: shortHash,
+                date,
+                subject,
+                classification,
+                status: existing.status,
+                reason: existing.reason,
+              };
             }
 
             // Check for PR number or message match against existing triaged items
@@ -2748,7 +3241,10 @@ function cmdDivergence(cwd, opts) {
             let matchReason = '';
             if (prNumber) {
               for (const [triHash, triEntry] of existingTriage) {
-                if (extractPrNumber(triEntry.subject) === prNumber && triEntry.status !== 'pending') {
+                if (
+                  extractPrNumber(triEntry.subject) === prNumber &&
+                  triEntry.status !== 'pending'
+                ) {
                   matchStatus = 'already-covered';
                   matchReason = `Matches PR #${prNumber} (${triHash})`;
                   break;
@@ -2758,7 +3254,10 @@ function cmdDivergence(cwd, opts) {
             if (matchStatus === 'pending') {
               const normalized = normalizeForMatch(subject);
               for (const [triHash, triEntry] of existingTriage) {
-                if (normalizeForMatch(triEntry.subject) === normalized && triEntry.status !== 'pending') {
+                if (
+                  normalizeForMatch(triEntry.subject) === normalized &&
+                  triEntry.status !== 'pending'
+                ) {
                   matchStatus = 'already-covered';
                   matchReason = `Message matches ${triHash}`;
                   break;
@@ -2766,17 +3265,33 @@ function cmdDivergence(cwd, opts) {
               }
             }
 
-            return { hash: shortHash, date, subject, classification, status: matchStatus, reason: matchReason };
+            return {
+              hash: shortHash,
+              date,
+              subject,
+              classification,
+              status: matchStatus,
+              reason: matchReason,
+            };
           });
 
           // Sort by priority: fix > feat > other > unknown
-          allCommits.sort((a, b) => priorityOrder(a.classification) - priorityOrder(b.classification));
+          allCommits.sort(
+            (a, b) =>
+              priorityOrder(a.classification) - priorityOrder(b.classification),
+          );
         }
       } catch {}
 
       writeDivergenceBranchSection(divergencePath, sectionKey, allCommits);
-      output({ status: 'initialized', section: sectionKey, commits: allCommits.length },
-        `Initialized branch section '${sectionKey}' with ${allCommits.length} commits`);
+      output(
+        {
+          status: 'initialized',
+          section: sectionKey,
+          commits: allCommits.length,
+        },
+        `Initialized branch section '${sectionKey}' with ${allCommits.length} commits`,
+      );
       return;
     }
 
@@ -2787,21 +3302,39 @@ function cmdDivergence(cwd, opts) {
       const reason = opts.reason || '';
 
       if (!VALID_TRIAGE_STATES.includes(status)) {
-        error(`Invalid status: ${status}. Must be one of: ${VALID_TRIAGE_STATES.join(', ')}`);
+        error(
+          `Invalid status: ${status}. Must be one of: ${VALID_TRIAGE_STATES.join(', ')}`,
+        );
         return;
       }
-      if (['skipped', 'deferred', 'needs-adaptation', 'adapted'].includes(status) && !reason) {
-        error(`Reason required for ${status} status. Use --reason "your rationale"`);
+      if (
+        ['skipped', 'deferred', 'needs-adaptation', 'adapted'].includes(
+          status,
+        ) &&
+        !reason
+      ) {
+        error(
+          `Reason required for ${status} status. Use --reason "your rationale"`,
+        );
         return;
       }
 
-      const triageState = parseDivergenceBranchSection(divergencePath, sectionKey);
+      const triageState = parseDivergenceBranchSection(
+        divergencePath,
+        sectionKey,
+      );
       let entry = triageState.get(hash);
       if (!entry) {
         try {
-          const info = execSync(`git log --format="%ad|%s" --date=short -1 ${hash}`, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+          const info = execSync(
+            `git log --format="%ad|%s" --date=short -1 ${hash}`,
+            { cwd, encoding: 'utf8', stdio: 'pipe' },
+          ).trim();
           const [date, ...subjectParts] = info.split('|');
-          entry = { date: date || '', subject: subjectParts.join('|').substring(0, 80) };
+          entry = {
+            date: date || '',
+            subject: subjectParts.join('|').substring(0, 80),
+          };
         } catch {
           entry = { date: '', subject: '' };
         }
@@ -2810,62 +3343,80 @@ function cmdDivergence(cwd, opts) {
       triageState.set(hash, { ...entry, status, reason });
       // Rewrite section
       const commits = [...triageState.entries()].map(([h, e]) => ({
-        hash: h, date: e.date || '', subject: e.subject || '',
+        hash: h,
+        date: e.date || '',
+        subject: e.subject || '',
         classification: classifyCommit(e.subject || ''),
-        status: e.status || 'pending', reason: e.reason || '',
+        status: e.status || 'pending',
+        reason: e.reason || '',
       }));
       writeDivergenceBranchSection(divergencePath, sectionKey, commits);
-      output({ status: 'updated', hash, new_status: status, section: sectionKey },
-        `Updated ${hash} in ${sectionKey}: ${status}${reason ? ' — ' + reason : ''}`);
+      output(
+        { status: 'updated', hash, new_status: status, section: sectionKey },
+        `Updated ${hash} in ${sectionKey}: ${status}${reason ? ' — ' + reason : ''}`,
+      );
       return;
     }
 
     // ── Branch show mode (default) ──
-    const triageState = parseDivergenceBranchSection(divergencePath, sectionKey);
+    const triageState = parseDivergenceBranchSection(
+      divergencePath,
+      sectionKey,
+    );
     let commits = [];
     try {
       const log = execSync(
         `git log ${sectionKey} --format="%H|%ad|%s" --date=short`,
-        { cwd, encoding: 'utf8', stdio: 'pipe' }
+        { cwd, encoding: 'utf8', stdio: 'pipe' },
       ).trim();
       if (log) {
-        commits = log.split('\n').map(line => {
+        commits = log.split('\n').map((line) => {
           const [hash, date, ...subjectParts] = line.split('|');
           const subject = subjectParts.join('|').substring(0, 80);
           const shortHash = hash.substring(0, 7);
           const existing = triageState.get(shortHash);
           const classification = classifyCommit(subject);
           return {
-            hash: shortHash, full_hash: hash, date: date || '', subject,
+            hash: shortHash,
+            full_hash: hash,
+            date: date || '',
+            subject,
             classification,
             status: existing ? existing.status : 'pending',
             reason: existing ? existing.reason : '',
           };
         });
         // Sort by priority
-        commits.sort((a, b) => priorityOrder(a.classification) - priorityOrder(b.classification));
+        commits.sort(
+          (a, b) =>
+            priorityOrder(a.classification) - priorityOrder(b.classification),
+        );
       }
     } catch {}
 
-    const pending = commits.filter(c => c.status === 'pending').length;
+    const pending = commits.filter((c) => c.status === 'pending').length;
     const summaryText = `Branch divergence (${sectionKey}): ${pending} pending of ${commits.length} total`;
-    output({
-      status: 'ok',
-      section: sectionKey,
-      base,
-      branch: opts.branch,
-      commits,
-      summary: {
-        pending,
-        total: commits.length,
-        by_classification: {
-          fix: commits.filter(c => c.classification === 'fix').length,
-          feat: commits.filter(c => c.classification === 'feat').length,
-          other: commits.filter(c => c.classification === 'other').length,
-          unknown: commits.filter(c => c.classification === 'unknown').length,
+    output(
+      {
+        status: 'ok',
+        section: sectionKey,
+        base,
+        branch: opts.branch,
+        commits,
+        summary: {
+          pending,
+          total: commits.length,
+          by_classification: {
+            fix: commits.filter((c) => c.classification === 'fix').length,
+            feat: commits.filter((c) => c.classification === 'feat').length,
+            other: commits.filter((c) => c.classification === 'other').length,
+            unknown: commits.filter((c) => c.classification === 'unknown')
+              .length,
+          },
         },
       },
-    }, summaryText);
+      summaryText,
+    );
     return;
   }
 
@@ -2874,18 +3425,29 @@ function cmdDivergence(cwd, opts) {
   const trackingRef = `${remoteName}/${opts.remoteBranch || 'main'}`;
   let upstreamUrl = null;
   try {
-    upstreamUrl = execSync(`git remote get-url ${remoteName}`, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+    upstreamUrl = execSync(`git remote get-url ${remoteName}`, {
+      cwd,
+      encoding: 'utf8',
+      stdio: 'pipe',
+    }).trim();
   } catch {}
 
   if (!upstreamUrl) {
-    output({ status: 'no_upstream', commits: [] }, `No '${remoteName}' remote found. Add one with: git remote add ${remoteName} <url>`);
+    output(
+      { status: 'no_upstream', commits: [] },
+      `No '${remoteName}' remote found. Add one with: git remote add ${remoteName} <url>`,
+    );
     return;
   }
 
   // Optionally fetch from upstream
   if (opts.refresh) {
     try {
-      execSync(`git fetch ${remoteName}`, { cwd, stdio: 'pipe', timeout: 30000 });
+      execSync(`git fetch ${remoteName}`, {
+        cwd,
+        stdio: 'pipe',
+        timeout: 30000,
+      });
     } catch {
       // Fetch failed (network? auth?) — continue with cached refs
     }
@@ -2895,7 +3457,11 @@ function cmdDivergence(cwd, opts) {
   if (opts.init) {
     let mergeBase = '';
     try {
-      mergeBase = execSync(`git merge-base HEAD ${trackingRef}`, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+      mergeBase = execSync(`git merge-base HEAD ${trackingRef}`, {
+        cwd,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }).trim();
     } catch {}
 
     const range = mergeBase ? `${mergeBase}..${trackingRef}` : trackingRef;
@@ -2903,10 +3469,10 @@ function cmdDivergence(cwd, opts) {
     try {
       const log = execSync(
         `git log ${range} --format="%H|%ad|%s" --date=short`,
-        { cwd, encoding: 'utf8', stdio: 'pipe' }
+        { cwd, encoding: 'utf8', stdio: 'pipe' },
       ).trim();
       if (log) {
-        allCommits = log.split('\n').map(line => {
+        allCommits = log.split('\n').map((line) => {
           const [hash, date, ...subjectParts] = line.split('|');
           return {
             hash: hash.substring(0, 7),
@@ -2920,7 +3486,10 @@ function cmdDivergence(cwd, opts) {
     } catch {}
 
     writeDivergenceFile(divergencePath, upstreamUrl, allCommits, remoteName);
-    output({ status: 'initialized', commits: allCommits.length }, `Initialized DIVERGENCE.md with ${allCommits.length} upstream commits`);
+    output(
+      { status: 'initialized', commits: allCommits.length },
+      `Initialized DIVERGENCE.md with ${allCommits.length} upstream commits`,
+    );
     return;
   }
 
@@ -2931,11 +3500,15 @@ function cmdDivergence(cwd, opts) {
     const reason = opts.reason || '';
 
     if (!VALID_TRIAGE_STATES.includes(status)) {
-      error(`Invalid status: ${status}. Must be one of: ${VALID_TRIAGE_STATES.join(', ')}`);
+      error(
+        `Invalid status: ${status}. Must be one of: ${VALID_TRIAGE_STATES.join(', ')}`,
+      );
       return;
     }
     if (['skipped', 'deferred', 'adapted'].includes(status) && !reason) {
-      error(`Reason required for ${status} status. Use --reason "your rationale"`);
+      error(
+        `Reason required for ${status} status. Use --reason "your rationale"`,
+      );
       return;
     }
 
@@ -2945,9 +3518,15 @@ function cmdDivergence(cwd, opts) {
     let entry = triageState.get(hash);
     if (!entry) {
       try {
-        const info = execSync(`git log --format="%ad|%s" --date=short -1 ${hash}`, { cwd, encoding: 'utf8', stdio: 'pipe' }).trim();
+        const info = execSync(
+          `git log --format="%ad|%s" --date=short -1 ${hash}`,
+          { cwd, encoding: 'utf8', stdio: 'pipe' },
+        ).trim();
         const [date, ...subjectParts] = info.split('|');
-        entry = { date: date || '', subject: subjectParts.join('|').substring(0, 80) };
+        entry = {
+          date: date || '',
+          subject: subjectParts.join('|').substring(0, 80),
+        };
       } catch {
         entry = { date: '', subject: '' };
       }
@@ -2955,7 +3534,10 @@ function cmdDivergence(cwd, opts) {
 
     triageState.set(hash, { ...entry, status, reason });
     rewriteDivergenceTable(divergencePath, triageState);
-    output({ status: 'updated', hash, new_status: status }, `Updated ${hash}: ${status}${reason ? ' — ' + reason : ''}`);
+    output(
+      { status: 'updated', hash, new_status: status },
+      `Updated ${hash}: ${status}${reason ? ' — ' + reason : ''}`,
+    );
     return;
   }
 
@@ -2966,10 +3548,10 @@ function cmdDivergence(cwd, opts) {
   try {
     const log = execSync(
       `git log HEAD..${trackingRef} --format="%H|%ad|%s" --date=short`,
-      { cwd, encoding: 'utf8', stdio: 'pipe' }
+      { cwd, encoding: 'utf8', stdio: 'pipe' },
     ).trim();
     if (log) {
-      commits = log.split('\n').map(line => {
+      commits = log.split('\n').map((line) => {
         const [hash, date, ...subjectParts] = line.split('|');
         const subject = subjectParts.join('|').substring(0, 80);
         const shortHash = hash.substring(0, 7);
@@ -2987,7 +3569,7 @@ function cmdDivergence(cwd, opts) {
   } catch {}
 
   // Include triage entries for commits already picked (no longer in HEAD..upstream/main)
-  const logHashes = new Set(commits.map(c => c.hash));
+  const logHashes = new Set(commits.map((c) => c.hash));
   for (const [hash, entry] of triageState) {
     if (!logHashes.has(hash) && entry.status !== 'pending') {
       commits.push({
@@ -3001,18 +3583,21 @@ function cmdDivergence(cwd, opts) {
     }
   }
 
-  const pending = commits.filter(c => c.status === 'pending').length;
-  const picked = commits.filter(c => c.status === 'picked').length;
-  const skipped = commits.filter(c => c.status === 'skipped').length;
-  const deferred = commits.filter(c => c.status === 'deferred').length;
+  const pending = commits.filter((c) => c.status === 'pending').length;
+  const picked = commits.filter((c) => c.status === 'picked').length;
+  const skipped = commits.filter((c) => c.status === 'skipped').length;
+  const deferred = commits.filter((c) => c.status === 'deferred').length;
 
   const summaryText = `Upstream divergence: ${pending} pending, ${picked} picked, ${skipped} skipped, ${deferred} deferred (${commits.length} total)`;
-  output({
-    status: 'ok',
-    upstream: upstreamUrl,
-    commits,
-    summary: { pending, picked, skipped, deferred, total: commits.length },
-  }, summaryText);
+  output(
+    {
+      status: 'ok',
+      upstream: upstreamUrl,
+      commits,
+      summary: { pending, picked, skipped, deferred, total: commits.length },
+    },
+    summaryText,
+  );
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -3113,7 +3698,9 @@ function detectOscillation(commits) {
       if (!fileHistory.has(file)) {
         fileHistory.set(file, []);
       }
-      fileHistory.get(file).push({ author: commit.author, hash: commit.hash, index: i });
+      fileHistory
+        .get(file)
+        .push({ author: commit.author, hash: commit.hash, index: i });
     }
   }
 
@@ -3134,11 +3721,11 @@ function detectOscillation(commits) {
 
     if (alternations >= 1) {
       // Check that there are at least 2 distinct authors involved
-      const uniqueAuthors = new Set(history.map(h => h.author));
+      const uniqueAuthors = new Set(history.map((h) => h.author));
       if (uniqueAuthors.size >= 2) {
         oscillatingFiles.push(file);
         agentSequenceEntries.push(
-          `${file}: [${history.map(h => h.author).join(' → ')}]`
+          `${file}: [${history.map((h) => h.author).join(' → ')}]`,
         );
         if (alternations > maxAlternations) {
           maxAlternations = alternations;
@@ -3159,9 +3746,10 @@ function detectOscillation(commits) {
   // A-B = 1 alternation = warning
   // A-B-A = 2 alternations = halt
   const status = maxAlternations >= 2 ? 'halt' : 'warning';
-  const reason = status === 'halt'
-    ? `Oscillation halted: ${oscillatingFiles.length} file(s) modified 3+ times by alternating agents`
-    : `Oscillation warning: ${oscillatingFiles.length} file(s) modified by alternating agents`;
+  const reason =
+    status === 'halt'
+      ? `Oscillation halted: ${oscillatingFiles.length} file(s) modified 3+ times by alternating agents`
+      : `Oscillation warning: ${oscillatingFiles.length} file(s) modified by alternating agents`;
 
   return {
     status,
@@ -3181,12 +3769,24 @@ function detectOscillation(commits) {
  */
 function cmdPingpongCheck(cwd, args) {
   const windowIdx = args.indexOf('--window');
-  const window = windowIdx !== -1 ? parseInt(args[windowIdx + 1], 10) || 20 : 20;
+  const window =
+    windowIdx !== -1 ? parseInt(args[windowIdx + 1], 10) || 20 : 20;
 
-  const result = execGit(cwd, ['log', `--format=%H|%ae|%s`, '--name-only', `-${window}`, '--', '.']);
+  const result = execGit(cwd, [
+    'log',
+    `--format=%H|%ae|%s`,
+    '--name-only',
+    `-${window}`,
+    '--',
+    '.',
+  ]);
 
   if (result.exitCode !== 0 || !result.stdout || !result.stdout.trim()) {
-    const response = { status: 'ok', reason: 'no git history', details: { oscillating_files: [], agent_sequence: [] } };
+    const response = {
+      status: 'ok',
+      reason: 'no git history',
+      details: { oscillating_files: [], agent_sequence: [] },
+    };
     output(response, 'ok');
     return;
   }
@@ -3214,10 +3814,18 @@ function cmdPingpongCheck(cwd, args) {
  */
 function detectBreakout(commits, declaredFiles) {
   if (!declaredFiles || declaredFiles.length === 0) {
-    return { status: 'ok', reason: 'No declared files to check', details: { unexpected_files: [] } };
+    return {
+      status: 'ok',
+      reason: 'No declared files to check',
+      details: { unexpected_files: [] },
+    };
   }
   if (!commits || commits.length === 0) {
-    return { status: 'ok', reason: 'No commits to analyze', details: { unexpected_files: [] } };
+    return {
+      status: 'ok',
+      reason: 'No commits to analyze',
+      details: { unexpected_files: [] },
+    };
   }
 
   // Normalize: strip leading ./ and use path.normalize
@@ -3225,7 +3833,12 @@ function detectBreakout(commits, declaredFiles) {
   const declared = new Set(declaredFiles.map(normalize));
 
   // Always-allowed path prefixes (GSD internal artifacts)
-  const alwaysAllowedPrefixes = ['.planning' + path.sep, '.claude' + path.sep, '.planning/', '.claude/'];
+  const alwaysAllowedPrefixes = [
+    '.planning' + path.sep,
+    '.claude' + path.sep,
+    '.planning/',
+    '.claude/',
+  ];
   // Always-allowed exact files
   const alwaysAllowedFiles = new Set(['package-lock.json']);
 
@@ -3276,7 +3889,7 @@ function detectBreakout(commits, declaredFiles) {
       seen.add(key);
 
       // Skip always-allowed paths
-      if (alwaysAllowedPrefixes.some(p => file.startsWith(p))) continue;
+      if (alwaysAllowedPrefixes.some((p) => file.startsWith(p))) continue;
       if (alwaysAllowedFiles.has(file)) continue;
 
       // Skip declared files
@@ -3284,23 +3897,35 @@ function detectBreakout(commits, declaredFiles) {
 
       // Check same-directory proximity and test pairing
       const fileDir = path.dirname(file);
-      const inDeclaredDir = [...declared].some(d => path.dirname(d) === fileDir);
+      const inDeclaredDir = [...declared].some(
+        (d) => path.dirname(d) === fileDir,
+      );
       const paired = isTestPair(file);
 
-      const tier = (inDeclaredDir || paired || isSiblingDir(file)) ? 'info' : 'warning';
+      const tier =
+        inDeclaredDir || paired || isSiblingDir(file) ? 'info' : 'warning';
       unexpected.push({ file, commit: commit.hash, tier });
     }
   }
 
-  const warnings = unexpected.filter(u => u.tier === 'warning');
+  const warnings = unexpected.filter((u) => u.tier === 'warning');
 
   if (unexpected.length === 0) {
-    return { status: 'ok', reason: 'All committed files within declared scope', details: { unexpected_files: [] } };
+    return {
+      status: 'ok',
+      reason: 'All committed files within declared scope',
+      details: { unexpected_files: [] },
+    };
   }
 
   if (warnings.length === 0) {
     // Only informational tier — no output needed
-    return { status: 'ok', reason: 'Unexpected files only in same directory as declared files (informational)', details: { unexpected_files: unexpected } };
+    return {
+      status: 'ok',
+      reason:
+        'Unexpected files only in same directory as declared files (informational)',
+      details: { unexpected_files: unexpected },
+    };
   }
 
   if (warnings.length >= 4) {
@@ -3331,18 +3956,40 @@ function cmdBreakoutCheck(cwd, args) {
   const filesArg = filesIdx !== -1 ? args[filesIdx + 1] : '';
 
   if (!planId) {
-    const response = { status: 'ok', reason: 'No --plan specified', details: { unexpected_files: [] } };
+    const response = {
+      status: 'ok',
+      reason: 'No --plan specified',
+      details: { unexpected_files: [] },
+    };
     output(response, 'ok');
     return;
   }
 
-  const declaredFiles = filesArg ? filesArg.split(',').map(f => f.trim()).filter(Boolean) : [];
+  const declaredFiles = filesArg
+    ? filesArg
+        .split(',')
+        .map((f) => f.trim())
+        .filter(Boolean)
+    : [];
 
   // Query git log for commits matching this plan
-  const result = execGit(cwd, ['log', '--format=%H|%ae|%s', '--name-only', '--grep', planId, '-30', '--', '.']);
+  const result = execGit(cwd, [
+    'log',
+    '--format=%H|%ae|%s',
+    '--name-only',
+    '--grep',
+    planId,
+    '-30',
+    '--',
+    '.',
+  ]);
 
   if (result.exitCode !== 0 || !result.stdout || !result.stdout.trim()) {
-    const response = { status: 'ok', reason: 'No matching commits found', details: { unexpected_files: [] } };
+    const response = {
+      status: 'ok',
+      reason: 'No matching commits found',
+      details: { unexpected_files: [] },
+    };
     output(response, 'ok');
     return;
   }
@@ -3355,21 +4002,29 @@ function cmdBreakoutCheck(cwd, args) {
 
 function cmdGenerateAllowlist(cwd, platform = process.platform) {
   // 1. Load static template as baseline
-  const templatePath = path.join(__dirname, '..', '..', 'templates', 'settings-sandbox.json');
+  const templatePath = path.join(
+    __dirname,
+    '..',
+    '..',
+    'templates',
+    'settings-sandbox.json',
+  );
   let template;
   try {
     template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
   } catch (e) {
     template = {
       sandbox: { enabled: true, autoAllowBashIfSandboxed: true },
-      permissions: { allow: [] }
+      permissions: { allow: [] },
     };
   }
 
   // 2. Strip bare + canonical Read/Edit/Write from template — we append
   //    the platform-appropriate form below, matching install.js behavior.
   //    Uses RW_FORMS (frozen Set) from allowlist.cjs — single source of truth (ALLOW-19).
-  const baseStatic = (template.permissions?.allow || []).filter(e => !RW_FORMS.has(e));
+  const baseStatic = (template.permissions?.allow || []).filter(
+    (e) => !RW_FORMS.has(e),
+  );
   const staticEntries = new Set(baseStatic);
 
   // 3. Add platform-aware Read/Edit/Write forms
@@ -3406,8 +4061,11 @@ function cmdGenerateAllowlist(cwd, platform = process.platform) {
 
   // 6. Build output JSON
   const result = {
-    sandbox: template.sandbox || { enabled: true, autoAllowBashIfSandboxed: true },
-    permissions: { allow: allEntries }
+    sandbox: template.sandbox || {
+      enabled: true,
+      autoAllowBashIfSandboxed: true,
+    },
+    permissions: { allow: allEntries },
   };
 
   output(result);
@@ -3426,11 +4084,18 @@ function detectSingleDir(dir) {
   const pkgPath = path.join(dir, 'package.json');
   try {
     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-    if (pkg.scripts && pkg.scripts.test && !pkg.scripts.test.includes('no test specified')) {
+    if (
+      pkg.scripts &&
+      pkg.scripts.test &&
+      !pkg.scripts.test.includes('no test specified')
+    ) {
       return 'npm test';
     }
   } catch {}
-  if (fs.existsSync(path.join(dir, 'pytest.ini')) || fs.existsSync(path.join(dir, 'pyproject.toml'))) {
+  if (
+    fs.existsSync(path.join(dir, 'pytest.ini')) ||
+    fs.existsSync(path.join(dir, 'pyproject.toml'))
+  ) {
     return 'python -m pytest';
   }
   if (fs.existsSync(path.join(dir, 'Cargo.toml'))) {
@@ -3472,10 +4137,16 @@ function resolveWorkspacePaths(cwd, signal) {
   let patterns = [];
   if (signal === 'pnpm-workspace.yaml') {
     try {
-      const content = fs.readFileSync(path.join(cwd, 'pnpm-workspace.yaml'), 'utf-8');
+      const content = fs.readFileSync(
+        path.join(cwd, 'pnpm-workspace.yaml'),
+        'utf-8',
+      );
       let inPackages = false;
       for (const line of content.split('\n')) {
-        if (/^packages\s*:/.test(line)) { inPackages = true; continue; }
+        if (/^packages\s*:/.test(line)) {
+          inPackages = true;
+          continue;
+        }
         if (inPackages) {
           const m = line.match(/^\s+-\s+['"]?([^'"#\s]+)['"]?/);
           if (m) patterns.push(m[1]);
@@ -3485,9 +4156,11 @@ function resolveWorkspacePaths(cwd, signal) {
     } catch {}
   } else if (signal === 'package.json#workspaces') {
     try {
-      const pkg = JSON.parse(fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'));
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(cwd, 'package.json'), 'utf-8'),
+      );
       const ws = pkg.workspaces;
-      patterns = Array.isArray(ws) ? ws : (ws && ws.packages ? ws.packages : []);
+      patterns = Array.isArray(ws) ? ws : ws && ws.packages ? ws.packages : [];
     } catch {}
   }
 
@@ -3549,15 +4222,15 @@ function discoverTestCommand(cwd) {
 
   if (ws.type === 'submodule') {
     return ws.submodule_paths
-      .map(p => ({ dir: p, command: detectSingleDir(path.join(cwd, p)) }))
-      .filter(entry => entry.command !== null);
+      .map((p) => ({ dir: p, command: detectSingleDir(path.join(cwd, p)) }))
+      .filter((entry) => entry.command !== null);
   }
 
   if (ws.type === 'monorepo') {
     const pkgDirs = resolveWorkspacePaths(cwd, ws.signal);
     return pkgDirs
-      .map(p => ({ dir: p, command: detectSingleDir(path.join(cwd, p)) }))
-      .filter(entry => entry.command !== null);
+      .map((p) => ({ dir: p, command: detectSingleDir(path.join(cwd, p)) }))
+      .filter((entry) => entry.command !== null);
   }
 
   return [];
@@ -3575,27 +4248,35 @@ function discoverTestCommand(cwd) {
  */
 function cmdCleanup(cwd, options) {
   const { dryRun } = options || {};
-  const { milestonesFile: milestonesFilePath, milestones: milestonesDir, phases: phasesDir } = planningPaths(cwd);
+  const {
+    milestonesFile: milestonesFilePath,
+    milestones: milestonesDir,
+    phases: phasesDir,
+  } = planningPaths(cwd);
 
   // Read MILESTONES.md
   let milestonesContent;
   try {
     milestonesContent = fs.readFileSync(milestonesFilePath, 'utf-8');
   } catch {
-    const result = { milestones: [], nothing_to_do: true, error: 'MILESTONES.md not found' };
+    const result = {
+      milestones: [],
+      nothing_to_do: true,
+      error: 'MILESTONES.md not found',
+    };
     output(result, 'MILESTONES.md not found. Nothing to clean up.');
     return;
   }
 
   // Extract completed milestone versions: - [x] **vX.Y ... or table format | vX.Y | ... | Complete |
   const completedVersions = [];
-  const listPattern = /^-\s*\[x\]\s*\*\*(v[\d.]+)[^*]*/gmi;
+  const listPattern = /^-\s*\[x\]\s*\*\*(v[\d.]+)[^*]*/gim;
   let m;
   while ((m = listPattern.exec(milestonesContent)) !== null) {
     completedVersions.push(m[1]);
   }
   // Table format fallback: | vX.Y | ... | Complete |
-  const tablePattern = /^\|\s*(v[\d.]+)\s*\|[^|]+\|\s*Complete\s*\|/gmi;
+  const tablePattern = /^\|\s*(v[\d.]+)\s*\|[^|]+\|\s*Complete\s*\|/gim;
   while ((m = tablePattern.exec(milestonesContent)) !== null) {
     if (!completedVersions.includes(m[1])) completedVersions.push(m[1]);
   }
@@ -3633,7 +4314,11 @@ function cmdCleanup(cwd, options) {
 
     const roadmapSnapshot = path.join(milestonesDir, `${version}-ROADMAP.md`);
     if (!fs.existsSync(roadmapSnapshot)) {
-      milestoneResults.push({ version, skipped: true, reason: 'ROADMAP snapshot not found' });
+      milestoneResults.push({
+        version,
+        skipped: true,
+        reason: 'ROADMAP snapshot not found',
+      });
       continue;
     }
 
@@ -3642,7 +4327,11 @@ function cmdCleanup(cwd, options) {
     try {
       snapshotContent = fs.readFileSync(roadmapSnapshot, 'utf-8');
     } catch {
-      milestoneResults.push({ version, skipped: true, reason: 'Could not read ROADMAP snapshot' });
+      milestoneResults.push({
+        version,
+        skipped: true,
+        reason: 'Could not read ROADMAP snapshot',
+      });
       continue;
     }
 
@@ -3656,7 +4345,7 @@ function cmdCleanup(cwd, options) {
     // Normalize phase numbers for comparison: "01" == "1", "1.1" == "1.1"
     // Build a set of normalized phase numbers from the ROADMAP snapshot
     const normalizedPhaseNums = new Set(
-      [...phaseNums].map(n => n.replace(/^0+(\d)/, '$1'))
+      [...phaseNums].map((n) => n.replace(/^0+(\d)/, '$1')),
     );
 
     // Match phase numbers to actual directories that still exist
@@ -3671,11 +4360,24 @@ function cmdCleanup(cwd, options) {
       }
     }
 
-    const destination = path.join('.planning', 'milestones', `${version}-phases`);
-    const nameLine = milestonesContent.match(new RegExp(`\\*\\*${version.replace('.', '\\.')}\\s*[—–-]?\\s*([^*]+)\\*\\*`));
+    const destination = path.join(
+      '.planning',
+      'milestones',
+      `${version}-phases`,
+    );
+    const nameLine = milestonesContent.match(
+      new RegExp(
+        `\\*\\*${version.replace('.', '\\.')}\\s*[—–-]?\\s*([^*]+)\\*\\*`,
+      ),
+    );
     const name = nameLine ? nameLine[1].trim() : version;
 
-    milestoneResults.push({ version, name, destination, phases_to_archive: phasesToArchive });
+    milestoneResults.push({
+      version,
+      name,
+      destination,
+      phases_to_archive: phasesToArchive,
+    });
 
     // If executing (not dry-run), do the move
     if (!dryRun && phasesToArchive.length > 0) {
@@ -3688,9 +4390,12 @@ function cmdCleanup(cwd, options) {
     }
   }
 
-  const nonSkipped = milestoneResults.filter(m => !m.skipped);
-  const hasWork = nonSkipped.some(m => m.phases_to_archive && m.phases_to_archive.length > 0);
-  const nothingToDo = milestoneResults.length === 0 || (!hasWork && nonSkipped.length === 0);
+  const nonSkipped = milestoneResults.filter((m) => !m.skipped);
+  const hasWork = nonSkipped.some(
+    (m) => m.phases_to_archive && m.phases_to_archive.length > 0,
+  );
+  const nothingToDo =
+    milestoneResults.length === 0 || (!hasWork && nonSkipped.length === 0);
 
   const result = { milestones: milestoneResults, nothing_to_do: nothingToDo };
 
@@ -3711,9 +4416,21 @@ function cmdCleanup(cwd, options) {
     }
     output(result, text);
   } else {
-    const total = milestoneResults.filter(m => !m.skipped).reduce((sum, m) => sum + (m.phases_to_archive ? m.phases_to_archive.length : 0), 0);
-    const mCount = milestoneResults.filter(m => !m.skipped && m.phases_to_archive && m.phases_to_archive.length > 0).length;
-    output(result, `Archived ${total} phase directories from ${mCount} milestones.`);
+    const total = milestoneResults
+      .filter((m) => !m.skipped)
+      .reduce(
+        (sum, m) =>
+          sum + (m.phases_to_archive ? m.phases_to_archive.length : 0),
+        0,
+      );
+    const mCount = milestoneResults.filter(
+      (m) =>
+        !m.skipped && m.phases_to_archive && m.phases_to_archive.length > 0,
+    ).length;
+    output(
+      result,
+      `Archived ${total} phase directories from ${mCount} milestones.`,
+    );
   }
 }
 
@@ -3756,7 +4473,11 @@ function detectInstallLocation(cwd) {
         const localDir = path.dirname(localPath);
         const globalDir = path.dirname(globalPath);
         if (localDir !== globalDir) {
-          return { isLocal: true, installPath: localDir, installedVersion: localVersion.match(/^\d+\.\d+\.\d+/)[0] };
+          return {
+            isLocal: true,
+            installPath: localDir,
+            installedVersion: localVersion.match(/^\d+\.\d+\.\d+/)[0],
+          };
         }
       }
     } catch {}
@@ -3767,7 +4488,11 @@ function detectInstallLocation(cwd) {
     try {
       const globalVersion = fs.readFileSync(globalPath, 'utf-8').trim();
       if (/^\d+\.\d+\.\d+/.test(globalVersion)) {
-        return { isLocal: false, installPath: path.dirname(globalPath), installedVersion: globalVersion.match(/^\d+\.\d+\.\d+/)[0] };
+        return {
+          isLocal: false,
+          installPath: path.dirname(globalPath),
+          installedVersion: globalVersion.match(/^\d+\.\d+\.\d+/)[0],
+        };
       }
     } catch {}
   }
@@ -3973,36 +4698,54 @@ function cmdUpdate(cwd, options, _testOverrides) {
           if (err) { process.stderr.write('Download failed: ' + err.message + '\\n'); process.exit(1); }
         });
       `;
-      const dlResult = spawnSync('node', ['-e', downloadScript, tarballUrl, tarballPath], {
-        timeout: 60000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-      });
+      const dlResult = spawnSync(
+        'node',
+        ['-e', downloadScript, tarballUrl, tarballPath],
+        {
+          timeout: 60000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+        },
+      );
       if (dlResult.status !== 0) throw new Error('Download failed');
 
       // Extract tarball
-      const tarResult = spawnSync('tar', ['xzf', tarballPath, '-C', extractDir], { stdio: 'pipe' });
+      const tarResult = spawnSync(
+        'tar',
+        ['xzf', tarballPath, '-C', extractDir],
+        { stdio: 'pipe' },
+      );
       if (tarResult.status !== 0) throw new Error('Extract failed');
 
       // Run install.js
-      const installResult = spawnSync('node', [path.join(extractDir, 'bin', 'install.js'), installFlag], {
-        stdio: 'inherit',
-        timeout: 120000,
-      });
+      const installResult = spawnSync(
+        'node',
+        [path.join(extractDir, 'bin', 'install.js'), installFlag],
+        {
+          stdio: 'inherit',
+          timeout: 120000,
+        },
+      );
       if (installResult.status !== 0) throw new Error('Install failed');
     } catch (e) {
-      try { fs.rmSync(tmpExtractDir, { recursive: true, force: true }); } catch {}
+      try {
+        fs.rmSync(tmpExtractDir, { recursive: true, force: true });
+      } catch {}
       return output({
         status: 'error',
         message: 'Update failed: ' + (e.message || 'unknown error'),
       });
     }
-    try { fs.rmSync(tmpExtractDir, { recursive: true, force: true }); } catch {}
+    try {
+      fs.rmSync(tmpExtractDir, { recursive: true, force: true });
+    } catch {}
   }
 
   // 6. Clear update cache
   for (const cacheBase of [cwd, homeDir]) {
     try {
-      fs.unlinkSync(path.join(cacheBase, '.claude', 'cache', 'gsd-update-check.json'));
+      fs.unlinkSync(
+        path.join(cacheBase, '.claude', 'cache', 'gsd-update-check.json'),
+      );
     } catch {}
   }
 

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -14,20 +14,42 @@ const {
   formatAgentToModelMapAsTable,
   formatAgentToEffortMapAsTable,
 } = require('./model-profiles.cjs');
-const { syncAgentEffortFrontmatter, formatRestartNotice } = require('./effort-sync.cjs');
+const {
+  syncAgentEffortFrontmatter,
+  formatRestartNotice,
+} = require('./effort-sync.cjs');
 
 const VALID_CONFIG_KEYS = new Set([
-  'mode', 'granularity', 'parallelization', 'commit_docs', 'model_profile',
+  'mode',
+  'granularity',
+  'parallelization',
+  'commit_docs',
+  'model_profile',
   'search_gitignored',
-  'workflow.research', 'workflow.plan_check', 'workflow.verifier',
-  'workflow.nyquist_validation', 'workflow.ui_phase', 'workflow.ui_safety_gate',
-  'workflow._auto_chain_active', 'workflow.guardrail_enabled',
-  'git.branching_strategy', 'git.phase_branch_template', 'git.milestone_branch_template',
-  'git.target_branch', 'git.auto_push', 'git.remote',
-  'git.review_branch_template', 'git.type_aliases',
-  'git.pr_template', 'git.pr_draft', 'git.platform',
-  'git.commit_format', 'git.commit_template', 'git.versioning_scheme',
-  'planning.commit_docs', 'planning.search_gitignored',
+  'workflow.research',
+  'workflow.plan_check',
+  'workflow.verifier',
+  'workflow.nyquist_validation',
+  'workflow.ui_phase',
+  'workflow.ui_safety_gate',
+  'workflow._auto_chain_active',
+  'workflow.guardrail_enabled',
+  'git.branching_strategy',
+  'git.phase_branch_template',
+  'git.milestone_branch_template',
+  'git.target_branch',
+  'git.auto_push',
+  'git.remote',
+  'git.review_branch_template',
+  'git.type_aliases',
+  'git.pr_template',
+  'git.pr_draft',
+  'git.platform',
+  'git.commit_format',
+  'git.commit_template',
+  'git.versioning_scheme',
+  'planning.commit_docs',
+  'planning.search_gitignored',
   'issue_tracker.auto_sync',
   'issue_tracker.default_action',
   'issue_tracker.comment_style',
@@ -41,7 +63,8 @@ const VALID_CONFIG_KEYS = new Set([
   'git.ssh_check',
 ]);
 
-const SUBMODULE_KEY_PATTERN = /^git\.submodules\.[^.]+\.(target_branch|branching_strategy|phase_branch_template|milestone_branch_template|review_branch_template|remote|auto_push|platform|pr_template|pr_draft|commit_format|commit_template|versioning_scheme|type_aliases|ssh_check)$/;
+const SUBMODULE_KEY_PATTERN =
+  /^git\.submodules\.[^.]+\.(target_branch|branching_strategy|phase_branch_template|milestone_branch_template|review_branch_template|remote|auto_push|platform|pr_template|pr_draft|commit_format|commit_template|versioning_scheme|type_aliases|ssh_check)$/;
 
 const EFFORT_OVERRIDE_KEY_PATTERN = /^effort_overrides\.[a-z][\w-]+$/;
 
@@ -49,7 +72,8 @@ const EFFORT_OVERRIDE_KEY_PATTERN = /^effort_overrides\.[a-z][\w-]+$/;
 // cmdConfigGet hides these from Copilot consumers — even if a hand-edited
 // copilot config.json contains them — so the read-side strip is robust
 // against future key additions.
-const PROFILE_EFFORT_KEY_PATTERN = /^(model_profile|model_overrides(\..+)?|effort_overrides(\..+)?)$/;
+const PROFILE_EFFORT_KEY_PATTERN =
+  /^(model_profile|model_overrides(\..+)?|effort_overrides(\..+)?)$/;
 
 const CONFIG_KEY_SUGGESTIONS = {
   'workflow.nyquist_validation_enabled': 'workflow.nyquist_validation',
@@ -96,11 +120,20 @@ function ensureConfigFile(cwd) {
       userDefaults = JSON.parse(fs.readFileSync(globalDefaultsPath, 'utf-8'));
       // Migrate deprecated "depth" key to "granularity"
       if ('depth' in userDefaults && !('granularity' in userDefaults)) {
-        const depthToGranularity = { quick: 'coarse', standard: 'standard', comprehensive: 'fine' };
-        userDefaults.granularity = depthToGranularity[userDefaults.depth] || userDefaults.depth;
+        const depthToGranularity = {
+          quick: 'coarse',
+          standard: 'standard',
+          comprehensive: 'fine',
+        };
+        userDefaults.granularity =
+          depthToGranularity[userDefaults.depth] || userDefaults.depth;
         delete userDefaults.depth;
         try {
-          fs.writeFileSync(globalDefaultsPath, JSON.stringify(userDefaults, null, 2), 'utf-8');
+          fs.writeFileSync(
+            globalDefaultsPath,
+            JSON.stringify(userDefaults, null, 2),
+            'utf-8',
+          );
         } catch {}
       }
     }
@@ -205,7 +238,9 @@ function cmdConfigSet(cwd, keyPath, value) {
   validateKnownConfigKeyPath(keyPath);
 
   if (keyPath === 'git.submodule.workspace_branch') {
-    error('git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.');
+    error(
+      'git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.',
+    );
   }
 
   // model_profile is a domain-level setting, not a flat key/value.
@@ -214,19 +249,28 @@ function cmdConfigSet(cwd, keyPath, value) {
   if (keyPath === 'model_profile') {
     error(
       "'model_profile' must be set via 'config-set-model-profile <profile>'. " +
-      "Setting it through 'config-set' skips agent effort sync, profile validation, and the restart notice."
+        "Setting it through 'config-set' skips agent effort sync, profile validation, and the restart notice.",
     );
   }
 
-  if (!VALID_CONFIG_KEYS.has(keyPath) && !SUBMODULE_KEY_PATTERN.test(keyPath) && !EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath)) {
-    error(`Unknown config key: "${keyPath}". Valid keys: ${[...VALID_CONFIG_KEYS].sort().join(', ')}`);
+  if (
+    !VALID_CONFIG_KEYS.has(keyPath) &&
+    !SUBMODULE_KEY_PATTERN.test(keyPath) &&
+    !EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath)
+  ) {
+    error(
+      `Unknown config key: "${keyPath}". Valid keys: ${[...VALID_CONFIG_KEYS].sort().join(', ')}`,
+    );
   }
 
   // Value-validation for effort_overrides.* keys: reject values outside the valid set.
-  if (EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath) && !VALID_EFFORT_VALUES.includes(value)) {
+  if (
+    EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath) &&
+    !VALID_EFFORT_VALUES.includes(value)
+  ) {
     error(
       `Invalid effort value "${value}" for ${keyPath}. ` +
-      `Valid values: ${VALID_EFFORT_VALUES.join(', ')}.`
+        `Valid values: ${VALID_EFFORT_VALUES.join(', ')}.`,
     );
   }
 
@@ -261,7 +305,9 @@ function cmdConfigGet(cwd, keyPath, defaultValue) {
   }
 
   if (keyPath === 'git.submodule.workspace_branch') {
-    process.stderr.write('Warning: git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.\n');
+    process.stderr.write(
+      'Warning: git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.\n',
+    );
   }
 
   // Phase 55 Area 1 lock: profile/effort keys are Claude-only.
@@ -303,7 +349,11 @@ function cmdConfigGet(cwd, keyPath, defaultValue) {
   const keys = keyPath.split('.');
   let current = config;
   for (const key of keys) {
-    if (current === undefined || current === null || typeof current !== 'object') {
+    if (
+      current === undefined ||
+      current === null ||
+      typeof current !== 'object'
+    ) {
       if (defaultValue !== undefined) {
         output(defaultValue, String(defaultValue));
         return;
@@ -336,14 +386,20 @@ function cmdConfigSetModelProfile(cwd, profile) {
 
   const normalizedProfile = profile.toLowerCase().trim();
   if (!VALID_PROFILES.includes(normalizedProfile)) {
-    error(`Invalid profile '${profile}'. Valid profiles: ${VALID_PROFILES.join(', ')}`);
+    error(
+      `Invalid profile '${profile}'. Valid profiles: ${VALID_PROFILES.join(', ')}`,
+    );
   }
 
   // Ensure config exists (create if needed)
   ensureConfigFile(cwd);
 
   // Set the model profile in the config
-  const { previousValue } = setConfigValue(cwd, 'model_profile', normalizedProfile);
+  const { previousValue } = setConfigValue(
+    cwd,
+    'model_profile',
+    normalizedProfile,
+  );
   const previousProfile = previousValue || 'balanced';
 
   // Build result value / message and return
@@ -371,7 +427,7 @@ function cmdConfigSetModelProfile(cwd, profile) {
     normalizedProfile,
     previousProfile,
     agentToModelMap,
-    agentToEffortMap
+    agentToEffortMap,
   );
   output(result, rawValue);
 }
@@ -384,24 +440,30 @@ function getCmdConfigSetModelProfileResultMessage(
   normalizedProfile,
   previousProfile,
   agentToModelMap,
-  agentToEffortMap
+  agentToEffortMap,
 ) {
   const agentToModelTable = formatAgentToModelMapAsTable(agentToModelMap);
-  const agentToEffortTable = agentToEffortMap ? formatAgentToEffortMapAsTable(agentToEffortMap) : null;
+  const agentToEffortTable = agentToEffortMap
+    ? formatAgentToEffortMapAsTable(agentToEffortMap)
+    : null;
   const didChange = previousProfile !== normalizedProfile;
   const paragraphs = didChange
     ? [
         `\u2713 Model profile set to: ${normalizedProfile} (was: ${previousProfile})`,
         'Model assignments:',
         agentToModelTable,
-        ...(agentToEffortTable ? ['Effort assignments:', agentToEffortTable] : []),
+        ...(agentToEffortTable
+          ? ['Effort assignments:', agentToEffortTable]
+          : []),
         'Next spawned agents will use the new profile.',
       ]
     : [
         `\u2713 Model profile is already set to: ${normalizedProfile}`,
         'Model assignments:',
         agentToModelTable,
-        ...(agentToEffortTable ? ['Effort assignments:', agentToEffortTable] : []),
+        ...(agentToEffortTable
+          ? ['Effort assignments:', agentToEffortTable]
+          : []),
       ];
   return paragraphs.join('\n\n');
 }

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -25,20 +25,20 @@ function planningPaths(cwd) {
   const root = path.join(cwd, '.planning');
   return {
     root,
-    phases:         path.join(root, 'phases'),
-    config:         path.join(root, 'config.json'),
-    state:          path.join(root, 'STATE.md'),
-    roadmap:        path.join(root, 'ROADMAP.md'),
-    requirements:   path.join(root, 'REQUIREMENTS.md'),
-    todos:          path.join(root, 'todos'),
-    todosPending:   path.join(root, 'todos', 'pending'),
+    phases: path.join(root, 'phases'),
+    config: path.join(root, 'config.json'),
+    state: path.join(root, 'STATE.md'),
+    roadmap: path.join(root, 'ROADMAP.md'),
+    requirements: path.join(root, 'REQUIREMENTS.md'),
+    todos: path.join(root, 'todos'),
+    todosPending: path.join(root, 'todos', 'pending'),
     todosCompleted: path.join(root, 'todos', 'completed'),
-    codebase:       path.join(root, 'codebase'),
-    divergence:     path.join(root, 'DIVERGENCE.md'),
-    milestones:     path.join(root, 'milestones'),
+    codebase: path.join(root, 'codebase'),
+    divergence: path.join(root, 'DIVERGENCE.md'),
+    milestones: path.join(root, 'milestones'),
     milestonesFile: path.join(root, 'MILESTONES.md'),
-    project:        path.join(root, 'PROJECT.md'),
-    archive:        path.join(root, 'archive'),
+    project: path.join(root, 'PROJECT.md'),
+    archive: path.join(root, 'archive'),
   };
 }
 
@@ -52,7 +52,10 @@ function planningPaths(cwd) {
  * @param {number} opts.maxAgeMs - max age in ms before removal (default: 5 min)
  * @param {boolean} opts.dirsOnly - if true, only remove directories (default: false)
  */
-function reapStaleTempFiles(prefix = 'gsd-', { maxAgeMs = 5 * 60 * 1000, dirsOnly = false } = {}) {
+function reapStaleTempFiles(
+  prefix = 'gsd-',
+  { maxAgeMs = 5 * 60 * 1000, dirsOnly = false } = {},
+) {
   try {
     const tmpDir = require('os').tmpdir();
     const now = Date.now();
@@ -82,12 +85,16 @@ function reapStaleTempFiles(prefix = 'gsd-', { maxAgeMs = 5 * 60 * 1000, dirsOnl
 // a temp file prefixed with @file:. Off by default -- inline is the standard path.
 // Activated via --file global flag in gsd-tools.cjs.
 let _fileOutput = false;
-function setFileOutput(val) { _fileOutput = val; }
+function setFileOutput(val) {
+  _fileOutput = val;
+}
 
 // Module-level JSON mode flag: when true, output() always emits JSON regardless
 // of displayValue. Activated via --json global flag or --pick in gsd-tools.cjs.
 let _jsonMode = false;
-function setJsonMode(val) { _jsonMode = val; }
+function setJsonMode(val) {
+  _jsonMode = val;
+}
 
 /**
  * Write JSON to a temp file and return the @file: prefixed path.
@@ -170,15 +177,25 @@ function loadConfig(cwd) {
 
     // Migrate deprecated "depth" key to "granularity" with value mapping
     if ('depth' in parsed && !('granularity' in parsed)) {
-      const depthToGranularity = { quick: 'coarse', standard: 'standard', comprehensive: 'fine' };
+      const depthToGranularity = {
+        quick: 'coarse',
+        standard: 'standard',
+        comprehensive: 'fine',
+      };
       parsed.granularity = depthToGranularity[parsed.depth] || parsed.depth;
       delete parsed.depth;
-      try { fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2), 'utf-8'); } catch {}
+      try {
+        fs.writeFileSync(configPath, JSON.stringify(parsed, null, 2), 'utf-8');
+      } catch {}
     }
 
     const get = (key, nested) => {
       if (parsed[key] !== undefined) return parsed[key];
-      if (nested && parsed[nested.section] && parsed[nested.section][nested.field] !== undefined) {
+      if (
+        nested &&
+        parsed[nested.section] &&
+        parsed[nested.section][nested.field] !== undefined
+      ) {
         return parsed[nested.section][nested.field];
       }
       return undefined;
@@ -187,14 +204,18 @@ function loadConfig(cwd) {
     const parallelization = (() => {
       const val = get('parallelization');
       if (typeof val === 'boolean') return val;
-      if (typeof val === 'object' && val !== null && 'enabled' in val) return val.enabled;
+      if (typeof val === 'object' && val !== null && 'enabled' in val)
+        return val.enabled;
       return defaults.parallelization;
     })();
 
     return {
       model_profile: get('model_profile') ?? defaults.model_profile,
       commit_docs: (() => {
-        const explicit = get('commit_docs', { section: 'planning', field: 'commit_docs' });
+        const explicit = get('commit_docs', {
+          section: 'planning',
+          field: 'commit_docs',
+        });
         // If explicitly set in config, respect the user's choice
         if (explicit !== undefined) return explicit;
         // Auto-detection: when no explicit value and .planning/ is gitignored,
@@ -202,23 +223,70 @@ function loadConfig(cwd) {
         if (isGitIgnored(cwd, '.planning/')) return false;
         return defaults.commit_docs;
       })(),
-      search_gitignored: get('search_gitignored', { section: 'planning', field: 'search_gitignored' }) ?? defaults.search_gitignored,
-      branching_strategy: get('branching_strategy', { section: 'git', field: 'branching_strategy' }) ?? defaults.branching_strategy,
-      phase_branch_template: get('phase_branch_template', { section: 'git', field: 'phase_branch_template' }) ?? defaults.phase_branch_template,
-      milestone_branch_template: get('milestone_branch_template', { section: 'git', field: 'milestone_branch_template' }) ?? defaults.milestone_branch_template,
-      target_branch: get('target_branch', { section: 'git', field: 'target_branch' }) ?? defaults.target_branch,
-      auto_push: get('auto_push', { section: 'git', field: 'auto_push' }) ?? defaults.auto_push,
-      remote: get('remote', { section: 'git', field: 'remote' }) ?? defaults.remote,
-      review_branch_template: get('review_branch_template', { section: 'git', field: 'review_branch_template' }) ?? defaults.review_branch_template,
-      pr_draft: get('pr_draft', { section: 'git', field: 'pr_draft' }) ?? defaults.pr_draft,
-      platform: get('platform', { section: 'git', field: 'platform' }) ?? defaults.platform,
-      commit_format: get('commit_format', { section: 'git', field: 'commit_format' }) ?? defaults.commit_format,
-      commit_template: get('commit_template', { section: 'git', field: 'commit_template' }) ?? defaults.commit_template,
-      versioning_scheme: get('versioning_scheme', { section: 'git', field: 'versioning_scheme' }) ?? defaults.versioning_scheme,
-      research: get('research', { section: 'workflow', field: 'research' }) ?? defaults.research,
-      plan_checker: get('plan_checker', { section: 'workflow', field: 'plan_check' }) ?? defaults.plan_checker,
-      verifier: get('verifier', { section: 'workflow', field: 'verifier' }) ?? defaults.verifier,
-      nyquist_validation: get('nyquist_validation', { section: 'workflow', field: 'nyquist_validation' }) ?? defaults.nyquist_validation,
+      search_gitignored:
+        get('search_gitignored', {
+          section: 'planning',
+          field: 'search_gitignored',
+        }) ?? defaults.search_gitignored,
+      branching_strategy:
+        get('branching_strategy', {
+          section: 'git',
+          field: 'branching_strategy',
+        }) ?? defaults.branching_strategy,
+      phase_branch_template:
+        get('phase_branch_template', {
+          section: 'git',
+          field: 'phase_branch_template',
+        }) ?? defaults.phase_branch_template,
+      milestone_branch_template:
+        get('milestone_branch_template', {
+          section: 'git',
+          field: 'milestone_branch_template',
+        }) ?? defaults.milestone_branch_template,
+      target_branch:
+        get('target_branch', { section: 'git', field: 'target_branch' }) ??
+        defaults.target_branch,
+      auto_push:
+        get('auto_push', { section: 'git', field: 'auto_push' }) ??
+        defaults.auto_push,
+      remote:
+        get('remote', { section: 'git', field: 'remote' }) ?? defaults.remote,
+      review_branch_template:
+        get('review_branch_template', {
+          section: 'git',
+          field: 'review_branch_template',
+        }) ?? defaults.review_branch_template,
+      pr_draft:
+        get('pr_draft', { section: 'git', field: 'pr_draft' }) ??
+        defaults.pr_draft,
+      platform:
+        get('platform', { section: 'git', field: 'platform' }) ??
+        defaults.platform,
+      commit_format:
+        get('commit_format', { section: 'git', field: 'commit_format' }) ??
+        defaults.commit_format,
+      commit_template:
+        get('commit_template', { section: 'git', field: 'commit_template' }) ??
+        defaults.commit_template,
+      versioning_scheme:
+        get('versioning_scheme', {
+          section: 'git',
+          field: 'versioning_scheme',
+        }) ?? defaults.versioning_scheme,
+      research:
+        get('research', { section: 'workflow', field: 'research' }) ??
+        defaults.research,
+      plan_checker:
+        get('plan_checker', { section: 'workflow', field: 'plan_check' }) ??
+        defaults.plan_checker,
+      verifier:
+        get('verifier', { section: 'workflow', field: 'verifier' }) ??
+        defaults.verifier,
+      nyquist_validation:
+        get('nyquist_validation', {
+          section: 'workflow',
+          field: 'nyquist_validation',
+        }) ?? defaults.nyquist_validation,
       parallelization,
       model_overrides: parsed.model_overrides || null,
       effort_overrides: parsed.effort_overrides || null,
@@ -238,10 +306,14 @@ function isGitIgnored(cwd, targetPath) {
     // .gitignore explicitly lists them — a common source of confusion when .planning/
     // was committed before being added to .gitignore.
     // Use execFileSync with array args to prevent command injection via path values.
-    execFileSync('git', ['check-ignore', '-q', '--no-index', '--', targetPath], {
-      cwd,
-      stdio: 'pipe',
-    });
+    execFileSync(
+      'git',
+      ['check-ignore', '-q', '--no-index', '--', targetPath],
+      {
+        cwd,
+        stdio: 'pipe',
+      },
+    );
     return true;
   } catch {
     return false;
@@ -291,8 +363,18 @@ function comparePhaseNum(a, b) {
     return la < lb ? -1 : 1;
   }
   // Segment-by-segment decimal comparison: 12A < 12A.1 < 12A.1.2 < 12A.2
-  const aDecParts = pa[3] ? pa[3].slice(1).split('.').map(p => parseInt(p, 10)) : [];
-  const bDecParts = pb[3] ? pb[3].slice(1).split('.').map(p => parseInt(p, 10)) : [];
+  const aDecParts = pa[3]
+    ? pa[3]
+        .slice(1)
+        .split('.')
+        .map((p) => parseInt(p, 10))
+    : [];
+  const bDecParts = pb[3]
+    ? pb[3]
+        .slice(1)
+        .split('.')
+        .map((p) => parseInt(p, 10))
+    : [];
   const maxLen = Math.max(aDecParts.length, bDecParts.length);
   if (aDecParts.length === 0 && bDecParts.length > 0) return -1;
   if (bDecParts.length === 0 && aDecParts.length > 0) return 1;
@@ -307,8 +389,11 @@ function comparePhaseNum(a, b) {
 function searchPhaseInDir(baseDir, relBase, normalized) {
   try {
     const entries = fs.readdirSync(baseDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
-    const match = dirs.find(d => d.startsWith(normalized));
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => comparePhaseNum(a, b));
+    const match = dirs.find((d) => d.startsWith(normalized));
     if (!match) return null;
 
     const dirMatch = match.match(/^(\d+[A-Z]?(?:\.\d+)*)-?(.*)/i);
@@ -317,18 +402,30 @@ function searchPhaseInDir(baseDir, relBase, normalized) {
     const phaseDir = path.join(baseDir, match);
     const phaseFiles = fs.readdirSync(phaseDir);
 
-    const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').sort();
-    const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md').sort();
-    const hasResearch = phaseFiles.some(f =>
-      (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) || f === 'RESEARCH.md'
+    const plans = phaseFiles
+      .filter((f) => f.endsWith('-PLAN.md') || f === 'PLAN.md')
+      .sort();
+    const summaries = phaseFiles
+      .filter((f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md')
+      .sort();
+    const hasResearch = phaseFiles.some(
+      (f) =>
+        (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) ||
+        f === 'RESEARCH.md',
     );
-    const hasContext = phaseFiles.some(f => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md');
-    const hasVerification = phaseFiles.some(f => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md');
+    const hasContext = phaseFiles.some(
+      (f) => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md',
+    );
+    const hasVerification = phaseFiles.some(
+      (f) => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md',
+    );
 
     const completedPlanIds = new Set(
-      summaries.map(s => s.replace('-SUMMARY.md', '').replace('SUMMARY.md', ''))
+      summaries.map((s) =>
+        s.replace('-SUMMARY.md', '').replace('SUMMARY.md', ''),
+      ),
     );
-    const incompletePlans = plans.filter(p => {
+    const incompletePlans = plans.filter((p) => {
       const planId = p.replace('-PLAN.md', '').replace('PLAN.md', '');
       return !completedPlanIds.has(planId);
     });
@@ -338,7 +435,12 @@ function searchPhaseInDir(baseDir, relBase, normalized) {
       directory: toPosixPath(path.join(relBase, match)),
       phase_number: phaseNumber,
       phase_name: phaseName,
-      phase_slug: phaseName ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
+      phase_slug: phaseName
+        ? phaseName
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+        : null,
       plans,
       summaries,
       incomplete_plans: incompletePlans,
@@ -365,10 +467,12 @@ function findPhaseInternal(cwd, phase) {
   if (!fs.existsSync(milestonesDir)) return null;
 
   try {
-    const milestoneEntries = fs.readdirSync(milestonesDir, { withFileTypes: true });
+    const milestoneEntries = fs.readdirSync(milestonesDir, {
+      withFileTypes: true,
+    });
     const archiveDirs = milestoneEntries
-      .filter(e => e.isDirectory() && /^v[\d.]+-phases$/.test(e.name))
-      .map(e => e.name)
+      .filter((e) => e.isDirectory() && /^v[\d.]+-phases$/.test(e.name))
+      .map((e) => e.name)
       .sort()
       .reverse();
 
@@ -394,11 +498,13 @@ function getArchivedPhaseDirs(cwd) {
   if (!fs.existsSync(milestonesDir)) return results;
 
   try {
-    const milestoneEntries = fs.readdirSync(milestonesDir, { withFileTypes: true });
+    const milestoneEntries = fs.readdirSync(milestonesDir, {
+      withFileTypes: true,
+    });
     // Find v*-phases directories, sort newest first
     const phaseDirs = milestoneEntries
-      .filter(e => e.isDirectory() && /^v[\d.]+-phases$/.test(e.name))
-      .map(e => e.name)
+      .filter((e) => e.isDirectory() && /^v[\d.]+-phases$/.test(e.name))
+      .map((e) => e.name)
       .sort()
       .reverse();
 
@@ -406,7 +512,10 @@ function getArchivedPhaseDirs(cwd) {
       const version = archiveName.match(/^(v[\d.]+)-phases$/)[1];
       const archivePath = path.join(milestonesDir, archiveName);
       const entries = fs.readdirSync(archivePath, { withFileTypes: true });
-      const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
+      const dirs = entries
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort((a, b) => comparePhaseNum(a, b));
 
       for (const dir of dirs) {
         results.push({
@@ -457,20 +566,31 @@ function getRoadmapPhaseInternal(cwd, phaseNum) {
   if (!fs.existsSync(roadmapPath)) return null;
 
   try {
-    const content = extractCurrentMilestone(fs.readFileSync(roadmapPath, 'utf-8'));
+    const content = extractCurrentMilestone(
+      fs.readFileSync(roadmapPath, 'utf-8'),
+    );
     const escapedPhase = escapeRegex(phaseNum.toString());
-    const phasePattern = new RegExp(`#{2,4}\\s*Phase\\s+${escapedPhase}:\\s*([^\\n]+)`, 'i');
+    const phasePattern = new RegExp(
+      `#{2,4}\\s*Phase\\s+${escapedPhase}:\\s*([^\\n]+)`,
+      'i',
+    );
     const headerMatch = content.match(phasePattern);
     if (!headerMatch) return null;
 
     const phaseName = headerMatch[1].trim();
     const headerIndex = headerMatch.index;
     const restOfContent = content.slice(headerIndex);
-    const nextHeaderMatch = restOfContent.match(/\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i);
-    const sectionEnd = nextHeaderMatch ? headerIndex + nextHeaderMatch.index : content.length;
+    const nextHeaderMatch = restOfContent.match(
+      /\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i,
+    );
+    const sectionEnd = nextHeaderMatch
+      ? headerIndex + nextHeaderMatch.index
+      : content.length;
     const section = content.slice(headerIndex, sectionEnd).trim();
 
-    const goalMatch = section.match(/\*\*Goal(?:\*\*:|\*?\*?:\*\*)\s*([^\n]+)/i);
+    const goalMatch = section.match(
+      /\*\*Goal(?:\*\*:|\*?\*?:\*\*)\s*([^\n]+)/i,
+    );
     const goal = goalMatch ? goalMatch[1].trim() : null;
 
     return {
@@ -513,7 +633,8 @@ function resolveEffortInternal(cwd, agentType) {
 
   // Resolve effort from override or profile (unchanged logic).
   const hasExplicitOverride = Object.prototype.hasOwnProperty.call(
-    config.effort_overrides || {}, agentType
+    config.effort_overrides || {},
+    agentType,
   );
   let effort;
   if (hasExplicitOverride) {
@@ -524,7 +645,8 @@ function resolveEffortInternal(cwd, agentType) {
     const agentEfforts = EFFORT_PROFILES[agentType];
     if (!agentEfforts) return null;
     const profileEffort = agentEfforts[profile];
-    effort = (!profileEffort || profileEffort === 'inherit') ? null : profileEffort;
+    effort =
+      !profileEffort || profileEffort === 'inherit' ? null : profileEffort;
   }
 
   // Model-tier compatibility: haiku does not support effort at all; xhigh and max
@@ -534,7 +656,9 @@ function resolveEffortInternal(cwd, agentType) {
   const resolvedModel = resolveModelInternal(cwd, agentType);
   const haikuSkip = resolvedModel === 'haiku';
   const opusOnlySkip =
-    resolvedModel && resolvedModel !== 'opus' && (effort === 'xhigh' || effort === 'max');
+    resolvedModel &&
+    resolvedModel !== 'opus' &&
+    (effort === 'xhigh' || effort === 'max');
   if (haikuSkip || opusOnlySkip) {
     if (hasExplicitOverride && effort !== null) {
       const overrideValue = config.effort_overrides[agentType];
@@ -543,7 +667,7 @@ function resolveEffortInternal(cwd, agentType) {
         : `${effort} requires opus (resolved model: ${resolvedModel})`;
       fs.writeSync(
         2,
-        `Warning: effort_overrides.${agentType}="${overrideValue}" ignored — ${reason}\n`
+        `Warning: effort_overrides.${agentType}="${overrideValue}" ignored — ${reason}\n`,
       );
     }
     return null;
@@ -555,7 +679,9 @@ function resolveEffortInternal(cwd, agentType) {
 // ─── Misc utilities ───────────────────────────────────────────────────────────
 
 function pathExistsInternal(cwd, targetPath) {
-  const fullPath = path.isAbsolute(targetPath) ? targetPath : path.join(cwd, targetPath);
+  const fullPath = path.isAbsolute(targetPath)
+    ? targetPath
+    : path.join(cwd, targetPath);
   try {
     fs.statSync(fullPath);
     return true;
@@ -566,7 +692,10 @@ function pathExistsInternal(cwd, targetPath) {
 
 function generateSlugInternal(text, maxLen = 50) {
   if (!text) return null;
-  let slug = text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+  let slug = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
   if (slug.length > maxLen) {
     slug = slug.slice(0, maxLen).replace(/-[^-]*$/, '');
   }
@@ -616,7 +745,9 @@ function getMilestoneInfo(cwd) {
 function getMilestonePhaseFilter(cwd) {
   const milestonePhaseNums = new Set();
   try {
-    const roadmap = extractCurrentMilestone(fs.readFileSync(planningPaths(cwd).roadmap, 'utf-8'));
+    const roadmap = extractCurrentMilestone(
+      fs.readFileSync(planningPaths(cwd).roadmap, 'utf-8'),
+    );
     const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:/gi;
     let m;
     while ((m = phasePattern.exec(roadmap)) !== null) {
@@ -631,7 +762,9 @@ function getMilestonePhaseFilter(cwd) {
   }
 
   const normalized = new Set(
-    [...milestonePhaseNums].map(n => (n.replace(/^0+/, '') || '0').toLowerCase())
+    [...milestonePhaseNums].map((n) =>
+      (n.replace(/^0+/, '') || '0').toLowerCase(),
+    ),
   );
 
   function isDirInMilestone(dirName) {
@@ -662,16 +795,26 @@ function getPhaseCompletionStatus(phaseDir) {
   } catch {
     return { isComplete: false, status: 'not_started' };
   }
-  const planCount = files.filter(f => f.match(/-PLAN\.md$/i) || f === 'PLAN.md').length;
-  const summaryCount = files.filter(f => f.match(/-SUMMARY\.md$/i) || f === 'SUMMARY.md').length;
+  const planCount = files.filter(
+    (f) => f.match(/-PLAN\.md$/i) || f === 'PLAN.md',
+  ).length;
+  const summaryCount = files.filter(
+    (f) => f.match(/-SUMMARY\.md$/i) || f === 'SUMMARY.md',
+  ).length;
   if (planCount === 0) return { isComplete: false, status: 'not_started' };
-  if (summaryCount < planCount) return { isComplete: false, status: 'in_progress' };
+  if (summaryCount < planCount)
+    return { isComplete: false, status: 'in_progress' };
   // summaries >= plans — phase is complete. Check verification status.
-  const verificationFile = files.find(f => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md');
+  const verificationFile = files.find(
+    (f) => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md',
+  );
   if (verificationFile) {
     try {
       const { extractFrontmatter } = require('./frontmatter.cjs');
-      const verContent = fs.readFileSync(path.join(phaseDir, verificationFile), 'utf-8');
+      const verContent = fs.readFileSync(
+        path.join(phaseDir, verificationFile),
+        'utf-8',
+      );
       const fm = extractFrontmatter(verContent);
       if (fm && fm.status === 'passed') {
         return { isComplete: true, status: 'complete (verified)' };

--- a/gsd-ng/bin/lib/effort-sync.cjs
+++ b/gsd-ng/bin/lib/effort-sync.cjs
@@ -46,7 +46,8 @@ function syncAgentEffortFrontmatter(cwd, agentsDir) {
 
     const content = fs.readFileSync(agentFile, 'utf-8');
     const fm = extractFrontmatter(content);
-    const existing = (fm.effort !== undefined && fm.effort !== null) ? fm.effort : null;
+    const existing =
+      fm.effort !== undefined && fm.effort !== null ? fm.effort : null;
     const resolved = resolveEffortInternal(cwd, agentType); // null means omit
 
     if (existing === resolved) continue; // idempotent short-circuit

--- a/gsd-ng/bin/lib/frontmatter.cjs
+++ b/gsd-ng/bin/lib/frontmatter.cjs
@@ -51,7 +51,11 @@ function extractFrontmatter(content) {
         stack.push({ obj: current.obj[key], key: null, indent });
       } else if (value.startsWith('[') && value.endsWith(']')) {
         // Inline array: key: [a, b, c]
-        current.obj[key] = value.slice(1, -1).split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+        current.obj[key] = value
+          .slice(1, -1)
+          .split(',')
+          .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
         current.key = null;
       } else {
         // Simple key: value
@@ -60,10 +64,17 @@ function extractFrontmatter(content) {
       }
     } else if (line.trim().startsWith('- ')) {
       // Array item
-      const itemValue = line.trim().slice(2).replace(/^["']|["']$/g, '');
+      const itemValue = line
+        .trim()
+        .slice(2)
+        .replace(/^["']|["']$/g, '');
 
       // If current context is an empty object, convert to array
-      if (typeof current.obj === 'object' && !Array.isArray(current.obj) && Object.keys(current.obj).length === 0) {
+      if (
+        typeof current.obj === 'object' &&
+        !Array.isArray(current.obj) &&
+        Object.keys(current.obj).length === 0
+      ) {
         // Find the key in parent that points to this object and convert it
         const parent = stack.length > 1 ? stack[stack.length - 2] : null;
         if (parent) {
@@ -91,12 +102,18 @@ function reconstructFrontmatter(obj) {
     if (Array.isArray(value)) {
       if (value.length === 0) {
         lines.push(`${key}: []`);
-      } else if (value.every(v => typeof v === 'string') && value.length <= 3 && value.join(', ').length < 60) {
+      } else if (
+        value.every((v) => typeof v === 'string') &&
+        value.length <= 3 &&
+        value.join(', ').length < 60
+      ) {
         lines.push(`${key}: [${value.join(', ')}]`);
       } else {
         lines.push(`${key}:`);
         for (const item of value) {
-          lines.push(`  - ${typeof item === 'string' && (item.includes(':') || item.includes('#')) ? `"${item}"` : item}`);
+          lines.push(
+            `  - ${typeof item === 'string' && (item.includes(':') || item.includes('#')) ? `"${item}"` : item}`,
+          );
         }
       }
     } else if (typeof value === 'object') {
@@ -106,12 +123,18 @@ function reconstructFrontmatter(obj) {
         if (Array.isArray(subval)) {
           if (subval.length === 0) {
             lines.push(`  ${subkey}: []`);
-          } else if (subval.every(v => typeof v === 'string') && subval.length <= 3 && subval.join(', ').length < 60) {
+          } else if (
+            subval.every((v) => typeof v === 'string') &&
+            subval.length <= 3 &&
+            subval.join(', ').length < 60
+          ) {
             lines.push(`  ${subkey}: [${subval.join(', ')}]`);
           } else {
             lines.push(`  ${subkey}:`);
             for (const item of subval) {
-              lines.push(`    - ${typeof item === 'string' && (item.includes(':') || item.includes('#')) ? `"${item}"` : item}`);
+              lines.push(
+                `    - ${typeof item === 'string' && (item.includes(':') || item.includes('#')) ? `"${item}"` : item}`,
+              );
             }
           }
         } else if (typeof subval === 'object') {
@@ -133,12 +156,22 @@ function reconstructFrontmatter(obj) {
           }
         } else {
           const sv = String(subval);
-          lines.push(`  ${subkey}: ${sv.includes(':') || sv.includes('#') || sv.includes(' \u2014 ') || sv.includes('(') || sv.includes(')') ? `"${sv}"` : sv}`);
+          lines.push(
+            `  ${subkey}: ${sv.includes(':') || sv.includes('#') || sv.includes(' \u2014 ') || sv.includes('(') || sv.includes(')') ? `"${sv}"` : sv}`,
+          );
         }
       }
     } else {
       const sv = String(value);
-      if (sv.includes(':') || sv.includes('#') || sv.startsWith('[') || sv.startsWith('{') || sv.includes(' \u2014 ') || sv.includes('(') || sv.includes(')')) {
+      if (
+        sv.includes(':') ||
+        sv.includes('#') ||
+        sv.startsWith('[') ||
+        sv.startsWith('{') ||
+        sv.includes(' \u2014 ') ||
+        sv.includes('(') ||
+        sv.includes(')')
+      ) {
         lines.push(`${key}: "${sv}"`);
       } else {
         lines.push(`${key}: ${sv}`);
@@ -226,29 +259,57 @@ function parseMustHavesBlock(content, blockName) {
 // ─── Frontmatter CRUD commands ────────────────────────────────────────────────
 
 const FRONTMATTER_SCHEMAS = {
-  plan: { required: ['phase', 'plan', 'type', 'wave', 'depends_on', 'files_modified', 'autonomous', 'must_haves'] },
-  summary: { required: ['phase', 'plan', 'subsystem', 'tags', 'duration', 'completed'] },
+  plan: {
+    required: [
+      'phase',
+      'plan',
+      'type',
+      'wave',
+      'depends_on',
+      'files_modified',
+      'autonomous',
+      'must_haves',
+    ],
+  },
+  summary: {
+    required: ['phase', 'plan', 'subsystem', 'tags', 'duration', 'completed'],
+  },
   verification: { required: ['phase', 'verified', 'status', 'score'] },
 };
 
 function cmdFrontmatterGet(cwd, filePath, field, format, defaultValue) {
-  if (!filePath) { error('file path required'); }
-  const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+  if (!filePath) {
+    error('file path required');
+  }
+  const fullPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
   if (!content) {
-    if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
-    output({ error: 'File not found', path: filePath }); return;
+    if (defaultValue !== undefined) {
+      output(defaultValue, String(defaultValue));
+      return;
+    }
+    output({ error: 'File not found', path: filePath });
+    return;
   }
   const fm = extractFrontmatter(content);
   if (field) {
     const value = fm[field];
     if (value === undefined) {
-      if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
-      output({ error: 'Field not found', field }); return;
+      if (defaultValue !== undefined) {
+        output(defaultValue, String(defaultValue));
+        return;
+      }
+      output({ error: 'Field not found', field });
+      return;
     }
-    const rawString = (format === 'newline' && Array.isArray(value))
-      ? value.join('\n')
-      : (Array.isArray(value) ? value.join(', ') : String(value));
+    const rawString =
+      format === 'newline' && Array.isArray(value)
+        ? value.join('\n')
+        : Array.isArray(value)
+          ? value.join(', ')
+          : String(value);
     output({ [field]: value }, rawString);
   } else {
     output(fm);
@@ -256,7 +317,9 @@ function cmdFrontmatterGet(cwd, filePath, field, format, defaultValue) {
 }
 
 function cmdFrontmatterSet(cwd, filePath, field, value) {
-  if (!filePath || !field || value === undefined) { error('file, field, and value required'); }
+  if (!filePath || !field || value === undefined) {
+    error('file, field, and value required');
+  }
   const fieldCheck = validateFieldName(field);
   if (!fieldCheck.valid) {
     error(`Invalid field name: ${fieldCheck.error}`);
@@ -267,12 +330,21 @@ function cmdFrontmatterSet(cwd, filePath, field, value) {
       error(`Invalid file path: ${pathCheck.error}`);
     }
   }
-  const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
-  if (!fs.existsSync(fullPath)) { output({ error: 'File not found', path: filePath }); return; }
+  const fullPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
+  if (!fs.existsSync(fullPath)) {
+    output({ error: 'File not found', path: filePath });
+    return;
+  }
   const content = fs.readFileSync(fullPath, 'utf-8');
   const fm = extractFrontmatter(content);
   let parsedValue;
-  try { parsedValue = JSON.parse(value); } catch { parsedValue = value; }
+  try {
+    parsedValue = JSON.parse(value);
+  } catch {
+    parsedValue = value;
+  }
   fm[field] = parsedValue;
   const newContent = spliceFrontmatter(content, fm);
   fs.writeFileSync(fullPath, newContent, 'utf-8');
@@ -280,19 +352,31 @@ function cmdFrontmatterSet(cwd, filePath, field, value) {
 }
 
 function cmdFrontmatterMerge(cwd, filePath, data) {
-  if (!filePath || !data) { error('file and data required'); }
+  if (!filePath || !data) {
+    error('file and data required');
+  }
   if (!path.isAbsolute(filePath)) {
     const pathCheck = validatePath(filePath, cwd);
     if (!pathCheck.safe) {
       error(`Invalid file path: ${pathCheck.error}`);
     }
   }
-  const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
-  if (!fs.existsSync(fullPath)) { output({ error: 'File not found', path: filePath }); return; }
+  const fullPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
+  if (!fs.existsSync(fullPath)) {
+    output({ error: 'File not found', path: filePath });
+    return;
+  }
   const content = fs.readFileSync(fullPath, 'utf-8');
   const fm = extractFrontmatter(content);
   let mergeData;
-  try { mergeData = JSON.parse(data); } catch { error('Invalid JSON for --data'); return; }
+  try {
+    mergeData = JSON.parse(data);
+  } catch {
+    error('Invalid JSON for --data');
+    return;
+  }
   Object.assign(fm, mergeData);
   const newContent = spliceFrontmatter(content, fm);
   fs.writeFileSync(fullPath, newContent, 'utf-8');
@@ -300,16 +384,30 @@ function cmdFrontmatterMerge(cwd, filePath, data) {
 }
 
 function cmdFrontmatterValidate(cwd, filePath, schemaName) {
-  if (!filePath || !schemaName) { error('file and schema required'); }
+  if (!filePath || !schemaName) {
+    error('file and schema required');
+  }
   const schema = FRONTMATTER_SCHEMAS[schemaName];
-  if (!schema) { error(`Unknown schema: ${schemaName}. Available: ${Object.keys(FRONTMATTER_SCHEMAS).join(', ')}`); }
-  const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+  if (!schema) {
+    error(
+      `Unknown schema: ${schemaName}. Available: ${Object.keys(FRONTMATTER_SCHEMAS).join(', ')}`,
+    );
+  }
+  const fullPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: filePath }); return; }
+  if (!content) {
+    output({ error: 'File not found', path: filePath });
+    return;
+  }
   const fm = extractFrontmatter(content);
-  const missing = schema.required.filter(f => fm[f] === undefined);
-  const present = schema.required.filter(f => fm[f] !== undefined);
-  output({ valid: missing.length === 0, missing, present, schema: schemaName }, missing.length === 0 ? 'valid' : 'invalid');
+  const missing = schema.required.filter((f) => fm[f] === undefined);
+  const present = schema.required.filter((f) => fm[f] !== undefined);
+  output(
+    { valid: missing.length === 0, missing, present, schema: schemaName },
+    missing.length === 0 ? 'valid' : 'invalid',
+  );
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/guard.cjs
+++ b/gsd-ng/bin/lib/guard.cjs
@@ -40,12 +40,16 @@ function cmdGuardSyncChain(cwd, argumentsStr) {
  */
 function cmdGuardInitValid(jsonStr) {
   if (!jsonStr || !jsonStr.trim()) {
-    error('guard init-valid: $INIT is empty or malformed — did the init command fail?');
+    error(
+      'guard init-valid: $INIT is empty or malformed — did the init command fail?',
+    );
   }
   try {
     JSON.parse(jsonStr);
   } catch {
-    error('guard init-valid: $INIT is empty or malformed — did the init command fail?');
+    error(
+      'guard init-valid: $INIT is empty or malformed — did the init command fail?',
+    );
   }
   output({ valid: true });
 }

--- a/gsd-ng/bin/lib/init.cjs
+++ b/gsd-ng/bin/lib/init.cjs
@@ -5,7 +5,23 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { loadConfig, resolveModelInternal, resolveEffortInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, extractCurrentMilestone, normalizePhaseName, toPosixPath, output, error, planningPaths } = require('./core.cjs');
+const {
+  loadConfig,
+  resolveModelInternal,
+  resolveEffortInternal,
+  findPhaseInternal,
+  getRoadmapPhaseInternal,
+  pathExistsInternal,
+  generateSlugInternal,
+  getMilestoneInfo,
+  getMilestonePhaseFilter,
+  extractCurrentMilestone,
+  normalizePhaseName,
+  toPosixPath,
+  output,
+  error,
+  planningPaths,
+} = require('./core.cjs');
 const { DEFAULTS } = require('./defaults.cjs');
 const { validatePhaseNumber } = require('./security.cjs');
 const { adjustQuickTable } = require('./state.cjs');
@@ -35,7 +51,12 @@ function cmdInitExecutePhase(cwd, phase) {
       directory: null,
       phase_number: roadmapPhase.phase_number,
       phase_name: phaseName,
-      phase_slug: phaseName ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
+      phase_slug: phaseName
+        ? phaseName
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+        : null,
       plans: [],
       summaries: [],
       incomplete_plans: [],
@@ -45,11 +66,19 @@ function cmdInitExecutePhase(cwd, phase) {
     };
   }
 
-  const reqMatch = roadmapPhase?.section?.match(/^\*\*Requirements\*\*:[^\S\n]*([^\n]*)$/m);
+  const reqMatch = roadmapPhase?.section?.match(
+    /^\*\*Requirements\*\*:[^\S\n]*([^\n]*)$/m,
+  );
   const reqExtracted = reqMatch
-    ? reqMatch[1].replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean).join(', ')
+    ? reqMatch[1]
+        .replace(/[\[\]]/g, '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .join(', ')
     : null;
-  const phase_req_ids = (reqExtracted && reqExtracted !== 'TBD') ? reqExtracted : null;
+  const phase_req_ids =
+    reqExtracted && reqExtracted !== 'TBD' ? reqExtracted : null;
 
   const result = {
     // Models
@@ -90,15 +119,19 @@ function cmdInitExecutePhase(cwd, phase) {
     incomplete_count: phaseInfo?.incomplete_plans?.length || 0,
 
     // Branch name (pre-computed)
-    branch_name: config.branching_strategy === 'phase' && phaseInfo
-      ? config.phase_branch_template
-          .replace('{phase}', phaseInfo.phase_number)
-          .replace('{slug}', phaseInfo.phase_slug || 'phase')
-      : config.branching_strategy === 'milestone'
-        ? config.milestone_branch_template
-            .replace('{milestone}', milestone.version)
-            .replace('{slug}', generateSlugInternal(milestone.name) || 'milestone')
-        : null,
+    branch_name:
+      config.branching_strategy === 'phase' && phaseInfo
+        ? config.phase_branch_template
+            .replace('{phase}', phaseInfo.phase_number)
+            .replace('{slug}', phaseInfo.phase_slug || 'phase')
+        : config.branching_strategy === 'milestone'
+          ? config.milestone_branch_template
+              .replace('{milestone}', milestone.version)
+              .replace(
+                '{slug}',
+                generateSlugInternal(milestone.name) || 'milestone',
+              )
+          : null,
 
     // Milestone info
     milestone_version: milestone.version,
@@ -156,15 +189,19 @@ function cmdInitExecutePhase(cwd, phase) {
 
     // Recompute branch_name using overridden values
     const bs = result.branching_strategy;
-    result.branch_name = bs === 'phase' && phaseInfo
-      ? result.phase_branch_template
-          .replace('{phase}', phaseInfo.phase_number)
-          .replace('{slug}', phaseInfo.phase_slug || 'phase')
-      : bs === 'milestone'
-        ? result.milestone_branch_template
-            .replace('{milestone}', result.milestone_version)
-            .replace('{slug}', generateSlugInternal(result.milestone_name) || 'milestone')
-        : null;
+    result.branch_name =
+      bs === 'phase' && phaseInfo
+        ? result.phase_branch_template
+            .replace('{phase}', phaseInfo.phase_number)
+            .replace('{slug}', phaseInfo.phase_slug || 'phase')
+        : bs === 'milestone'
+          ? result.milestone_branch_template
+              .replace('{milestone}', result.milestone_version)
+              .replace(
+                '{slug}',
+                generateSlugInternal(result.milestone_name) || 'milestone',
+              )
+          : null;
   }
 
   output(result);
@@ -193,7 +230,12 @@ function cmdInitPlanPhase(cwd, phase) {
       directory: null,
       phase_number: roadmapPhase.phase_number,
       phase_name: phaseName,
-      phase_slug: phaseName ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
+      phase_slug: phaseName
+        ? phaseName
+            .toLowerCase()
+            .replace(/[^a-z0-9]+/g, '-')
+            .replace(/^-+|-+$/g, '')
+        : null,
       plans: [],
       summaries: [],
       incomplete_plans: [],
@@ -203,11 +245,19 @@ function cmdInitPlanPhase(cwd, phase) {
     };
   }
 
-  const reqMatch = roadmapPhase?.section?.match(/^\*\*Requirements\*\*:[^\S\n]*([^\n]*)$/m);
+  const reqMatch = roadmapPhase?.section?.match(
+    /^\*\*Requirements\*\*:[^\S\n]*([^\n]*)$/m,
+  );
   const reqExtracted = reqMatch
-    ? reqMatch[1].replace(/[\[\]]/g, '').split(',').map(s => s.trim()).filter(Boolean).join(', ')
+    ? reqMatch[1]
+        .replace(/[\[\]]/g, '')
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+        .join(', ')
     : null;
-  const phase_req_ids = (reqExtracted && reqExtracted !== 'TBD') ? reqExtracted : null;
+  const phase_req_ids =
+    reqExtracted && reqExtracted !== 'TBD' ? reqExtracted : null;
 
   const result = {
     // Models
@@ -232,7 +282,9 @@ function cmdInitPlanPhase(cwd, phase) {
     phase_number: phaseInfo?.phase_number || null,
     phase_name: phaseInfo?.phase_name || null,
     phase_slug: phaseInfo?.phase_slug || null,
-    padded_phase: phaseInfo?.phase_number ? normalizePhaseName(phaseInfo.phase_number) : null,
+    padded_phase: phaseInfo?.phase_number
+      ? normalizePhaseName(phaseInfo.phase_number)
+      : null,
     phase_req_ids,
 
     // Existing artifacts
@@ -266,26 +318,42 @@ function cmdInitPlanPhase(cwd, phase) {
     const phaseDirFull = path.join(cwd, phaseInfo.directory);
     try {
       const files = fs.readdirSync(phaseDirFull);
-      const contextFile = files.find(f => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md');
+      const contextFile = files.find(
+        (f) => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md',
+      );
       if (contextFile) {
-        result.context_path = toPosixPath(path.join(phaseInfo.directory, contextFile));
+        result.context_path = toPosixPath(
+          path.join(phaseInfo.directory, contextFile),
+        );
       }
-      const researchFile = files.find(f =>
-        (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) || f === 'RESEARCH.md'
+      const researchFile = files.find(
+        (f) =>
+          (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) ||
+          f === 'RESEARCH.md',
       );
       if (researchFile) {
-        result.research_path = toPosixPath(path.join(phaseInfo.directory, researchFile));
+        result.research_path = toPosixPath(
+          path.join(phaseInfo.directory, researchFile),
+        );
       }
-      const gapResearchFile = files.find(f => f.endsWith('-GAP-RESEARCH.md'));
+      const gapResearchFile = files.find((f) => f.endsWith('-GAP-RESEARCH.md'));
       if (gapResearchFile) {
-        result.gap_research_path = toPosixPath(path.join(phaseInfo.directory, gapResearchFile));
+        result.gap_research_path = toPosixPath(
+          path.join(phaseInfo.directory, gapResearchFile),
+        );
       }
       result.has_gap_research = !!gapResearchFile;
-      const verificationFile = files.find(f => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md');
+      const verificationFile = files.find(
+        (f) => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md',
+      );
       if (verificationFile) {
-        result.verification_path = toPosixPath(path.join(phaseInfo.directory, verificationFile));
+        result.verification_path = toPosixPath(
+          path.join(phaseInfo.directory, verificationFile),
+        );
       }
-      const uatFile = files.find(f => f.endsWith('-UAT.md') || f === 'UAT.md');
+      const uatFile = files.find(
+        (f) => f.endsWith('-UAT.md') || f === 'UAT.md',
+      );
       if (uatFile) {
         result.uat_path = toPosixPath(path.join(phaseInfo.directory, uatFile));
       }
@@ -304,19 +372,23 @@ function cmdInitNewProject(cwd) {
   let hasCode = false;
   let hasPackageFile = false;
   try {
-    const files = execSync('find . -maxdepth 3 \\( -name "*.ts" -o -name "*.js" -o -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.swift" -o -name "*.java" \\) 2>/dev/null | grep -v node_modules | grep -v .git | head -5', {
-      cwd,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
+    const files = execSync(
+      'find . -maxdepth 3 \\( -name "*.ts" -o -name "*.js" -o -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.swift" -o -name "*.java" \\) 2>/dev/null | grep -v node_modules | grep -v .git | head -5',
+      {
+        cwd,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      },
+    );
     hasCode = files.trim().length > 0;
   } catch {}
 
-  hasPackageFile = pathExistsInternal(cwd, 'package.json') ||
-                   pathExistsInternal(cwd, 'requirements.txt') ||
-                   pathExistsInternal(cwd, 'Cargo.toml') ||
-                   pathExistsInternal(cwd, 'go.mod') ||
-                   pathExistsInternal(cwd, 'Package.swift');
+  hasPackageFile =
+    pathExistsInternal(cwd, 'package.json') ||
+    pathExistsInternal(cwd, 'requirements.txt') ||
+    pathExistsInternal(cwd, 'Cargo.toml') ||
+    pathExistsInternal(cwd, 'go.mod') ||
+    pathExistsInternal(cwd, 'Package.swift');
 
   const result = {
     // Models
@@ -341,7 +413,9 @@ function cmdInitNewProject(cwd) {
     has_existing_code: hasCode,
     has_package_file: hasPackageFile,
     is_brownfield: hasCode || hasPackageFile,
-    needs_codebase_map: (hasCode || hasPackageFile) && !pathExistsInternal(cwd, '.planning/codebase'),
+    needs_codebase_map:
+      (hasCode || hasPackageFile) &&
+      !pathExistsInternal(cwd, '.planning/codebase'),
 
     // Git state
     has_git: pathExistsInternal(cwd, '.git'),
@@ -393,7 +467,9 @@ function cmdInitNewMilestone(cwd) {
 function cmdInitQuick(cwd, description, verifyMode) {
   const config = loadConfig(cwd);
   const now = new Date();
-  const slug = description ? generateSlugInternal(description)?.substring(0, 40) : null;
+  const slug = description
+    ? generateSlugInternal(description)?.substring(0, 40)
+    : null;
 
   // Generate collision-resistant quick task ID: YYMMDD-xxx
   // xxx = 2-second precision blocks since midnight, encoded as 3-char Base36 (lowercase)
@@ -403,7 +479,8 @@ function cmdInitQuick(cwd, description, verifyMode) {
   const mm = String(now.getMonth() + 1).padStart(2, '0');
   const dd = String(now.getDate()).padStart(2, '0');
   const dateStr = yy + mm + dd;
-  const secondsSinceMidnight = now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
+  const secondsSinceMidnight =
+    now.getHours() * 3600 + now.getMinutes() * 60 + now.getSeconds();
   const timeBlocks = Math.floor(secondsSinceMidnight / 2);
   const timeEncoded = timeBlocks.toString(36).padStart(3, '0');
   const quickId = dateStr + '-' + timeEncoded;
@@ -420,13 +497,24 @@ function cmdInitQuick(cwd, description, verifyMode) {
     try {
       const { state: statePath } = planningPaths(cwd);
       const stateContent = fs.readFileSync(statePath, 'utf-8');
-      const sectionMatch = stateContent.match(/###\s*Quick Tasks Completed\s*\n/i);
+      const sectionMatch = stateContent.match(
+        /###\s*Quick Tasks Completed\s*\n/i,
+      );
       if (sectionMatch) {
-        const afterSection = stateContent.slice(sectionMatch.index + sectionMatch[0].length);
-        const firstTableLine = afterSection.split('\n').find(l => l.trimStart().startsWith('|'));
+        const afterSection = stateContent.slice(
+          sectionMatch.index + sectionMatch[0].length,
+        );
+        const firstTableLine = afterSection
+          .split('\n')
+          .find((l) => l.trimStart().startsWith('|'));
         if (firstTableLine) {
-          const headerCells = firstTableLine.split('|').map(c => c.trim()).filter(c => c !== '');
-          table_has_status = headerCells.some(c => c.toLowerCase() === 'status');
+          const headerCells = firstTableLine
+            .split('|')
+            .map((c) => c.trim())
+            .filter((c) => c !== '');
+          table_has_status = headerCells.some(
+            (c) => c.toLowerCase() === 'status',
+          );
         }
       }
     } catch {
@@ -480,7 +568,12 @@ function cmdInitResume(cwd) {
   // Check for interrupted agent
   let interruptedAgentId = null;
   try {
-    interruptedAgentId = fs.readFileSync(path.join(planningPaths(cwd).root, 'current-agent-id.txt'), 'utf-8').trim();
+    interruptedAgentId = fs
+      .readFileSync(
+        path.join(planningPaths(cwd).root, 'current-agent-id.txt'),
+        'utf-8',
+      )
+      .trim();
   } catch {}
 
   const result = {
@@ -529,7 +622,12 @@ function cmdInitVerifyWork(cwd, phase) {
         directory: null,
         phase_number: roadmapPhase.phase_number,
         phase_name: phaseName,
-        phase_slug: phaseName ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
+        phase_slug: phaseName
+          ? phaseName
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '')
+          : null,
         plans: [],
         summaries: [],
         incomplete_plans: [],
@@ -584,7 +682,12 @@ function cmdInitPhaseOp(cwd, phase) {
         directory: null,
         phase_number: roadmapPhase.phase_number,
         phase_name: phaseName,
-        phase_slug: phaseName ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
+        phase_slug: phaseName
+          ? phaseName
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '')
+          : null,
         plans: [],
         summaries: [],
         incomplete_plans: [],
@@ -605,7 +708,12 @@ function cmdInitPhaseOp(cwd, phase) {
         directory: null,
         phase_number: roadmapPhase.phase_number,
         phase_name: phaseName,
-        phase_slug: phaseName ? phaseName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') : null,
+        phase_slug: phaseName
+          ? phaseName
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '')
+          : null,
         plans: [],
         summaries: [],
         incomplete_plans: [],
@@ -626,7 +734,9 @@ function cmdInitPhaseOp(cwd, phase) {
     phase_number: phaseInfo?.phase_number || null,
     phase_name: phaseInfo?.phase_name || null,
     phase_slug: phaseInfo?.phase_slug || null,
-    padded_phase: phaseInfo?.phase_number ? normalizePhaseName(phaseInfo.phase_number) : null,
+    padded_phase: phaseInfo?.phase_number
+      ? normalizePhaseName(phaseInfo.phase_number)
+      : null,
 
     // Existing artifacts
     has_research: phaseInfo?.has_research || false,
@@ -659,21 +769,35 @@ function cmdInitPhaseOp(cwd, phase) {
     const phaseDirFull = path.join(cwd, phaseInfo.directory);
     try {
       const files = fs.readdirSync(phaseDirFull);
-      const contextFile = files.find(f => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md');
+      const contextFile = files.find(
+        (f) => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md',
+      );
       if (contextFile) {
-        result.context_path = toPosixPath(path.join(phaseInfo.directory, contextFile));
+        result.context_path = toPosixPath(
+          path.join(phaseInfo.directory, contextFile),
+        );
       }
-      const researchFile = files.find(f =>
-        (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) || f === 'RESEARCH.md'
+      const researchFile = files.find(
+        (f) =>
+          (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) ||
+          f === 'RESEARCH.md',
       );
       if (researchFile) {
-        result.research_path = toPosixPath(path.join(phaseInfo.directory, researchFile));
+        result.research_path = toPosixPath(
+          path.join(phaseInfo.directory, researchFile),
+        );
       }
-      const verificationFile = files.find(f => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md');
+      const verificationFile = files.find(
+        (f) => f.endsWith('-VERIFICATION.md') || f === 'VERIFICATION.md',
+      );
       if (verificationFile) {
-        result.verification_path = toPosixPath(path.join(phaseInfo.directory, verificationFile));
+        result.verification_path = toPosixPath(
+          path.join(phaseInfo.directory, verificationFile),
+        );
       }
-      const uatFile = files.find(f => f.endsWith('-UAT.md') || f === 'UAT.md');
+      const uatFile = files.find(
+        (f) => f.endsWith('-UAT.md') || f === 'UAT.md',
+      );
       if (uatFile) {
         result.uat_path = toPosixPath(path.join(phaseInfo.directory, uatFile));
       }
@@ -693,7 +817,7 @@ function cmdInitTodos(cwd, area) {
   const todos = [];
 
   try {
-    const files = fs.readdirSync(pendingDir).filter(f => f.endsWith('.md'));
+    const files = fs.readdirSync(pendingDir).filter((f) => f.endsWith('.md'));
     for (const file of files) {
       try {
         const content = fs.readFileSync(path.join(pendingDir, file), 'utf-8');
@@ -752,14 +876,16 @@ function cmdInitMilestoneOp(cwd) {
   const { phases: phasesDir, archive: archiveDir } = planningPaths(cwd);
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
     phaseCount = dirs.length;
 
     // Count phases with summaries (completed)
     for (const dir of dirs) {
       try {
         const phaseFiles = fs.readdirSync(path.join(phasesDir, dir));
-        const hasSummary = phaseFiles.some(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+        const hasSummary = phaseFiles.some(
+          (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+        );
         if (hasSummary) completedPhases++;
       } catch {}
     }
@@ -768,9 +894,10 @@ function cmdInitMilestoneOp(cwd) {
   // Check archive
   let archivedMilestones = [];
   try {
-    archivedMilestones = fs.readdirSync(archiveDir, { withFileTypes: true })
-      .filter(e => e.isDirectory())
-      .map(e => e.name);
+    archivedMilestones = fs
+      .readdirSync(archiveDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name);
   } catch {}
 
   const result = {
@@ -855,7 +982,7 @@ function cmdInitMapCodebase(cwd) {
   const { codebase: codebaseDir } = planningPaths(cwd);
   let existingMaps = [];
   try {
-    existingMaps = fs.readdirSync(codebaseDir).filter(f => f.endsWith('.md'));
+    existingMaps = fs.readdirSync(codebaseDir).filter((f) => f.endsWith('.md'));
   } catch {}
 
   const result = {
@@ -897,9 +1024,10 @@ function cmdInitProgress(cwd) {
   const roadmapPhaseNames = new Map();
   try {
     const roadmapContent = extractCurrentMilestone(
-      fs.readFileSync(roadmapPath, 'utf-8')
+      fs.readFileSync(roadmapPath, 'utf-8'),
     );
-    const headingPattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+    const headingPattern =
+      /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
     let hm;
     while ((hm = headingPattern.exec(roadmapContent)) !== null) {
       roadmapPhaseNums.add(hm[1]);
@@ -912,7 +1040,9 @@ function cmdInitProgress(cwd) {
 
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name)
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
       .filter(isDirInMilestone)
       .sort((a, b) => {
         const pa = a.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
@@ -930,15 +1060,26 @@ function cmdInitProgress(cwd) {
       const phasePath = path.join(phasesDir, dir);
       const phaseFiles = fs.readdirSync(phasePath);
 
-      const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md');
-      const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
-      const hasResearch = phaseFiles.some(f =>
-        (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) || f === 'RESEARCH.md'
+      const plans = phaseFiles.filter(
+        (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md',
+      );
+      const summaries = phaseFiles.filter(
+        (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+      );
+      const hasResearch = phaseFiles.some(
+        (f) =>
+          (f.endsWith('-RESEARCH.md') && !f.endsWith('-GAP-RESEARCH.md')) ||
+          f === 'RESEARCH.md',
       );
 
-      const status = summaries.length >= plans.length && plans.length > 0 ? 'complete' :
-                     plans.length > 0 ? 'in_progress' :
-                     hasResearch ? 'researched' : 'pending';
+      const status =
+        summaries.length >= plans.length && plans.length > 0
+          ? 'complete'
+          : plans.length > 0
+            ? 'in_progress'
+            : hasResearch
+              ? 'researched'
+              : 'pending';
 
       const phaseInfo = {
         number: phaseNumber,
@@ -953,7 +1094,10 @@ function cmdInitProgress(cwd) {
       phases.push(phaseInfo);
 
       // Find current (first incomplete with plans) and next (first pending)
-      if (!currentPhase && (status === 'in_progress' || status === 'researched')) {
+      if (
+        !currentPhase &&
+        (status === 'in_progress' || status === 'researched')
+      ) {
         currentPhase = phaseInfo;
       }
       if (!nextPhase && status === 'pending') {
@@ -968,7 +1112,10 @@ function cmdInitProgress(cwd) {
     if (!seenPhaseNums.has(stripped)) {
       const phaseInfo = {
         number: num,
-        name: name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
+        name: name
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-+|-+$/g, ''),
         directory: null,
         status: 'not_started',
         plan_count: 0,
@@ -1008,8 +1155,8 @@ function cmdInitProgress(cwd) {
     // Phase overview
     phases,
     phase_count: phases.length,
-    completed_count: phases.filter(p => p.status === 'complete').length,
-    in_progress_count: phases.filter(p => p.status === 'in_progress').length,
+    completed_count: phases.filter((p) => p.status === 'complete').length,
+    in_progress_count: phases.filter((p) => p.status === 'in_progress').length,
 
     // Current state
     current_phase: currentPhase,
@@ -1112,7 +1259,9 @@ function cmdInitGet(jsonStr, fieldName) {
   if (parsed !== null) {
     const value = parsed[fieldName];
     if (value !== undefined && value !== null) {
-      const rawStr = Array.isArray(value) ? JSON.stringify(value) : String(value);
+      const rawStr = Array.isArray(value)
+        ? JSON.stringify(value)
+        : String(value);
       output(value, rawStr);
       return;
     }
@@ -1120,7 +1269,11 @@ function cmdInitGet(jsonStr, fieldName) {
   // Field absent — use registry default (parse succeeded, field just not present)
   if (Object.prototype.hasOwnProperty.call(INIT_FIELD_DEFAULTS, fieldName)) {
     const def = INIT_FIELD_DEFAULTS[fieldName];
-    const rawStr = Array.isArray(def) ? JSON.stringify(def) : (def === null ? '' : String(def));
+    const rawStr = Array.isArray(def)
+      ? JSON.stringify(def)
+      : def === null
+        ? ''
+        : String(def);
     output(def, rawStr);
     return;
   }

--- a/gsd-ng/bin/lib/milestone.cjs
+++ b/gsd-ng/bin/lib/milestone.cjs
@@ -4,13 +4,22 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, getMilestonePhaseFilter, extractOneLinerFromBody, output, error, planningPaths } = require('./core.cjs');
+const {
+  escapeRegex,
+  getMilestonePhaseFilter,
+  extractOneLinerFromBody,
+  output,
+  error,
+  planningPaths,
+} = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 
 function cmdRequirementsMarkComplete(cwd, reqIdsRaw) {
   if (!reqIdsRaw || reqIdsRaw.length === 0) {
-    error('requirement IDs required. Usage: requirements mark-complete REQ-01,REQ-02 or REQ-01 REQ-02');
+    error(
+      'requirement IDs required. Usage: requirements mark-complete REQ-01,REQ-02 or REQ-01 REQ-02',
+    );
   }
 
   // Accept comma-separated, space-separated, or bracket-wrapped: [REQ-01, REQ-02]
@@ -18,7 +27,7 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw) {
     .join(' ')
     .replace(/[\[\]]/g, '')
     .split(/[,\s]+/)
-    .map(r => r.trim())
+    .map((r) => r.trim())
     .filter(Boolean);
 
   if (reqIds.length === 0) {
@@ -27,7 +36,10 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw) {
 
   const { requirements: reqPath } = planningPaths(cwd);
   if (!fs.existsSync(reqPath)) {
-    output({ updated: false, reason: 'REQUIREMENTS.md not found', ids: reqIds }, 'no requirements file');
+    output(
+      { updated: false, reason: 'REQUIREMENTS.md not found', ids: reqIds },
+      'no requirements file',
+    );
     return;
   }
 
@@ -41,19 +53,28 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw) {
     const reqEscaped = escapeRegex(reqId);
 
     // Update checkbox: - [ ] **REQ-ID** → - [x] **REQ-ID**
-    const checkboxPattern = new RegExp(`(-\\s*\\[)[ ](\\]\\s*\\*\\*${reqEscaped}\\*\\*)`, 'gi');
+    const checkboxPattern = new RegExp(
+      `(-\\s*\\[)[ ](\\]\\s*\\*\\*${reqEscaped}\\*\\*)`,
+      'gi',
+    );
     if (checkboxPattern.test(reqContent)) {
       reqContent = reqContent.replace(checkboxPattern, '$1x$2');
       found = true;
     }
 
     // Update traceability table: | REQ-ID | Phase N | Pending | → | REQ-ID | Phase N | Complete |
-    const tablePattern = new RegExp(`(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*Pending\\s*(\\|)`, 'gi');
+    const tablePattern = new RegExp(
+      `(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*Pending\\s*(\\|)`,
+      'gi',
+    );
     if (tablePattern.test(reqContent)) {
       // Re-read since test() advances lastIndex for global regex
       reqContent = reqContent.replace(
-        new RegExp(`(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*Pending\\s*(\\|)`, 'gi'),
-        '$1 Complete $2'
+        new RegExp(
+          `(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*Pending\\s*(\\|)`,
+          'gi',
+        ),
+        '$1 Complete $2',
       );
       found = true;
     }
@@ -62,8 +83,14 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw) {
       updated.push(reqId);
     } else {
       // Check if already complete before declaring not_found
-      const doneCheckbox = new RegExp(`-\\s*\\[x\\]\\s*\\*\\*${reqEscaped}\\*\\*`, 'gi');
-      const doneTable = new RegExp(`\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|\\s*Complete\\s*\\|`, 'gi');
+      const doneCheckbox = new RegExp(
+        `-\\s*\\[x\\]\\s*\\*\\*${reqEscaped}\\*\\*`,
+        'gi',
+      );
+      const doneTable = new RegExp(
+        `\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|\\s*Complete\\s*\\|`,
+        'gi',
+      );
       if (doneCheckbox.test(reqContent) || doneTable.test(reqContent)) {
         alreadyComplete.push(reqId);
       } else {
@@ -76,13 +103,16 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw) {
     fs.writeFileSync(reqPath, reqContent, 'utf-8');
   }
 
-  output({
-    updated: updated.length > 0,
-    marked_complete: updated,
-    already_complete: alreadyComplete,
-    not_found: notFound,
-    total: reqIds.length,
-  }, `${updated.length}/${reqIds.length} requirements marked complete`);
+  output(
+    {
+      updated: updated.length > 0,
+      marked_complete: updated,
+      already_complete: alreadyComplete,
+      not_found: notFound,
+      total: reqIds.length,
+    },
+    `${updated.length}/${reqIds.length} requirements marked complete`,
+  );
 }
 
 function cmdMilestoneComplete(cwd, version, options) {
@@ -90,7 +120,14 @@ function cmdMilestoneComplete(cwd, version, options) {
     error('version required for milestone complete (e.g., v1.0)');
   }
 
-  const { roadmap: roadmapPath, requirements: reqPath, state: statePath, milestonesFile: milestonesPath, milestones: archiveDir, phases: phasesDir } = planningPaths(cwd);
+  const {
+    roadmap: roadmapPath,
+    requirements: reqPath,
+    state: statePath,
+    milestonesFile: milestonesPath,
+    milestones: archiveDir,
+    phases: phasesDir,
+  } = planningPaths(cwd);
   const today = new Date().toISOString().split('T')[0];
   const milestoneName = options.name || version;
 
@@ -110,21 +147,31 @@ function cmdMilestoneComplete(cwd, version, options) {
 
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort();
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
 
     for (const dir of dirs) {
       if (!isDirInMilestone(dir)) continue;
 
       phaseCount++;
       const phaseFiles = fs.readdirSync(path.join(phasesDir, dir));
-      const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md');
-      const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+      const plans = phaseFiles.filter(
+        (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md',
+      );
+      const summaries = phaseFiles.filter(
+        (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+      );
       totalPlans += plans.length;
 
       // Extract one-liners from summaries
       for (const s of summaries) {
         try {
-          const content = fs.readFileSync(path.join(phasesDir, dir, s), 'utf-8');
+          const content = fs.readFileSync(
+            path.join(phasesDir, dir, s),
+            'utf-8',
+          );
           const fm = extractFrontmatter(content);
           const oneLiner = fm['one-liner'] || extractOneLinerFromBody(content);
           if (oneLiner) {
@@ -148,45 +195,71 @@ function cmdMilestoneComplete(cwd, version, options) {
   // Archive ROADMAP.md
   if (fs.existsSync(roadmapPath)) {
     const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
-    fs.writeFileSync(path.join(archiveDir, `${version}-ROADMAP.md`), roadmapContent, 'utf-8');
+    fs.writeFileSync(
+      path.join(archiveDir, `${version}-ROADMAP.md`),
+      roadmapContent,
+      'utf-8',
+    );
   }
 
   // Archive REQUIREMENTS.md
   if (fs.existsSync(reqPath)) {
     const reqContent = fs.readFileSync(reqPath, 'utf-8');
     const archiveHeader = `# Requirements Archive: ${version} ${milestoneName}\n\n**Archived:** ${today}\n**Status:** SHIPPED\n\nFor current requirements, see \`.planning/REQUIREMENTS.md\`.\n\n---\n\n`;
-    fs.writeFileSync(path.join(archiveDir, `${version}-REQUIREMENTS.md`), archiveHeader + reqContent, 'utf-8');
+    fs.writeFileSync(
+      path.join(archiveDir, `${version}-REQUIREMENTS.md`),
+      archiveHeader + reqContent,
+      'utf-8',
+    );
   }
 
   // Archive audit file if exists
-  const auditFile = path.join(planningPaths(cwd).root, `${version}-MILESTONE-AUDIT.md`);
+  const auditFile = path.join(
+    planningPaths(cwd).root,
+    `${version}-MILESTONE-AUDIT.md`,
+  );
   if (fs.existsSync(auditFile)) {
-    fs.renameSync(auditFile, path.join(archiveDir, `${version}-MILESTONE-AUDIT.md`));
+    fs.renameSync(
+      auditFile,
+      path.join(archiveDir, `${version}-MILESTONE-AUDIT.md`),
+    );
   }
 
   // Create/append MILESTONES.md entry
-  const accomplishmentsList = accomplishments.map(a => `- ${a}`).join('\n');
+  const accomplishmentsList = accomplishments.map((a) => `- ${a}`).join('\n');
   const milestoneEntry = `## ${version} ${milestoneName} (Shipped: ${today})\n\n**Phases completed:** ${phaseCount} phases, ${totalPlans} plans, ${totalTasks} tasks\n\n**Key accomplishments:**\n${accomplishmentsList || '- (none recorded)'}\n\n---\n\n`;
 
   if (fs.existsSync(milestonesPath)) {
     const existing = fs.readFileSync(milestonesPath, 'utf-8');
     if (!existing.trim()) {
       // Empty file — treat like new
-      fs.writeFileSync(milestonesPath, `# Milestones\n\n${milestoneEntry}`, 'utf-8');
+      fs.writeFileSync(
+        milestonesPath,
+        `# Milestones\n\n${milestoneEntry}`,
+        'utf-8',
+      );
     } else {
       // Insert after the header line(s) for reverse chronological order (newest first)
       const headerMatch = existing.match(/^(#{1,3}\s+[^\n]*\n\n?)/);
       if (headerMatch) {
         const header = headerMatch[1];
         const rest = existing.slice(header.length);
-        fs.writeFileSync(milestonesPath, header + milestoneEntry + rest, 'utf-8');
+        fs.writeFileSync(
+          milestonesPath,
+          header + milestoneEntry + rest,
+          'utf-8',
+        );
       } else {
         // No recognizable header — prepend the entry
         fs.writeFileSync(milestonesPath, milestoneEntry + existing, 'utf-8');
       }
     }
   } else {
-    fs.writeFileSync(milestonesPath, `# Milestones\n\n${milestoneEntry}`, 'utf-8');
+    fs.writeFileSync(
+      milestonesPath,
+      `# Milestones\n\n${milestoneEntry}`,
+      'utf-8',
+    );
   }
 
   // Update STATE.md
@@ -194,15 +267,15 @@ function cmdMilestoneComplete(cwd, version, options) {
     let stateContent = fs.readFileSync(statePath, 'utf-8');
     stateContent = stateContent.replace(
       /(\*\*Status:\*\*\s*).*/,
-      `$1${version} milestone complete`
+      `$1${version} milestone complete`,
     );
     stateContent = stateContent.replace(
       /(\*\*Last Activity:\*\*\s*).*/,
-      `$1${today}`
+      `$1${today}`,
     );
     stateContent = stateContent.replace(
       /(\*\*Last Activity Description:\*\*\s*).*/,
-      `$1${version} milestone completed and archived`
+      `$1${version} milestone completed and archived`,
     );
     writeStateMd(statePath, stateContent, cwd);
   }
@@ -215,11 +288,16 @@ function cmdMilestoneComplete(cwd, version, options) {
       fs.mkdirSync(phaseArchiveDir, { recursive: true });
 
       const phaseEntries = fs.readdirSync(phasesDir, { withFileTypes: true });
-      const phaseDirNames = phaseEntries.filter(e => e.isDirectory()).map(e => e.name);
+      const phaseDirNames = phaseEntries
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name);
       let archivedCount = 0;
       for (const dir of phaseDirNames) {
         if (!isDirInMilestone(dir)) continue;
-        fs.renameSync(path.join(phasesDir, dir), path.join(phaseArchiveDir, dir));
+        fs.renameSync(
+          path.join(phasesDir, dir),
+          path.join(phaseArchiveDir, dir),
+        );
         archivedCount++;
       }
       phasesArchived = archivedCount > 0;
@@ -236,8 +314,12 @@ function cmdMilestoneComplete(cwd, version, options) {
     accomplishments,
     archived: {
       roadmap: fs.existsSync(path.join(archiveDir, `${version}-ROADMAP.md`)),
-      requirements: fs.existsSync(path.join(archiveDir, `${version}-REQUIREMENTS.md`)),
-      audit: fs.existsSync(path.join(archiveDir, `${version}-MILESTONE-AUDIT.md`)),
+      requirements: fs.existsSync(
+        path.join(archiveDir, `${version}-REQUIREMENTS.md`),
+      ),
+      audit: fs.existsSync(
+        path.join(archiveDir, `${version}-MILESTONE-AUDIT.md`),
+      ),
       phases: phasesArchived,
     },
     milestones_updated: true,

--- a/gsd-ng/bin/lib/model-profiles.cjs
+++ b/gsd-ng/bin/lib/model-profiles.cjs
@@ -10,16 +10,48 @@ const MODEL_PROFILES = {
   'gsd-planner': { quality: 'opus', balanced: 'opus', budget: 'sonnet' },
   'gsd-roadmapper': { quality: 'opus', balanced: 'sonnet', budget: 'sonnet' },
   'gsd-executor': { quality: 'opus', balanced: 'sonnet', budget: 'sonnet' },
-  'gsd-phase-researcher': { quality: 'opus', balanced: 'sonnet', budget: 'haiku' },
-  'gsd-project-researcher': { quality: 'opus', balanced: 'sonnet', budget: 'haiku' },
-  'gsd-research-synthesizer': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku' },
+  'gsd-phase-researcher': {
+    quality: 'opus',
+    balanced: 'sonnet',
+    budget: 'haiku',
+  },
+  'gsd-project-researcher': {
+    quality: 'opus',
+    balanced: 'sonnet',
+    budget: 'haiku',
+  },
+  'gsd-research-synthesizer': {
+    quality: 'sonnet',
+    balanced: 'sonnet',
+    budget: 'haiku',
+  },
   'gsd-debugger': { quality: 'opus', balanced: 'sonnet', budget: 'sonnet' },
-  'gsd-codebase-mapper': { quality: 'sonnet', balanced: 'haiku', budget: 'haiku' },
-  'gsd-incremental-mapper': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku' },
+  'gsd-codebase-mapper': {
+    quality: 'sonnet',
+    balanced: 'haiku',
+    budget: 'haiku',
+  },
+  'gsd-incremental-mapper': {
+    quality: 'sonnet',
+    balanced: 'sonnet',
+    budget: 'haiku',
+  },
   'gsd-verifier': { quality: 'opus', balanced: 'sonnet', budget: 'haiku' },
-  'gsd-plan-checker': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku' },
-  'gsd-integration-checker': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku' },
-  'gsd-nyquist-auditor': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku' },
+  'gsd-plan-checker': {
+    quality: 'sonnet',
+    balanced: 'sonnet',
+    budget: 'haiku',
+  },
+  'gsd-integration-checker': {
+    quality: 'sonnet',
+    balanced: 'sonnet',
+    budget: 'haiku',
+  },
+  'gsd-nyquist-auditor': {
+    quality: 'sonnet',
+    balanced: 'sonnet',
+    budget: 'haiku',
+  },
   'gsd-ui-researcher': { quality: 'opus', balanced: 'sonnet', budget: 'haiku' },
   'gsd-ui-checker': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku' },
   'gsd-ui-auditor': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku' },
@@ -33,7 +65,14 @@ const VALID_PROFILES = Object.keys(MODEL_PROFILES['gsd-planner']);
  * Tier ordering (ascending thinking budget): low < medium < high < xhigh < max.
  * `inherit` resolves to null in resolveEffortInternal (omits the field).
  */
-const VALID_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max', 'inherit'];
+const VALID_EFFORT_VALUES = [
+  'low',
+  'medium',
+  'high',
+  'xhigh',
+  'max',
+  'inherit',
+];
 
 /**
  * Mapping of GSD agent to effort level for each profile.
@@ -43,22 +82,58 @@ const VALID_EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max', 'inherit']
  * Budget: writers/decision-makers at high, mechanical/read-only agents at medium.
  */
 const EFFORT_PROFILES = {
-  'gsd-planner':              { quality: 'max',     balanced: 'inherit', budget: 'high' },
-  'gsd-roadmapper':           { quality: 'max',     balanced: 'inherit', budget: 'high' },
-  'gsd-executor':             { quality: 'high',    balanced: 'inherit', budget: 'high' },
-  'gsd-phase-researcher':     { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-project-researcher':   { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-research-synthesizer': { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-debugger':             { quality: 'max',     balanced: 'inherit', budget: 'high' },
-  'gsd-codebase-mapper':      { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-incremental-mapper':   { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-verifier':             { quality: 'max',     balanced: 'inherit', budget: 'high' },
-  'gsd-plan-checker':         { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-integration-checker':  { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-nyquist-auditor':      { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-ui-researcher':        { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-ui-checker':           { quality: 'high',    balanced: 'inherit', budget: 'medium' },
-  'gsd-ui-auditor':           { quality: 'high',    balanced: 'inherit', budget: 'medium' },
+  'gsd-planner': { quality: 'max', balanced: 'inherit', budget: 'high' },
+  'gsd-roadmapper': { quality: 'max', balanced: 'inherit', budget: 'high' },
+  'gsd-executor': { quality: 'high', balanced: 'inherit', budget: 'high' },
+  'gsd-phase-researcher': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-project-researcher': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-research-synthesizer': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-debugger': { quality: 'max', balanced: 'inherit', budget: 'high' },
+  'gsd-codebase-mapper': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-incremental-mapper': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-verifier': { quality: 'max', balanced: 'inherit', budget: 'high' },
+  'gsd-plan-checker': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-integration-checker': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-nyquist-auditor': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-ui-researcher': {
+    quality: 'high',
+    balanced: 'inherit',
+    budget: 'medium',
+  },
+  'gsd-ui-checker': { quality: 'high', balanced: 'inherit', budget: 'medium' },
+  'gsd-ui-auditor': { quality: 'high', balanced: 'inherit', budget: 'medium' },
 };
 
 /**
@@ -68,16 +143,21 @@ const EFFORT_PROFILES = {
  * @returns {string} A formatted table string
  */
 function formatAgentToModelMapAsTable(agentToModelMap) {
-  const agentWidth = Math.max('Agent'.length, ...Object.keys(agentToModelMap).map((a) => a.length));
+  const agentWidth = Math.max(
+    'Agent'.length,
+    ...Object.keys(agentToModelMap).map((a) => a.length),
+  );
   const modelWidth = Math.max(
     'Model'.length,
-    ...Object.values(agentToModelMap).map((m) => m.length)
+    ...Object.values(agentToModelMap).map((m) => m.length),
   );
   const sep = '─'.repeat(agentWidth + 2) + '┼' + '─'.repeat(modelWidth + 2);
-  const header = ' ' + 'Agent'.padEnd(agentWidth) + ' │ ' + 'Model'.padEnd(modelWidth);
+  const header =
+    ' ' + 'Agent'.padEnd(agentWidth) + ' │ ' + 'Model'.padEnd(modelWidth);
   let agentToModelTable = header + '\n' + sep + '\n';
   for (const [agent, model] of Object.entries(agentToModelMap)) {
-    agentToModelTable += ' ' + agent.padEnd(agentWidth) + ' │ ' + model.padEnd(modelWidth) + '\n';
+    agentToModelTable +=
+      ' ' + agent.padEnd(agentWidth) + ' │ ' + model.padEnd(modelWidth) + '\n';
   }
   return agentToModelTable;
 }
@@ -103,16 +183,31 @@ function getAgentToModelMapForProfile(normalizedProfile) {
  * @returns {string} A formatted table string
  */
 function formatAgentToEffortMapAsTable(agentToEffortMap) {
-  const agentWidth = Math.max('Agent'.length, ...Object.keys(agentToEffortMap).map((a) => a.length));
+  const agentWidth = Math.max(
+    'Agent'.length,
+    ...Object.keys(agentToEffortMap).map((a) => a.length),
+  );
   const effortWidth = Math.max(
     'Effort'.length,
-    ...Object.values(agentToEffortMap).map((e) => e.length)
+    ...Object.values(agentToEffortMap).map((e) => e.length),
   );
-  const sep = '\u2500'.repeat(agentWidth + 2) + '\u253C' + '\u2500'.repeat(effortWidth + 2);
-  const header = ' ' + 'Agent'.padEnd(agentWidth) + ' \u2502 ' + 'Effort'.padEnd(effortWidth);
+  const sep =
+    '\u2500'.repeat(agentWidth + 2) +
+    '\u253C' +
+    '\u2500'.repeat(effortWidth + 2);
+  const header =
+    ' ' +
+    'Agent'.padEnd(agentWidth) +
+    ' \u2502 ' +
+    'Effort'.padEnd(effortWidth);
   let table = header + '\n' + sep + '\n';
   for (const [agent, effort] of Object.entries(agentToEffortMap)) {
-    table += ' ' + agent.padEnd(agentWidth) + ' \u2502 ' + effort.padEnd(effortWidth) + '\n';
+    table +=
+      ' ' +
+      agent.padEnd(agentWidth) +
+      ' \u2502 ' +
+      effort.padEnd(effortWidth) +
+      '\n';
   }
   return table;
 }

--- a/gsd-ng/bin/lib/phase.cjs
+++ b/gsd-ng/bin/lib/phase.cjs
@@ -4,7 +4,21 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, normalizePhaseName, comparePhaseNum, findPhaseInternal, getArchivedPhaseDirs, generateSlugInternal, getMilestonePhaseFilter, extractCurrentMilestone, replaceInCurrentMilestone, toPosixPath, output, error, planningPaths } = require('./core.cjs');
+const {
+  escapeRegex,
+  normalizePhaseName,
+  comparePhaseNum,
+  findPhaseInternal,
+  getArchivedPhaseDirs,
+  generateSlugInternal,
+  getMilestonePhaseFilter,
+  extractCurrentMilestone,
+  replaceInCurrentMilestone,
+  toPosixPath,
+  output,
+  error,
+  planningPaths,
+} = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 
@@ -25,7 +39,7 @@ function cmdPhasesList(cwd, options) {
   try {
     // Get all phase directories
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    let dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    let dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
 
     // Include archived phases if requested
     if (includeArchived) {
@@ -41,9 +55,12 @@ function cmdPhasesList(cwd, options) {
     // If filtering by phase number
     if (phase) {
       const normalized = normalizePhaseName(phase);
-      const match = dirs.find(d => d.startsWith(normalized));
+      const match = dirs.find((d) => d.startsWith(normalized));
       if (!match) {
-        output({ files: [], count: 0, phase_dir: null, error: 'Phase not found' }, '');
+        output(
+          { files: [], count: 0, phase_dir: null, error: 'Phase not found' },
+          '',
+        );
         return;
       }
       dirs = [match];
@@ -58,9 +75,13 @@ function cmdPhasesList(cwd, options) {
 
         let filtered;
         if (type === 'plans') {
-          filtered = dirFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md');
+          filtered = dirFiles.filter(
+            (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md',
+          );
         } else if (type === 'summaries') {
-          filtered = dirFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+          filtered = dirFiles.filter(
+            (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+          );
         } else {
           filtered = dirFiles;
         }
@@ -98,17 +119,19 @@ function cmdPhaseNextDecimal(cwd, basePhase) {
         existing: [],
       },
 
-      `${normalized}.1`
+      `${normalized}.1`,
     );
     return;
   }
 
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
 
     // Check if base phase exists
-    const baseExists = dirs.some(d => d.startsWith(normalized + '-') || d === normalized);
+    const baseExists = dirs.some(
+      (d) => d.startsWith(normalized + '-') || d === normalized,
+    );
 
     // Find existing decimal phases for this base
     const decimalPattern = new RegExp(`^${normalized}\\.(\\d+)`);
@@ -142,7 +165,7 @@ function cmdPhaseNextDecimal(cwd, basePhase) {
         existing: existingDecimals,
       },
 
-      nextDecimal
+      nextDecimal,
     );
   } catch (e) {
     error('Failed to calculate next decimal phase: ' + e.message);
@@ -157,13 +180,23 @@ function cmdFindPhase(cwd, phase) {
   const { phases: phasesDir } = planningPaths(cwd);
   const normalized = normalizePhaseName(phase);
 
-  const notFound = { found: false, directory: null, phase_number: null, phase_name: null, plans: [], summaries: [] };
+  const notFound = {
+    found: false,
+    directory: null,
+    phase_number: null,
+    phase_name: null,
+    plans: [],
+    summaries: [],
+  };
 
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => comparePhaseNum(a, b));
 
-    const match = dirs.find(d => d.startsWith(normalized));
+    const match = dirs.find((d) => d.startsWith(normalized));
     if (!match) {
       output(notFound, '');
       return;
@@ -175,8 +208,12 @@ function cmdFindPhase(cwd, phase) {
 
     const phaseDir = path.join(phasesDir, match);
     const phaseFiles = fs.readdirSync(phaseDir);
-    const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').sort();
-    const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md').sort();
+    const plans = phaseFiles
+      .filter((f) => f.endsWith('-PLAN.md') || f === 'PLAN.md')
+      .sort();
+    const summaries = phaseFiles
+      .filter((f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md')
+      .sort();
 
     const result = {
       found: true,
@@ -211,8 +248,11 @@ function cmdPhasePlanIndex(cwd, phase) {
   let phaseDirName = null;
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
-    const match = dirs.find(d => d.startsWith(normalized));
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => comparePhaseNum(a, b));
+    const match = dirs.find((d) => d.startsWith(normalized));
     if (match) {
       phaseDir = path.join(phasesDir, match);
       phaseDirName = match;
@@ -222,18 +262,31 @@ function cmdPhasePlanIndex(cwd, phase) {
   }
 
   if (!phaseDir) {
-    output({ phase: normalized, error: 'Phase not found', plans: [], waves: {}, incomplete: [], has_checkpoints: false });
+    output({
+      phase: normalized,
+      error: 'Phase not found',
+      plans: [],
+      waves: {},
+      incomplete: [],
+      has_checkpoints: false,
+    });
     return;
   }
 
   // Get all files in phase directory
   const phaseFiles = fs.readdirSync(phaseDir);
-  const planFiles = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').sort();
-  const summaryFiles = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+  const planFiles = phaseFiles
+    .filter((f) => f.endsWith('-PLAN.md') || f === 'PLAN.md')
+    .sort();
+  const summaryFiles = phaseFiles.filter(
+    (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+  );
 
   // Build set of plan IDs with summaries
   const completedPlanIds = new Set(
-    summaryFiles.map(s => s.replace('-SUMMARY.md', '').replace('SUMMARY.md', ''))
+    summaryFiles.map((s) =>
+      s.replace('-SUMMARY.md', '').replace('SUMMARY.md', ''),
+    ),
   );
 
   const plans = [];
@@ -335,7 +388,7 @@ function detectFileOverlaps(plans) {
         const planA = wavePlans[i];
         const planB = wavePlans[j];
         const setA = new Set(planA.files_modified);
-        const sharedFiles = planB.files_modified.filter(f => setA.has(f));
+        const sharedFiles = planB.files_modified.filter((f) => setA.has(f));
         if (sharedFiles.length > 0) {
           overlaps.push({
             plans: [planA.id, planB.id],
@@ -367,8 +420,12 @@ function insertCheckboxLine(rawContent, phaseNum, description, afterPhase) {
   if (afterPhase != null) {
     // For insert: find the parent phase's checkbox line (or last decimal of parent)
     const escapedParent = String(afterPhase).replace(/\./g, '\\.');
-    const parentPattern = new RegExp(`^- \\[[ x]\\] \\*\\*Phase\\s+${escapedParent}[.:]`);
-    const decimalPattern = new RegExp(`^- \\[[ x]\\] \\*\\*Phase\\s+${escapedParent}\\.\\d+[.:]`);
+    const parentPattern = new RegExp(
+      `^- \\[[ x]\\] \\*\\*Phase\\s+${escapedParent}[.:]`,
+    );
+    const decimalPattern = new RegExp(
+      `^- \\[[ x]\\] \\*\\*Phase\\s+${escapedParent}\\.\\d+[.:]`,
+    );
     let insertAfterIdx = -1;
 
     for (let i = 0; i < lines.length; i++) {
@@ -440,13 +497,21 @@ function cmdPhaseAdd(cwd, description) {
   let updatedContent;
   const lastSeparator = rawContent.lastIndexOf('\n---');
   if (lastSeparator > 0) {
-    updatedContent = rawContent.slice(0, lastSeparator) + phaseEntry + rawContent.slice(lastSeparator);
+    updatedContent =
+      rawContent.slice(0, lastSeparator) +
+      phaseEntry +
+      rawContent.slice(lastSeparator);
   } else {
     updatedContent = rawContent + phaseEntry;
   }
 
   // Insert checkbox summary line in the phases list at the top of ROADMAP.md
-  updatedContent = insertCheckboxLine(updatedContent, newPhaseNum, description, null);
+  updatedContent = insertCheckboxLine(
+    updatedContent,
+    newPhaseNum,
+    description,
+    null,
+  );
 
   fs.writeFileSync(roadmapPath, updatedContent, 'utf-8');
 
@@ -479,7 +544,10 @@ function cmdPhaseInsert(cwd, afterPhase, description) {
   const normalizedAfter = normalizePhaseName(afterPhase);
   const unpadded = normalizedAfter.replace(/^0+/, '');
   const afterPhaseEscaped = unpadded.replace(/\./g, '\\.');
-  const targetPattern = new RegExp(`#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:`, 'i');
+  const targetPattern = new RegExp(
+    `#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:`,
+    'i',
+  );
   if (!targetPattern.test(content)) {
     error(`Phase ${afterPhase} not found in ROADMAP.md`);
   }
@@ -490,7 +558,7 @@ function cmdPhaseInsert(cwd, afterPhase, description) {
 
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
     const decimalPattern = new RegExp(`^${normalizedBase}\\.(\\d+)`);
     for (const dir of dirs) {
       const dm = dir.match(decimalPattern);
@@ -498,7 +566,8 @@ function cmdPhaseInsert(cwd, afterPhase, description) {
     }
   } catch {}
 
-  const nextDecimal = existingDecimals.length === 0 ? 1 : Math.max(...existingDecimals) + 1;
+  const nextDecimal =
+    existingDecimals.length === 0 ? 1 : Math.max(...existingDecimals) + 1;
   const decimalPhase = `${normalizedBase}.${nextDecimal}`;
   const dirName = `${decimalPhase}-${slug}`;
   const dirPath = path.join(phasesDir, dirName);
@@ -511,7 +580,10 @@ function cmdPhaseInsert(cwd, afterPhase, description) {
   const phaseEntry = `\n### Phase ${decimalPhase}: ${description} (INSERTED)\n\n**Goal:** [Urgent work - to be planned]\n**Requirements**: TBD\n**Depends on:** Phase ${afterPhase}\n**Plans:** 0 plans\n\nPlans:\n- [ ] TBD (run /gsd:plan-phase ${decimalPhase} to break down)\n`;
 
   // Insert after the target phase section
-  const headerPattern = new RegExp(`(#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:[^\\n]*\\n)`, 'i');
+  const headerPattern = new RegExp(
+    `(#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:[^\\n]*\\n)`,
+    'i',
+  );
   const headerMatch = rawContent.match(headerPattern);
   if (!headerMatch) {
     error(`Could not find Phase ${afterPhase} header`);
@@ -519,7 +591,9 @@ function cmdPhaseInsert(cwd, afterPhase, description) {
 
   const headerIdx = rawContent.indexOf(headerMatch[0]);
   const afterHeader = rawContent.slice(headerIdx + headerMatch[0].length);
-  const nextPhaseMatch = afterHeader.match(/\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i);
+  const nextPhaseMatch = afterHeader.match(
+    /\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i,
+  );
 
   let insertIdx;
   if (nextPhaseMatch) {
@@ -528,10 +602,16 @@ function cmdPhaseInsert(cwd, afterPhase, description) {
     insertIdx = rawContent.length;
   }
 
-  let updatedContent = rawContent.slice(0, insertIdx) + phaseEntry + rawContent.slice(insertIdx);
+  let updatedContent =
+    rawContent.slice(0, insertIdx) + phaseEntry + rawContent.slice(insertIdx);
 
   // Insert checkbox summary line in the phases list, after the parent phase's checkbox
-  updatedContent = insertCheckboxLine(updatedContent, decimalPhase, description + ' (INSERTED)', afterPhase);
+  updatedContent = insertCheckboxLine(
+    updatedContent,
+    decimalPhase,
+    description + ' (INSERTED)',
+    afterPhase,
+  );
 
   fs.writeFileSync(roadmapPath, updatedContent, 'utf-8');
 
@@ -566,23 +646,35 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
   let targetDir = null;
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
-    targetDir = dirs.find(d => d.startsWith(normalized + '-') || d === normalized);
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort((a, b) => comparePhaseNum(a, b));
+    targetDir = dirs.find(
+      (d) => d.startsWith(normalized + '-') || d === normalized,
+    );
   } catch {}
 
   // Check for executed work (SUMMARY.md files)
   if (targetDir && !force) {
     const targetPath = path.join(phasesDir, targetDir);
     const files = fs.readdirSync(targetPath);
-    const summaries = files.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+    const summaries = files.filter(
+      (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+    );
     if (summaries.length > 0) {
-      error(`Phase ${targetPhase} has ${summaries.length} executed plan(s). Use --force to remove anyway.`);
+      error(
+        `Phase ${targetPhase} has ${summaries.length} executed plan(s). Use --force to remove anyway.`,
+      );
     }
   }
 
   // Delete target directory
   if (targetDir) {
-    fs.rmSync(path.join(phasesDir, targetDir), { recursive: true, force: true });
+    fs.rmSync(path.join(phasesDir, targetDir), {
+      recursive: true,
+      force: true,
+    });
   }
 
   // Renumber subsequent phases
@@ -597,7 +689,10 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
 
     try {
       const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-      const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
+      const dirs = entries
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort((a, b) => comparePhaseNum(a, b));
 
       // Find sibling decimals with higher numbers
       const decPattern = new RegExp(`^${baseInt}\\.(\\d+)-(.+)$`);
@@ -619,7 +714,10 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
         const newDirName = `${baseInt}.${newDecimal}-${item.slug}`;
 
         // Rename directory
-        fs.renameSync(path.join(phasesDir, item.dir), path.join(phasesDir, newDirName));
+        fs.renameSync(
+          path.join(phasesDir, item.dir),
+          path.join(phasesDir, newDirName),
+        );
         renamedDirs.push({ from: item.dir, to: newDirName });
 
         // Rename files inside
@@ -630,21 +728,23 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
             const newFileName = f.replace(oldPhaseId, newPhaseId);
             fs.renameSync(
               path.join(phasesDir, newDirName, f),
-              path.join(phasesDir, newDirName, newFileName)
+              path.join(phasesDir, newDirName, newFileName),
             );
             renamedFiles.push({ from: f, to: newFileName });
           }
         }
       }
     } catch {}
-
   } else {
     // Integer removal: renumber all subsequent integer phases
     const removedInt = parseInt(normalized, 10);
 
     try {
       const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-      const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort((a, b) => comparePhaseNum(a, b));
+      const dirs = entries
+        .filter((e) => e.isDirectory())
+        .map((e) => e.name)
+        .sort((a, b) => comparePhaseNum(a, b));
 
       // Collect directories that need renumbering (integer phases > removed, and their decimals/letters)
       const toRename = [];
@@ -680,7 +780,10 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
         const newDirName = `${newPrefix}-${item.slug}`;
 
         // Rename directory
-        fs.renameSync(path.join(phasesDir, item.dir), path.join(phasesDir, newDirName));
+        fs.renameSync(
+          path.join(phasesDir, item.dir),
+          path.join(phasesDir, newDirName),
+        );
         renamedDirs.push({ from: item.dir, to: newDirName });
 
         // Rename files inside
@@ -690,7 +793,7 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
             const newFileName = newPrefix + f.slice(oldPrefix.length);
             fs.renameSync(
               path.join(phasesDir, newDirName, f),
-              path.join(phasesDir, newDirName, newFileName)
+              path.join(phasesDir, newDirName, newFileName),
             );
             renamedFiles.push({ from: f, to: newFileName });
           }
@@ -706,16 +809,22 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
   const targetEscaped = escapeRegex(targetPhase);
   const sectionPattern = new RegExp(
     `\\n?#{2,4}\\s*Phase\\s+${targetEscaped}\\s*:[\\s\\S]*?(?=\\n#{2,4}\\s+Phase\\s+\\d+[A-Z]?(?:\\.\\d+)*|$)`,
-    'i'
+    'i',
   );
   roadmapContent = roadmapContent.replace(sectionPattern, '');
 
   // Remove from phase list (checkbox)
-  const checkboxPattern = new RegExp(`\\n?-\\s*\\[[ x]\\]\\s*.*Phase\\s+${targetEscaped}[:\\s][^\\n]*`, 'gi');
+  const checkboxPattern = new RegExp(
+    `\\n?-\\s*\\[[ x]\\]\\s*.*Phase\\s+${targetEscaped}[:\\s][^\\n]*`,
+    'gi',
+  );
   roadmapContent = roadmapContent.replace(checkboxPattern, '');
 
   // Remove from progress table
-  const tableRowPattern = new RegExp(`\\n?\\|\\s*${targetEscaped}\\.?\\s[^|]*\\|[^\\n]*`, 'gi');
+  const tableRowPattern = new RegExp(
+    `\\n?\\|\\s*${targetEscaped}\\.?\\s[^|]*\\|[^\\n]*`,
+    'gi',
+  );
   roadmapContent = roadmapContent.replace(tableRowPattern, '');
 
   // Renumber references in ROADMAP for subsequent phases
@@ -734,31 +843,31 @@ function cmdPhaseRemove(cwd, targetPhase, options) {
       // Phase headings: ## Phase 18: or ### Phase 18: → ## Phase 17: or ### Phase 17:
       roadmapContent = roadmapContent.replace(
         new RegExp(`(#{2,4}\\s*Phase\\s+)${oldStr}(\\s*:)`, 'gi'),
-        `$1${newStr}$2`
+        `$1${newStr}$2`,
       );
 
       // Checkbox items: - [ ] **Phase 18:** → - [ ] **Phase 17:**
       roadmapContent = roadmapContent.replace(
         new RegExp(`(Phase\\s+)${oldStr}([:\\s])`, 'g'),
-        `$1${newStr}$2`
+        `$1${newStr}$2`,
       );
 
       // Plan references: 18-01 → 17-01
       roadmapContent = roadmapContent.replace(
         new RegExp(`${oldPad}-(\\d{2})`, 'g'),
-        `${newPad}-$1`
+        `${newPad}-$1`,
       );
 
       // Table rows: | 18. → | 17.
       roadmapContent = roadmapContent.replace(
         new RegExp(`(\\|\\s*)${oldStr}\\.\\s`, 'g'),
-        `$1${newStr}. `
+        `$1${newStr}. `,
       );
 
       // Depends on references
       roadmapContent = roadmapContent.replace(
         new RegExp(`(Depends on:\\*\\*\\s*Phase\\s+)${oldStr}\\b`, 'gi'),
-        `$1${newStr}`
+        `$1${newStr}`,
       );
     }
   }
@@ -803,7 +912,11 @@ function cmdPhaseComplete(cwd, phaseNum) {
     error('phase number required for phase complete');
   }
 
-  const { roadmap: roadmapPath, state: statePath, phases: phasesDir } = planningPaths(cwd);
+  const {
+    roadmap: roadmapPath,
+    state: statePath,
+    phases: phasesDir,
+  } = planningPaths(cwd);
   const normalized = normalizePhaseName(phaseNum);
   const today = new Date().toISOString().split('T')[0];
 
@@ -824,38 +937,47 @@ function cmdPhaseComplete(cwd, phaseNum) {
     // Checkbox: - [ ] Phase N: → - [x] Phase N: (...completed DATE)
     const checkboxPattern = new RegExp(
       `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${escapeRegex(phaseNum)}[:\\s][^\\n]*)`,
-      'i'
+      'i',
     );
-    roadmapContent = replaceInCurrentMilestone(roadmapContent, checkboxPattern, `$1x$2 (completed ${today})`);
+    roadmapContent = replaceInCurrentMilestone(
+      roadmapContent,
+      checkboxPattern,
+      `$1x$2 (completed ${today})`,
+    );
 
     // Progress table: update Status to Complete, add date (handles 4 or 5 column tables)
     const phaseEscaped = escapeRegex(phaseNum);
     const tableRowPattern = new RegExp(
       `^(\\|\\s*${phaseEscaped}\\.?\\s[^|]*(?:\\|[^\\n]*)*)$`,
-      'im'
+      'im',
     );
-    roadmapContent = replaceInCurrentMilestone(roadmapContent, tableRowPattern, (fullRow) => {
-      const cells = fullRow.split('|').slice(1, -1);
-      if (cells.length === 5) {
-        // 5-col: Phase | Milestone | Plans | Status | Completed
-        cells[3] = ' Complete    ';
-        cells[4] = ` ${today} `;
-      } else if (cells.length === 4) {
-        // 4-col: Phase | Plans | Status | Completed
-        cells[2] = ' Complete    ';
-        cells[3] = ` ${today} `;
-      }
-      return '|' + cells.join('|') + '|';
-    });
+    roadmapContent = replaceInCurrentMilestone(
+      roadmapContent,
+      tableRowPattern,
+      (fullRow) => {
+        const cells = fullRow.split('|').slice(1, -1);
+        if (cells.length === 5) {
+          // 5-col: Phase | Milestone | Plans | Status | Completed
+          cells[3] = ' Complete    ';
+          cells[4] = ` ${today} `;
+        } else if (cells.length === 4) {
+          // 4-col: Phase | Plans | Status | Completed
+          cells[2] = ' Complete    ';
+          cells[3] = ` ${today} `;
+        }
+        return '|' + cells.join('|') + '|';
+      },
+    );
 
     // Update plan count in phase section
     const planCountPattern = new RegExp(
       `(#{2,4}\\s*Phase\\s+${phaseEscaped}[\\s\\S]*?\\*\\*Plans:\\*\\*\\s*)[^\\n]+`,
-      'i'
+      'i',
     );
     roadmapContent = replaceInCurrentMilestone(
-      roadmapContent, planCountPattern,
-      `$1${summaryCount}/${planCount} plans complete`
+      roadmapContent,
+      planCountPattern,
+      `$1${summaryCount}/${planCount} plans complete`,
     );
 
     fs.writeFileSync(roadmapPath, roadmapContent, 'utf-8');
@@ -867,14 +989,21 @@ function cmdPhaseComplete(cwd, phaseNum) {
       const phaseEsc = escapeRegex(phaseNum);
       const currentMilestoneRoadmap = extractCurrentMilestone(roadmapContent);
       const phaseSectionMatch = currentMilestoneRoadmap.match(
-        new RegExp(`(#{2,4}\\s*Phase\\s+${phaseEsc}[:\\s][\\s\\S]*?)(?=#{2,4}\\s*Phase\\s+|$)`, 'i')
+        new RegExp(
+          `(#{2,4}\\s*Phase\\s+${phaseEsc}[:\\s][\\s\\S]*?)(?=#{2,4}\\s*Phase\\s+|$)`,
+          'i',
+        ),
       );
 
       const sectionText = phaseSectionMatch ? phaseSectionMatch[1] : '';
       const reqMatch = sectionText.match(/\*\*Requirements:\*\*\s*([^\n]+)/i);
 
       if (reqMatch) {
-        const reqIds = reqMatch[1].replace(/[\[\]]/g, '').split(/[,\s]+/).map(r => r.trim()).filter(Boolean);
+        const reqIds = reqMatch[1]
+          .replace(/[\[\]]/g, '')
+          .split(/[,\s]+/)
+          .map((r) => r.trim())
+          .filter(Boolean);
         let reqContent = fs.readFileSync(reqPath, 'utf-8');
 
         for (const reqId of reqIds) {
@@ -882,12 +1011,15 @@ function cmdPhaseComplete(cwd, phaseNum) {
           // Update checkbox: - [ ] **REQ-ID** → - [x] **REQ-ID**
           reqContent = reqContent.replace(
             new RegExp(`(-\\s*\\[)[ ](\\]\\s*\\*\\*${reqEscaped}\\*\\*)`, 'gi'),
-            '$1x$2'
+            '$1x$2',
           );
           // Update traceability table: | REQ-ID | Phase N | Pending/In Progress | → | REQ-ID | Phase N | Complete |
           reqContent = reqContent.replace(
-            new RegExp(`(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*(?:Pending|In Progress)\\s*(\\|)`, 'gi'),
-            '$1 Complete $2'
+            new RegExp(
+              `(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*(?:Pending|In Progress)\\s*(\\|)`,
+              'gi',
+            ),
+            '$1 Complete $2',
           );
         }
 
@@ -907,7 +1039,9 @@ function cmdPhaseComplete(cwd, phaseNum) {
   try {
     const isDirInMilestone = getMilestonePhaseFilter(cwd);
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name)
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
       .filter(isDirInMilestone)
       .sort((a, b) => comparePhaseNum(a, b));
 
@@ -929,13 +1063,20 @@ function cmdPhaseComplete(cwd, phaseNum) {
   // for phases that are defined but not yet planned (no directory on disk)
   if (isLastPhase && fs.existsSync(roadmapPath)) {
     try {
-      const roadmapForPhases = extractCurrentMilestone(fs.readFileSync(roadmapPath, 'utf-8'));
-      const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+      const roadmapForPhases = extractCurrentMilestone(
+        fs.readFileSync(roadmapPath, 'utf-8'),
+      );
+      const phasePattern =
+        /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
       let pm;
       while ((pm = phasePattern.exec(roadmapForPhases)) !== null) {
         if (comparePhaseNum(pm[1], phaseNum) > 0) {
           nextPhaseNum = pm[1];
-          nextPhaseName = pm[2].replace(/\(INSERTED\)/i, '').trim().toLowerCase().replace(/\s+/g, '-');
+          nextPhaseName = pm[2]
+            .replace(/\(INSERTED\)/i, '')
+            .trim()
+            .toLowerCase()
+            .replace(/\s+/g, '-');
           isLastPhase = false;
           break;
         }
@@ -950,39 +1091,39 @@ function cmdPhaseComplete(cwd, phaseNum) {
     // Update Current Phase
     stateContent = stateContent.replace(
       /(\*\*Current Phase:\*\*\s*).*/,
-      `$1${nextPhaseNum || phaseNum}`
+      `$1${nextPhaseNum || phaseNum}`,
     );
 
     // Update Current Phase Name
     if (nextPhaseName) {
       stateContent = stateContent.replace(
         /(\*\*Current Phase Name:\*\*\s*).*/,
-        `$1${nextPhaseName.replace(/-/g, ' ')}`
+        `$1${nextPhaseName.replace(/-/g, ' ')}`,
       );
     }
 
     // Update Status
     stateContent = stateContent.replace(
       /(\*\*Status:\*\*\s*).*/,
-      `$1${isLastPhase ? 'Milestone complete' : 'Ready to plan'}`
+      `$1${isLastPhase ? 'Milestone complete' : 'Ready to plan'}`,
     );
 
     // Update Current Plan
     stateContent = stateContent.replace(
       /(\*\*Current Plan:\*\*\s*).*/,
-      `$1Not started`
+      `$1Not started`,
     );
 
     // Update Last Activity
     stateContent = stateContent.replace(
       /(\*\*Last Activity:\*\*\s*).*/,
-      `$1${today}`
+      `$1${today}`,
     );
 
     // Update Last Activity Description
     stateContent = stateContent.replace(
       /(\*\*Last Activity Description:\*\*\s*).*/,
-      `$1Phase ${phaseNum} complete${nextPhaseNum ? `, transitioned to Phase ${nextPhaseNum}` : ''}`
+      `$1Phase ${phaseNum} complete${nextPhaseNum ? `, transitioned to Phase ${nextPhaseNum}` : ''}`,
     );
 
     writeStateMd(statePath, stateContent, cwd);
@@ -992,8 +1133,10 @@ function cmdPhaseComplete(cwd, phaseNum) {
     completed_phase: phaseNum,
     phase_name: phaseInfo.phase_name,
     plans_executed: `${summaryCount}/${planCount}`,
-    next_phase: nextPhaseNum ? { number: nextPhaseNum, name: nextPhaseName } : null,
-    next_phase_name: nextPhaseName,  // keep for backward compat with transition.md consumers
+    next_phase: nextPhaseNum
+      ? { number: nextPhaseNum, name: nextPhaseName }
+      : null,
+    next_phase_name: nextPhaseName, // keep for backward compat with transition.md consumers
     is_last_phase: isLastPhase,
     date: today,
     roadmap_updated: fs.existsSync(roadmapPath),

--- a/gsd-ng/bin/lib/roadmap.cjs
+++ b/gsd-ng/bin/lib/roadmap.cjs
@@ -4,19 +4,34 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, normalizePhaseName, output, error, findPhaseInternal, extractCurrentMilestone, replaceInCurrentMilestone, getPhaseCompletionStatus, planningPaths } = require('./core.cjs');
+const {
+  escapeRegex,
+  normalizePhaseName,
+  output,
+  error,
+  findPhaseInternal,
+  extractCurrentMilestone,
+  replaceInCurrentMilestone,
+  getPhaseCompletionStatus,
+  planningPaths,
+} = require('./core.cjs');
 
 function cmdRoadmapGetPhase(cwd, phaseNum, defaultValue) {
   const { roadmap: roadmapPath } = planningPaths(cwd);
 
   if (!fs.existsSync(roadmapPath)) {
-    if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+    if (defaultValue !== undefined) {
+      output(defaultValue, String(defaultValue));
+      return;
+    }
     output({ found: false, error: 'ROADMAP.md not found' }, '');
     return;
   }
 
   try {
-    const content = extractCurrentMilestone(fs.readFileSync(roadmapPath, 'utf-8'));
+    const content = extractCurrentMilestone(
+      fs.readFileSync(roadmapPath, 'utf-8'),
+    );
 
     // Escape special regex chars in phase number, handle decimal
     const escapedPhase = escapeRegex(phaseNum);
@@ -24,7 +39,7 @@ function cmdRoadmapGetPhase(cwd, phaseNum, defaultValue) {
     // Match "## Phase X:", "### Phase X:", or "#### Phase X:" with optional name
     const phasePattern = new RegExp(
       `#{2,4}\\s*Phase\\s+${escapedPhase}:\\s*([^\\n]+)`,
-      'i'
+      'i',
     );
     const headerMatch = content.match(phasePattern);
 
@@ -32,24 +47,33 @@ function cmdRoadmapGetPhase(cwd, phaseNum, defaultValue) {
       // Fallback: check if phase exists in summary list but missing detail section
       const checklistPattern = new RegExp(
         `-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+${escapedPhase}:\\s*([^*]+)\\*\\*`,
-        'i'
+        'i',
       );
       const checklistMatch = content.match(checklistPattern);
 
       if (checklistMatch) {
         // Phase exists in summary but missing detail section - malformed ROADMAP
-        if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
-        output({
-          found: false,
-          phase_number: phaseNum,
-          phase_name: checklistMatch[1].trim(),
-          error: 'malformed_roadmap',
-          message: `Phase ${phaseNum} exists in summary list but missing "### Phase ${phaseNum}:" detail section. ROADMAP.md needs both formats.`
-        }, '');
+        if (defaultValue !== undefined) {
+          output(defaultValue, String(defaultValue));
+          return;
+        }
+        output(
+          {
+            found: false,
+            phase_number: phaseNum,
+            phase_name: checklistMatch[1].trim(),
+            error: 'malformed_roadmap',
+            message: `Phase ${phaseNum} exists in summary list but missing "### Phase ${phaseNum}:" detail section. ROADMAP.md needs both formats.`,
+          },
+          '',
+        );
         return;
       }
 
-      if (defaultValue !== undefined) { output(defaultValue, String(defaultValue)); return; }
+      if (defaultValue !== undefined) {
+        output(defaultValue, String(defaultValue));
+        return;
+      }
       output({ found: false, phase_number: phaseNum }, '');
       return;
     }
@@ -59,7 +83,9 @@ function cmdRoadmapGetPhase(cwd, phaseNum, defaultValue) {
 
     // Find the end of this section (next ## or ### phase header, or end of file)
     const restOfContent = content.slice(headerIndex);
-    const nextHeaderMatch = restOfContent.match(/\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i);
+    const nextHeaderMatch = restOfContent.match(
+      /\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i,
+    );
     const sectionEnd = nextHeaderMatch
       ? headerIndex + nextHeaderMatch.index
       : content.length;
@@ -71,9 +97,15 @@ function cmdRoadmapGetPhase(cwd, phaseNum, defaultValue) {
     const goal = goalMatch ? goalMatch[1].trim() : null;
 
     // Extract success criteria as structured array
-    const criteriaMatch = section.match(/\*\*Success Criteria\*\*[^\n]*:\s*\n((?:\s*\d+\.\s*[^\n]+\n?)+)/i);
+    const criteriaMatch = section.match(
+      /\*\*Success Criteria\*\*[^\n]*:\s*\n((?:\s*\d+\.\s*[^\n]+\n?)+)/i,
+    );
     const success_criteria = criteriaMatch
-      ? criteriaMatch[1].trim().split('\n').map(line => line.replace(/^\s*\d+\.\s*/, '').trim()).filter(Boolean)
+      ? criteriaMatch[1]
+          .trim()
+          .split('\n')
+          .map((line) => line.replace(/^\s*\d+\.\s*/, '').trim())
+          .filter(Boolean)
       : [];
 
     // Extract depends_on (same pattern as cmdRoadmapAnalyze)
@@ -96,7 +128,7 @@ function cmdRoadmapGetPhase(cwd, phaseNum, defaultValue) {
         section,
       },
 
-      section
+      section,
     );
   } catch (e) {
     error('Failed to read ROADMAP.md: ' + e.message);
@@ -107,7 +139,12 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
   const { roadmap: roadmapPath, phases: phasesDir } = planningPaths(cwd);
 
   if (!fs.existsSync(roadmapPath)) {
-    output({ error: 'ROADMAP.md not found', milestones: [], phases: [], current_phase: null });
+    output({
+      error: 'ROADMAP.md not found',
+      milestones: [],
+      phases: [],
+      current_phase: null,
+    });
     return;
   }
 
@@ -115,7 +152,8 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
   const content = extractCurrentMilestone(rawContent);
 
   // Extract all phase headings: ## Phase N: Name or ### Phase N: Name
-  const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+  const phasePattern =
+    /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
   const phases = [];
   let match;
 
@@ -126,8 +164,12 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
     // Extract goal from the section
     const sectionStart = match.index;
     const restOfContent = content.slice(sectionStart);
-    const nextHeader = restOfContent.match(/\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i);
-    const sectionEnd = nextHeader ? sectionStart + nextHeader.index : content.length;
+    const nextHeader = restOfContent.match(
+      /\n#{2,4}\s+Phase\s+\d+[A-Z]?(?:\.\d+)*/i,
+    );
+    const sectionEnd = nextHeader
+      ? sectionStart + nextHeader.index
+      : content.length;
     const section = content.slice(sectionStart, sectionEnd);
 
     const goalMatch = section.match(/\*\*Goal:\*\*\s*([^\n]+)/i);
@@ -149,18 +191,30 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
 
     try {
       const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-      const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
-      const dirMatch = dirs.find(d => d.startsWith(normalized + '-') || d === normalized);
+      const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
+      const dirMatch = dirs.find(
+        (d) => d.startsWith(normalized + '-') || d === normalized,
+      );
 
       if (dirMatch) {
         const phaseFiles = fs.readdirSync(path.join(phasesDir, dirMatch));
-        planCount = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').length;
-        summaryCount = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md').length;
-        hasContext = phaseFiles.some(f => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md');
-        hasResearch = phaseFiles.some(f => f.endsWith('-RESEARCH.md') || f === 'RESEARCH.md');
+        planCount = phaseFiles.filter(
+          (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md',
+        ).length;
+        summaryCount = phaseFiles.filter(
+          (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+        ).length;
+        hasContext = phaseFiles.some(
+          (f) => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md',
+        );
+        hasResearch = phaseFiles.some(
+          (f) => f.endsWith('-RESEARCH.md') || f === 'RESEARCH.md',
+        );
 
-        const { isComplete, status: completionStatus } = getPhaseCompletionStatus(path.join(phasesDir, dirMatch));
-        if (isComplete) diskStatus = completionStatus;  // 'complete (verified)' or 'complete (unverified)'
+        const { isComplete, status: completionStatus } =
+          getPhaseCompletionStatus(path.join(phasesDir, dirMatch));
+        if (isComplete)
+          diskStatus = completionStatus; // 'complete (verified)' or 'complete (unverified)'
         else if (summaryCount > 0) diskStatus = 'partial';
         else if (planCount > 0) diskStatus = 'planned';
         else if (hasResearch) diskStatus = 'researched';
@@ -170,7 +224,10 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
     } catch {}
 
     // Check ROADMAP checkbox status
-    const checkboxPattern = new RegExp(`-\\s*\\[(x| )\\]\\s*.*Phase\\s+${escapeRegex(phaseNum)}[:\\s]`, 'i');
+    const checkboxPattern = new RegExp(
+      `-\\s*\\[(x| )\\]\\s*.*Phase\\s+${escapeRegex(phaseNum)}[:\\s]`,
+      'i',
+    );
     const checkboxMatch = content.match(checkboxPattern);
     const roadmapComplete = checkboxMatch ? checkboxMatch[1] === 'x' : false;
 
@@ -208,13 +265,25 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
   }
 
   // Find current and next phase
-  const currentPhase = phases.find(p => p.disk_status === 'planned' || p.disk_status === 'partial') || null;
-  const nextPhase = phases.find(p => p.disk_status === 'empty' || p.disk_status === 'no_directory' || p.disk_status === 'discussed' || p.disk_status === 'researched') || null;
+  const currentPhase =
+    phases.find(
+      (p) => p.disk_status === 'planned' || p.disk_status === 'partial',
+    ) || null;
+  const nextPhase =
+    phases.find(
+      (p) =>
+        p.disk_status === 'empty' ||
+        p.disk_status === 'no_directory' ||
+        p.disk_status === 'discussed' ||
+        p.disk_status === 'researched',
+    ) || null;
 
   // Aggregated stats
   const totalPlans = phases.reduce((sum, p) => sum + p.plan_count, 0);
   const totalSummaries = phases.reduce((sum, p) => sum + p.summary_count, 0);
-  const completedPhases = phases.filter(p => p.disk_status.startsWith('complete')).length;
+  const completedPhases = phases.filter((p) =>
+    p.disk_status.startsWith('complete'),
+  ).length;
 
   // Detect phases in summary list without detail sections (malformed ROADMAP)
   const checklistPattern = /-\s*\[[ x]\]\s*\*\*Phase\s+(\d+[A-Z]?(?:\.\d+)*)/gi;
@@ -223,13 +292,17 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
   while ((checklistMatch = checklistPattern.exec(content)) !== null) {
     checklistPhases.add(checklistMatch[1]);
   }
-  const detailPhases = new Set(phases.map(p => p.number));
-  const missingDetails = [...checklistPhases].filter(p => !detailPhases.has(p));
+  const detailPhases = new Set(phases.map((p) => p.number));
+  const missingDetails = [...checklistPhases].filter(
+    (p) => !detailPhases.has(p),
+  );
 
   let resultPhases = phases;
   let resultMilestones = milestones;
   if (phaseFilter) {
-    resultPhases = phases.filter(p => String(p.number) === String(phaseFilter));
+    resultPhases = phases.filter(
+      (p) => String(p.number) === String(phaseFilter),
+    );
     resultMilestones = undefined;
   }
 
@@ -240,9 +313,14 @@ function cmdRoadmapAnalyze(cwd, phaseFilter) {
     completed_phases: completedPhases,
     total_plans: totalPlans,
     total_summaries: totalSummaries,
-    progress_percent: totalPlans > 0 ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100)) : 0,
+    progress_percent:
+      totalPlans > 0
+        ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100))
+        : 0,
     current_phase: currentPhase ? currentPhase.number : null,
-    next_phase: nextPhase ? { number: nextPhase.number, name: nextPhase.name } : null,
+    next_phase: nextPhase
+      ? { number: nextPhase.number, name: nextPhase.name }
+      : null,
     missing_phase_details: missingDetails.length > 0 ? missingDetails : null,
   };
 
@@ -265,19 +343,40 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum) {
   const summaryCount = phaseInfo.summaries.length;
 
   if (planCount === 0) {
-    output({ updated: false, reason: 'No plans found', plan_count: 0, summary_count: 0 }, 'no plans');
+    output(
+      {
+        updated: false,
+        reason: 'No plans found',
+        plan_count: 0,
+        summary_count: 0,
+      },
+      'no plans',
+    );
     return;
   }
 
   const phaseAbsDir = path.join(cwd, phaseInfo.directory);
-  const { isComplete, status: completionStatus } = getPhaseCompletionStatus(phaseAbsDir);
+  const { isComplete, status: completionStatus } =
+    getPhaseCompletionStatus(phaseAbsDir);
   const status = isComplete
-    ? (completionStatus === 'complete (verified)' ? 'Complete (verified)' : 'Complete')
-    : summaryCount > 0 ? 'In Progress' : 'Planned';
+    ? completionStatus === 'complete (verified)'
+      ? 'Complete (verified)'
+      : 'Complete'
+    : summaryCount > 0
+      ? 'In Progress'
+      : 'Planned';
   const today = new Date().toISOString().split('T')[0];
 
   if (!fs.existsSync(roadmapPath)) {
-    output({ updated: false, reason: 'ROADMAP.md not found', plan_count: planCount, summary_count: summaryCount }, 'no roadmap');
+    output(
+      {
+        updated: false,
+        reason: 'ROADMAP.md not found',
+        plan_count: planCount,
+        summary_count: summaryCount,
+      },
+      'no roadmap',
+    );
     return;
   }
 
@@ -287,66 +386,87 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum) {
   // Progress table row: update Plans/Status/Date columns (handles 4 or 5 column tables)
   const tableRowPattern = new RegExp(
     `^(\\|\\s*${phaseEscaped}\\.?\\s[^|]*(?:\\|[^\\n]*)*)$`,
-    'im'
+    'im',
   );
   const dateField = isComplete ? ` ${today} ` : '  ';
-  roadmapContent = replaceInCurrentMilestone(roadmapContent, tableRowPattern, (fullRow) => {
-    const cells = fullRow.split('|').slice(1, -1); // drop leading/trailing empty from split
-    if (cells.length === 5) {
-      // 5-col: Phase | Milestone | Plans | Status | Completed
-      cells[2] = ` ${summaryCount}/${planCount} `;
-      cells[3] = ` ${status.padEnd(11)}`;
-      cells[4] = dateField;
-    } else if (cells.length === 4) {
-      // 4-col: Phase | Plans | Status | Completed
-      cells[1] = ` ${summaryCount}/${planCount} `;
-      cells[2] = ` ${status.padEnd(11)}`;
-      cells[3] = dateField;
-    }
-    return '|' + cells.join('|') + '|';
-  });
+  roadmapContent = replaceInCurrentMilestone(
+    roadmapContent,
+    tableRowPattern,
+    (fullRow) => {
+      const cells = fullRow.split('|').slice(1, -1); // drop leading/trailing empty from split
+      if (cells.length === 5) {
+        // 5-col: Phase | Milestone | Plans | Status | Completed
+        cells[2] = ` ${summaryCount}/${planCount} `;
+        cells[3] = ` ${status.padEnd(11)}`;
+        cells[4] = dateField;
+      } else if (cells.length === 4) {
+        // 4-col: Phase | Plans | Status | Completed
+        cells[1] = ` ${summaryCount}/${planCount} `;
+        cells[2] = ` ${status.padEnd(11)}`;
+        cells[3] = dateField;
+      }
+      return '|' + cells.join('|') + '|';
+    },
+  );
 
   // Update plan count in phase detail section
   const planCountPattern = new RegExp(
     `(#{2,4}\\s*Phase\\s+${phaseEscaped}[\\s\\S]*?\\*\\*Plans:\\*\\*\\s*)[^\\n]+`,
-    'i'
+    'i',
   );
   const planCountText = isComplete
     ? `${summaryCount}/${planCount} plans complete`
     : `${summaryCount}/${planCount} plans executed`;
-  roadmapContent = replaceInCurrentMilestone(roadmapContent, planCountPattern, `$1${planCountText}`);
+  roadmapContent = replaceInCurrentMilestone(
+    roadmapContent,
+    planCountPattern,
+    `$1${planCountText}`,
+  );
 
   // If complete: check phase-level checkbox
   if (isComplete) {
     const checkboxPattern = new RegExp(
       `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}[:\\s][^\\n]*)`,
-      'i'
+      'i',
     );
-    roadmapContent = replaceInCurrentMilestone(roadmapContent, checkboxPattern, `$1x$2 (completed ${today})`);
+    roadmapContent = replaceInCurrentMilestone(
+      roadmapContent,
+      checkboxPattern,
+      `$1x$2 (completed ${today})`,
+    );
   }
 
   // Mark completed plan checkboxes (e.g. "- [ ] 50-01-PLAN.md" or "- [ ] 50-01:")
   for (const summaryFile of phaseInfo.summaries) {
-    const planId = summaryFile.replace('-SUMMARY.md', '').replace('SUMMARY.md', '');
+    const planId = summaryFile
+      .replace('-SUMMARY.md', '')
+      .replace('SUMMARY.md', '');
     if (!planId) continue;
     const planEscaped = escapeRegex(planId);
     const planCheckboxPattern = new RegExp(
       `(-\\s*\\[) (\\]\\s*${planEscaped})`,
-      'i'
+      'i',
     );
-    roadmapContent = replaceInCurrentMilestone(roadmapContent, planCheckboxPattern, '$1x$2');
+    roadmapContent = replaceInCurrentMilestone(
+      roadmapContent,
+      planCheckboxPattern,
+      '$1x$2',
+    );
   }
 
   fs.writeFileSync(roadmapPath, roadmapContent, 'utf-8');
 
-  output({
-    updated: true,
-    phase: phaseNum,
-    plan_count: planCount,
-    summary_count: summaryCount,
-    status,
-    complete: isComplete,
-  }, `${summaryCount}/${planCount} ${status}`);
+  output(
+    {
+      updated: true,
+      phase: phaseNum,
+      plan_count: planCount,
+      summary_count: summaryCount,
+      status,
+      complete: isComplete,
+    },
+    `${summaryCount}/${planCount} ${status}`,
+  );
 }
 
 module.exports = {

--- a/gsd-ng/bin/lib/security.cjs
+++ b/gsd-ng/bin/lib/security.cjs
@@ -68,12 +68,12 @@ const INJECTION_PATTERNS = [
   /override\s+(system|previous)\s+(prompt|instructions)/i,
   // Role/identity manipulation
   /you\s+are\s+now\s+(?:a|an|the)\s+/i,
-  /act\s+as\s+(?:a|an|the)\s+(?!plan|phase|wave)/i,  // allow "act as a plan/phase/wave"
+  /act\s+as\s+(?:a|an|the)\s+(?!plan|phase|wave)/i, // allow "act as a plan/phase/wave"
   /pretend\s+(?:you(?:'re| are)\s+|to\s+be\s+)/i,
   // System prompt extraction
   /(?:print|output|reveal|show|display|repeat)\s+(?:your\s+)?(?:system\s+)?(?:prompt|instructions)/i,
   // Hidden instruction markers
-  /<\/?(?:system|assistant|human)>/i,  // Note: <instructions> excluded — GSD uses it
+  /<\/?(?:system|assistant|human)>/i, // Note: <instructions> excluded — GSD uses it
   /\[SYSTEM\]/i,
   /<<\s*SYS\s*>>/i,
   // Exfiltration
@@ -111,9 +111,17 @@ const INJECTION_PATTERNS_TIERED = [
   // ── HIGH confidence — unambiguous attack indicators ─────────────────────────
   // Direct instruction override — the canonical prompt injection attack
   // Covers: "ignore all previous instructions", "ignore the above directions", etc.
-  { pattern: /ignore\s+(?:all\s+)?(?:the\s+)?(?:previous|above|prior)\s+(?:instructions?|directions?|rules?)/i, confidence: 'high' },
+  {
+    pattern:
+      /ignore\s+(?:all\s+)?(?:the\s+)?(?:previous|above|prior)\s+(?:instructions?|directions?|rules?)/i,
+    confidence: 'high',
+  },
   // System/previous override — "override system prompt", "SYSTEM OVERRIDE: new instructions"
-  { pattern: /(?:override|OVERRIDE)\s+(?:system|previous)\s+(?:prompt|instructions)|SYSTEM\s+OVERRIDE\s*:/i, confidence: 'high' },
+  {
+    pattern:
+      /(?:override|OVERRIDE)\s+(?:system|previous)\s+(?:prompt|instructions)|SYSTEM\s+OVERRIDE\s*:/i,
+    confidence: 'high',
+  },
   // Hidden instruction markers — <system>, <assistant>, <human> tags
   { pattern: /<\/?(?:system|assistant|human)>/i, confidence: 'high' },
   // [SYSTEM] marker
@@ -122,11 +130,18 @@ const INJECTION_PATTERNS_TIERED = [
   { pattern: /<<\s*SYS\s*>>/i, confidence: 'high' },
   // Markdown image exfiltration: ![x](https://evil.com/steal?data=secret)
   // Detects image links with suspicious query params (data, token, key, secret, content)
-  { pattern: /!\[.*?\]\(https?:\/\/[^)]*\?[^)]*(?:data|token|key|secret|content)[^)]*\)/i, confidence: 'high' },
+  {
+    pattern:
+      /!\[.*?\]\(https?:\/\/[^)]*\?[^)]*(?:data|token|key|secret|content)[^)]*\)/i,
+    confidence: 'high',
+  },
   // ADMIN OVERRIDE: authority claim variant (case-insensitive)
   { pattern: /ADMIN\s+OVERRIDE\s*:/i, confidence: 'high' },
   // DAN jailbreak family: "DAN:", "DAN mode", "Do Anything Now" (case-insensitive)
-  { pattern: /\bDAN\s*(?::|mode\b)|Do\s+Anything\s+Now\b/i, confidence: 'high' },
+  {
+    pattern: /\bDAN\s*(?::|mode\b)|Do\s+Anything\s+Now\b/i,
+    confidence: 'high',
+  },
   // JAILBREAK prefix: explicit jailbreak label (case-insensitive)
   { pattern: /\bJAILBREAK\s*(?::|mode\b)|\bJAILBREAK\b/i, confidence: 'high' },
 
@@ -134,24 +149,51 @@ const INJECTION_PATTERNS_TIERED = [
   // Role/identity manipulation
   { pattern: /you\s+are\s+now\s+(?:a|an|the)\s+/i, confidence: 'medium' },
   // act as [role] — with GSD allow-list: "act as a plan/phase/wave" excluded
-  { pattern: /act\s+as\s+(?:a|an|the)\s+(?!plan|phase|wave)/i, confidence: 'medium' },
+  {
+    pattern: /act\s+as\s+(?:a|an|the)\s+(?!plan|phase|wave)/i,
+    confidence: 'medium',
+  },
   // Pretend to be / pretend you're
-  { pattern: /pretend\s+(?:you(?:'re| are)\s+|to\s+be\s+)/i, confidence: 'medium' },
+  {
+    pattern: /pretend\s+(?:you(?:'re| are)\s+|to\s+be\s+)/i,
+    confidence: 'medium',
+  },
   // System prompt extraction
-  { pattern: /(?:print|output|reveal|show|display|repeat)\s+(?:your\s+)?(?:system\s+)?(?:prompt|instructions)/i, confidence: 'medium' },
+  {
+    pattern:
+      /(?:print|output|reveal|show|display|repeat)\s+(?:your\s+)?(?:system\s+)?(?:prompt|instructions)/i,
+    confidence: 'medium',
+  },
   // Network exfiltration (could appear in legitimate code examples)
-  { pattern: /(?:send|post|fetch|curl|wget)\s+(?:to|from)\s+https?:\/\//i, confidence: 'medium' },
+  {
+    pattern: /(?:send|post|fetch|curl|wget)\s+(?:to|from)\s+https?:\/\//i,
+    confidence: 'medium',
+  },
   // Tool manipulation (could appear in shell scripting docs)
-  { pattern: /(?:run|execute|call|invoke)\s+(?:the\s+)?(?:bash|shell|exec|spawn)\s+(?:tool|command)/i, confidence: 'medium' },
+  {
+    pattern:
+      /(?:run|execute|call|invoke)\s+(?:the\s+)?(?:bash|shell|exec|spawn)\s+(?:tool|command)/i,
+    confidence: 'medium',
+  },
   // HTML comment injection: <!-- ignore all previous instructions -->
   // Attackers hide instructions in HTML comments to bypass text-level scanning
-  { pattern: /<!--.*?(?:ignore|override|system|instructions|execute).*?-->/is, confidence: 'medium' },
+  {
+    pattern: /<!--.*?(?:ignore|override|system|instructions|execute).*?-->/is,
+    confidence: 'medium',
+  },
   // Base64 + execute combination: "decode and execute base64payload"
   // Attackers encode malicious payloads to bypass pattern detection
-  { pattern: /(?:decode|base64)[^.]{0,30}(?:execute|follow|apply|run)/i, confidence: 'medium' },
+  {
+    pattern: /(?:decode|base64)[^.]{0,30}(?:execute|follow|apply|run)/i,
+    confidence: 'medium',
+  },
   // Tool output / search result indirect injection
   // Attacker plants instructions in tool output that agent will process
-  { pattern: /(?:tool(?:\s+output)?|search\s+result|webpage\s+content|external\s+data)[^.]{0,40}(?:ignore|override|forget|disregard)\s+(?:previous|prior|above|all)/i, confidence: 'medium' },
+  {
+    pattern:
+      /(?:tool(?:\s+output)?|search\s+result|webpage\s+content|external\s+data)[^.]{0,40}(?:ignore|override|forget|disregard)\s+(?:previous|prior|above|all)/i,
+    confidence: 'medium',
+  },
 ];
 
 // ─── validatePath ─────────────────────────────────────────────────────────────
@@ -212,7 +254,11 @@ function validatePath(filePath, baseDir, opts = {}) {
   if (safe) {
     return { safe: true, resolved: resolvedTarget };
   } else {
-    return { safe: false, resolved: resolvedTarget, error: 'Path escapes allowed directory' };
+    return {
+      safe: false,
+      resolved: resolvedTarget,
+      error: 'Path escapes allowed directory',
+    };
   }
 }
 
@@ -263,7 +309,9 @@ function shannonEntropy(segment) {
  * @returns {string}
  */
 function stripFencedCodeBlocks(content) {
-  return content.replace(/```[\s\S]*?```/g, (match) => ' '.repeat(match.length));
+  return content.replace(/```[\s\S]*?```/g, (match) =>
+    ' '.repeat(match.length),
+  );
 }
 
 /**
@@ -363,8 +411,8 @@ function scanForInjection(content, opts = {}) {
   // Entropy scanning (Phase 40.1) — statistical detection for obfuscated payloads
   // Activated by: opts.entropy=true OR (opts.external=true AND opts.entropy!==false)
   // Deactivated by: opts.entropy=false OR global config workflow.entropy_scanning=false
-  const entropyEnabled = opts.entropy === true ||
-    (opts.external === true && opts.entropy !== false);
+  const entropyEnabled =
+    opts.entropy === true || (opts.external === true && opts.entropy !== false);
   const globalEnabled = opts.cwd ? isEntropyGloballyEnabled(opts.cwd) : true;
 
   if (entropyEnabled && globalEnabled) {
@@ -387,9 +435,13 @@ function scanForInjection(content, opts = {}) {
       }
 
       // Handle tail segment: remaining chars after last full window
-      const lastFullWindowStart = Math.floor((scannable.length - WINDOW) / STEP) * STEP;
+      const lastFullWindowStart =
+        Math.floor((scannable.length - WINDOW) / STEP) * STEP;
       const tailStart = lastFullWindowStart + STEP;
-      if (tailStart < scannable.length && (scannable.length - tailStart) >= MIN_SEGMENT) {
+      if (
+        tailStart < scannable.length &&
+        scannable.length - tailStart >= MIN_SEGMENT
+      ) {
         const segment = scannable.slice(tailStart);
         const H = shannonEntropy(segment);
         if (H > THRESHOLD) {
@@ -400,12 +452,15 @@ function scanForInjection(content, opts = {}) {
       // Merge overlapping/adjacent flagged regions (due to 50% window overlap)
       const merged = mergeRegions(flaggedRegions);
       for (const { start, end, H } of merged) {
-        findings.push(`[entropy] High entropy segment (H=${H.toFixed(2)}, offset ${start}-${end})`);
+        findings.push(
+          `[entropy] High entropy segment (H=${H.toFixed(2)}, offset ${start}-${end})`,
+        );
       }
     }
   }
 
-  const tier = blocked.length > 0 ? 'high' : (findings.length > 0 ? 'medium' : 'clean');
+  const tier =
+    blocked.length > 0 ? 'high' : findings.length > 0 ? 'medium' : 'clean';
   return {
     clean: blocked.length === 0 && findings.length === 0,
     findings,
@@ -467,7 +522,10 @@ function wrapUntrustedContent(content, source) {
  * @returns {string} Content with wrapper tags removed, inner content preserved
  */
 function stripUntrustedWrappers(content) {
-  return content.replace(/<untrusted-content[^>]*>([\s\S]*?)<\/untrusted-content>/g, '$1');
+  return content.replace(
+    /<untrusted-content[^>]*>([\s\S]*?)<\/untrusted-content>/g,
+    '$1',
+  );
 }
 
 // ─── logSecurityEvent ────────────────────────────────────────────────────────
@@ -495,7 +553,8 @@ function logSecurityEvent(cwd, eventData) {
     if (process.env.GSD_SECURITY_LOG_DIR) {
       logDir = process.env.GSD_SECURITY_LOG_DIR;
     } else {
-      const runtimeDir = process.env.GSD_RUNTIME === 'copilot' ? '.github' : '.claude';
+      const runtimeDir =
+        process.env.GSD_RUNTIME === 'copilot' ? '.github' : '.claude';
       logDir = path.join(cwd, runtimeDir, 'logs');
     }
     fs.mkdirSync(logDir, { recursive: true });
@@ -575,12 +634,18 @@ function validateFieldName(field) {
   }
 
   if (trimmed.length > 100) {
-    return { valid: false, error: `Field name exceeds 100 character limit (${trimmed.length} chars)` };
+    return {
+      valid: false,
+      error: `Field name exceeds 100 character limit (${trimmed.length} chars)`,
+    };
   }
 
   // YAML key separator — would create nested key injection
   if (trimmed.includes(':')) {
-    return { valid: false, error: 'Field name contains YAML key separator ":"' };
+    return {
+      valid: false,
+      error: 'Field name contains YAML key separator ":"',
+    };
   }
 
   // Newlines — would inject YAML content on next line
@@ -594,18 +659,32 @@ function validateFieldName(field) {
   }
 
   // YAML flow indicators — could break inline mappings/sequences
-  if (trimmed.includes('{') || trimmed.includes('}') || trimmed.includes('[') || trimmed.includes(']')) {
-    return { valid: false, error: 'Field name contains YAML flow indicators ({ } [ ])' };
+  if (
+    trimmed.includes('{') ||
+    trimmed.includes('}') ||
+    trimmed.includes('[') ||
+    trimmed.includes(']')
+  ) {
+    return {
+      valid: false,
+      error: 'Field name contains YAML flow indicators ({ } [ ])',
+    };
   }
 
   // YAML comment character at start
   if (trimmed.startsWith('#')) {
-    return { valid: false, error: 'Field name starts with YAML comment character "#"' };
+    return {
+      valid: false,
+      error: 'Field name starts with YAML comment character "#"',
+    };
   }
 
   // YAML directive at start
   if (trimmed.startsWith('%')) {
-    return { valid: false, error: 'Field name starts with YAML directive character "%"' };
+    return {
+      valid: false,
+      error: 'Field name starts with YAML directive character "%"',
+    };
   }
 
   return { valid: true, normalized: trimmed };
@@ -623,6 +702,6 @@ module.exports = {
   wrapUntrustedContent,
   stripUntrustedWrappers,
   logSecurityEvent,
-  INJECTION_PATTERNS,          // backward compat — 11-element array unchanged
-  INJECTION_PATTERNS_TIERED,   // Phase 40 — tiered patterns with confidence classification
+  INJECTION_PATTERNS, // backward compat — 11-element array unchanged
+  INJECTION_PATTERNS_TIERED, // Phase 40 — tiered patterns with confidence classification
 };

--- a/gsd-ng/bin/lib/state.cjs
+++ b/gsd-ng/bin/lib/state.cjs
@@ -4,8 +4,20 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, getPhaseCompletionStatus, output, error, planningPaths } = require('./core.cjs');
-const { extractFrontmatter, reconstructFrontmatter } = require('./frontmatter.cjs');
+const {
+  escapeRegex,
+  loadConfig,
+  getMilestoneInfo,
+  getMilestonePhaseFilter,
+  getPhaseCompletionStatus,
+  output,
+  error,
+  planningPaths,
+} = require('./core.cjs');
+const {
+  extractFrontmatter,
+  reconstructFrontmatter,
+} = require('./frontmatter.cjs');
 const { scanForInjection, sanitizeForPrompt } = require('./security.cjs');
 
 // Shared helper: extract a field value from STATE.md content.
@@ -25,7 +37,11 @@ function stateExtractField(content, fieldName) {
 
 function cmdStateLoad(cwd) {
   const config = loadConfig(cwd);
-  const { state: stateMdPath, config: configPath, roadmap: roadmapPath } = planningPaths(cwd);
+  const {
+    state: stateMdPath,
+    config: configPath,
+    roadmap: roadmapPath,
+  } = planningPaths(cwd);
 
   let stateRaw = '';
   try {
@@ -88,17 +104,17 @@ function parseSectionContent(content) {
 
   // Return the simplest useful structure
   if (hasItems && !hasFields && textLines.length === 0) {
-    return items;  // Pure bullet list -> array
+    return items; // Pure bullet list -> array
   }
   if (hasFields && !hasItems && textLines.length === 0) {
-    return fields;  // Pure key-value -> object
+    return fields; // Pure key-value -> object
   }
   // Mixed content
   const result = {};
   if (hasItems) result.items = items;
   if (hasFields) result.fields = fields;
   if (textLines.length > 0) result.text = textLines.join('\n');
-  return Object.keys(result).length > 0 ? result : content;  // Fallback to raw string if nothing parsed
+  return Object.keys(result).length > 0 ? result : content; // Fallback to raw string if nothing parsed
 }
 
 function cmdStateGet(cwd, section) {
@@ -132,7 +148,10 @@ function cmdStateGet(cwd, section) {
     }
 
     // Check for ## Section -- parse into structured data
-    const sectionPattern = new RegExp(`##\\s*${fieldEscaped}\\s*\n([\\s\\S]*?)(?=\\n##|$)`, 'i');
+    const sectionPattern = new RegExp(
+      `##\\s*${fieldEscaped}\\s*\n([\\s\\S]*?)(?=\\n##|$)`,
+      'i',
+    );
     const sectionMatch = content.match(sectionPattern);
     if (sectionMatch) {
       const sectionContent = sanitizeForPrompt(sectionMatch[1].trim());
@@ -150,7 +169,9 @@ function cmdStateGet(cwd, section) {
 function readTextArgOrFile(cwd, value, filePath, label) {
   if (!filePath) return value;
 
-  const resolvedPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+  const resolvedPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
   try {
     return fs.readFileSync(resolvedPath, 'utf-8').trimEnd();
   } catch {
@@ -167,14 +188,23 @@ function cmdStatePatch(cwd, patches) {
     for (const [field, value] of Object.entries(patches)) {
       const fieldEscaped = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       // Try **Field:** bold format first, then plain Field: format
-      const boldPattern = new RegExp(`(\\*\\*${fieldEscaped}:\\*\\*\\s*)(.*)`, 'i');
+      const boldPattern = new RegExp(
+        `(\\*\\*${fieldEscaped}:\\*\\*\\s*)(.*)`,
+        'i',
+      );
       const plainPattern = new RegExp(`(^${fieldEscaped}:\\s*)(.*)`, 'im');
 
       if (boldPattern.test(content)) {
-        content = content.replace(boldPattern, (_match, prefix) => `${prefix}${value}`);
+        content = content.replace(
+          boldPattern,
+          (_match, prefix) => `${prefix}${value}`,
+        );
         results.updated.push(field);
       } else if (plainPattern.test(content)) {
-        content = content.replace(plainPattern, (_match, prefix) => `${prefix}${value}`);
+        content = content.replace(
+          plainPattern,
+          (_match, prefix) => `${prefix}${value}`,
+        );
         results.updated.push(field);
       } else {
         results.failed.push(field);
@@ -216,7 +246,10 @@ function cmdStateUpdate(cwd, field, value) {
         process.exitCode = 1;
       }
     } else {
-      output({ updated: false, reason: `Field "${field}" not found in STATE.md` });
+      output({
+        updated: false,
+        reason: `Field "${field}" not found in STATE.md`,
+      });
     }
   } catch {
     output({ updated: false, reason: 'STATE.md not found' });
@@ -241,16 +274,24 @@ function stateExtractField(content, fieldName) {
 function stateReplaceField(content, fieldName, newValue) {
   const frontmatterMatch = content.match(/^---\r?\n[\s\S]*?\r?\n---\r?\n*/);
   const frontmatter = frontmatterMatch ? frontmatterMatch[0] : '';
-  const body = frontmatterMatch ? content.slice(frontmatterMatch[0].length) : content;
+  const body = frontmatterMatch
+    ? content.slice(frontmatterMatch[0].length)
+    : content;
   const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   // Try **Field:** bold format first, then plain Field: format
   const boldPattern = new RegExp(`(\\*\\*${escaped}:\\*\\*\\s*)(.*)`, 'i');
   if (boldPattern.test(body)) {
-    return frontmatter + body.replace(boldPattern, (_match, prefix) => `${prefix}${newValue}`);
+    return (
+      frontmatter +
+      body.replace(boldPattern, (_match, prefix) => `${prefix}${newValue}`)
+    );
   }
   const plainPattern = new RegExp(`(^${escaped}:\\s*)(.*)`, 'im');
   if (plainPattern.test(body)) {
-    return frontmatter + body.replace(plainPattern, (_match, prefix) => `${prefix}${newValue}`);
+    return (
+      frontmatter +
+      body.replace(plainPattern, (_match, prefix) => `${prefix}${newValue}`)
+    );
   }
   return null;
 }
@@ -268,7 +309,10 @@ function stateReplaceFieldWithFallback(content, fieldName, newValue) {
 
 function cmdStateAdvancePlan(cwd) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const today = new Date().toISOString().split('T')[0];
@@ -285,7 +329,9 @@ function cmdStateAdvancePlan(cwd) {
     // For compound format like "02-08", extract the plan number (rightmost digit group)
     // parseInt("02-08", 10) → 2 (WRONG). Use regex to get the trailing number.
     const planNumMatch = legacyPlan.match(/(\d+)$/);
-    currentPlan = planNumMatch ? parseInt(planNumMatch[1], 10) : parseInt(legacyPlan, 10);
+    currentPlan = planNumMatch
+      ? parseInt(planNumMatch[1], 10)
+      : parseInt(legacyPlan, 10);
     totalPlans = parseInt(legacyTotal, 10);
   } else if (planField) {
     // Compound format: "2 of 6 in current phase" or "2 of 6"
@@ -296,22 +342,41 @@ function cmdStateAdvancePlan(cwd) {
   }
 
   if (isNaN(currentPlan) || isNaN(totalPlans)) {
-    output({ error: 'Cannot parse Current Plan or Total Plans in Phase from STATE.md' });
+    output({
+      error: 'Cannot parse Current Plan or Total Plans in Phase from STATE.md',
+    });
     return;
   }
 
   const replaceField = (c, primary, fallback, value) => {
     let r = stateReplaceField(c, primary, value);
     if (r) return r;
-    if (fallback) { r = stateReplaceField(c, fallback, value); if (r) return r; }
+    if (fallback) {
+      r = stateReplaceField(c, fallback, value);
+      if (r) return r;
+    }
     return stateReplaceFieldWithFallback(c, primary, value);
   };
 
   if (currentPlan >= totalPlans) {
-    content = replaceField(content, 'Status', null, 'Phase complete — ready for verification');
+    content = replaceField(
+      content,
+      'Status',
+      null,
+      'Phase complete — ready for verification',
+    );
     content = replaceField(content, 'Last Activity', 'Last activity', today);
     writeStateMd(statePath, content, cwd);
-    output({ advanced: false, reason: 'last_plan', current_plan: currentPlan, total_plans: totalPlans, status: 'ready_for_verification' }, 'false');
+    output(
+      {
+        advanced: false,
+        reason: 'last_plan',
+        current_plan: currentPlan,
+        total_plans: totalPlans,
+        status: 'ready_for_verification',
+      },
+      'false',
+    );
   } else {
     const newPlan = currentPlan + 1;
     if (useCompoundFormat) {
@@ -321,29 +386,44 @@ function cmdStateAdvancePlan(cwd) {
     } else {
       // Preserve original format: "02-08" → "02-09", "08" → "09", "8" → "9"
       const legacyPlanRaw = stateExtractField(content, 'Current Plan');
-      const formatMatch = legacyPlanRaw && legacyPlanRaw.match(/^(\d+-)?(\d+)$/);
+      const formatMatch =
+        legacyPlanRaw && legacyPlanRaw.match(/^(\d+-)?(\d+)$/);
       if (formatMatch) {
         const prefix = formatMatch[1] || '';
         const num = parseInt(formatMatch[2], 10);
         const width = formatMatch[2].length;
         const incremented = String(num + 1).padStart(width, '0');
         const newValue = `${prefix}${incremented}`;
-        content = stateReplaceField(content, 'Current Plan', newValue) || content;
+        content =
+          stateReplaceField(content, 'Current Plan', newValue) || content;
       } else {
         // Non-numeric format — fall back to plain increment
-        content = stateReplaceField(content, 'Current Plan', String(newPlan)) || content;
+        content =
+          stateReplaceField(content, 'Current Plan', String(newPlan)) ||
+          content;
       }
     }
     content = replaceField(content, 'Status', null, 'Ready to execute');
     content = replaceField(content, 'Last Activity', 'Last activity', today);
     writeStateMd(statePath, content, cwd);
-    output({ advanced: true, previous_plan: currentPlan, current_plan: newPlan, total_plans: totalPlans }, 'true');
+    output(
+      {
+        advanced: true,
+        previous_plan: currentPlan,
+        current_plan: newPlan,
+        total_plans: totalPlans,
+      },
+      'true',
+    );
   }
 }
 
 function cmdStateRecordMetric(cwd, options) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const { phase, plan, duration, tasks, files } = options;
@@ -354,7 +434,8 @@ function cmdStateRecordMetric(cwd, options) {
   }
 
   // Find Performance Metrics section and its table
-  const metricsPattern = /(##\s*Performance Metrics[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n)([\s\S]*?)(?=\n##|\n$|$)/i;
+  const metricsPattern =
+    /(##\s*Performance Metrics[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n)([\s\S]*?)(?=\n##|\n$|$)/i;
   const metricsMatch = content.match(metricsPattern);
 
   if (metricsMatch) {
@@ -367,17 +448,29 @@ function cmdStateRecordMetric(cwd, options) {
       tableBody = tableBody + '\n' + newRow;
     }
 
-    content = content.replace(metricsPattern, (_match, header) => `${header}${tableBody}\n`);
+    content = content.replace(
+      metricsPattern,
+      (_match, header) => `${header}${tableBody}\n`,
+    );
     writeStateMd(statePath, content, cwd);
     output({ recorded: true, phase, plan, duration }, 'true');
   } else {
-    output({ recorded: false, reason: 'Performance Metrics section not found in STATE.md' }, 'false');
+    output(
+      {
+        recorded: false,
+        reason: 'Performance Metrics section not found in STATE.md',
+      },
+      'false',
+    );
   }
 }
 
 function cmdStateUpdateProgress(cwd) {
   const { state: statePath, phases: phasesDir } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
 
   let content = fs.readFileSync(statePath, 'utf-8');
 
@@ -387,19 +480,24 @@ function cmdStateUpdateProgress(cwd) {
 
   if (fs.existsSync(phasesDir)) {
     const isDirInMilestone = getMilestonePhaseFilter(cwd);
-    const phaseDirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-      .filter(e => e.isDirectory()).map(e => e.name)
+    const phaseDirs = fs
+      .readdirSync(phasesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
       .filter(isDirInMilestone);
     for (const dir of phaseDirs) {
       const files = fs.readdirSync(path.join(phasesDir, dir));
-      totalPlans += files.filter(f => f.match(/-PLAN\.md$/i)).length;
-      totalSummaries += files.filter(f => f.match(/-SUMMARY\.md$/i)).length;
+      totalPlans += files.filter((f) => f.match(/-PLAN\.md$/i)).length;
+      totalSummaries += files.filter((f) => f.match(/-SUMMARY\.md$/i)).length;
     }
   }
 
-  const percent = totalPlans > 0 ? Math.min(100, Math.round(totalSummaries / totalPlans * 100)) : 0;
+  const percent =
+    totalPlans > 0
+      ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100))
+      : 0;
   const barWidth = 10;
-  const filled = Math.round(percent / 100 * barWidth);
+  const filled = Math.round((percent / 100) * barWidth);
   const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(barWidth - filled);
   const progressStr = `[${bar}] ${percent}%`;
 
@@ -407,21 +505,51 @@ function cmdStateUpdateProgress(cwd) {
   const boldProgressPattern = /(\*\*Progress:\*\*\s*).*/i;
   const plainProgressPattern = /^(Progress:\s*).*/im;
   if (boldProgressPattern.test(content)) {
-    content = content.replace(boldProgressPattern, (_match, prefix) => `${prefix}${progressStr}`);
+    content = content.replace(
+      boldProgressPattern,
+      (_match, prefix) => `${prefix}${progressStr}`,
+    );
     writeStateMd(statePath, content, cwd);
-    output({ updated: true, percent, completed: totalSummaries, total: totalPlans, bar: progressStr }, progressStr);
+    output(
+      {
+        updated: true,
+        percent,
+        completed: totalSummaries,
+        total: totalPlans,
+        bar: progressStr,
+      },
+      progressStr,
+    );
   } else if (plainProgressPattern.test(content)) {
-    content = content.replace(plainProgressPattern, (_match, prefix) => `${prefix}${progressStr}`);
+    content = content.replace(
+      plainProgressPattern,
+      (_match, prefix) => `${prefix}${progressStr}`,
+    );
     writeStateMd(statePath, content, cwd);
-    output({ updated: true, percent, completed: totalSummaries, total: totalPlans, bar: progressStr }, progressStr);
+    output(
+      {
+        updated: true,
+        percent,
+        completed: totalSummaries,
+        total: totalPlans,
+        bar: progressStr,
+      },
+      progressStr,
+    );
   } else {
-    output({ updated: false, reason: 'Progress field not found in STATE.md' }, 'false');
+    output(
+      { updated: false, reason: 'Progress field not found in STATE.md' },
+      'false',
+    );
   }
 }
 
 function cmdStateAddDecision(cwd, options) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
 
   const { phase, summary, summary_file, rationale, rationale_file } = options;
   let summaryText = null;
@@ -429,81 +557,126 @@ function cmdStateAddDecision(cwd, options) {
 
   try {
     summaryText = readTextArgOrFile(cwd, summary, summary_file, 'summary');
-    rationaleText = readTextArgOrFile(cwd, rationale || '', rationale_file, 'rationale');
+    rationaleText = readTextArgOrFile(
+      cwd,
+      rationale || '',
+      rationale_file,
+      'rationale',
+    );
   } catch (err) {
     output({ added: false, reason: err.message }, 'false');
     return;
   }
 
-  if (!summaryText) { output({ error: 'summary required' }); return; }
+  if (!summaryText) {
+    output({ error: 'summary required' });
+    return;
+  }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const entry = `- [Phase ${phase || '?'}]: ${summaryText}${rationaleText ? ` — ${rationaleText}` : ''}`;
 
   // Find Decisions section (various heading patterns)
-  const sectionPattern = /(###?\s*(?:Decisions|Decisions Made|Accumulated.*Decisions)\s*\n)([\s\S]*?)(?=\n###?|\n##[^#]|$)/i;
+  const sectionPattern =
+    /(###?\s*(?:Decisions|Decisions Made|Accumulated.*Decisions)\s*\n)([\s\S]*?)(?=\n###?|\n##[^#]|$)/i;
   const match = content.match(sectionPattern);
 
   if (match) {
     let sectionBody = match[2];
     // Remove placeholders
-    sectionBody = sectionBody.replace(/None yet\.?\s*\n?/gi, '').replace(/No decisions yet\.?\s*\n?/gi, '');
+    sectionBody = sectionBody
+      .replace(/None yet\.?\s*\n?/gi, '')
+      .replace(/No decisions yet\.?\s*\n?/gi, '');
     sectionBody = sectionBody.trimEnd() + '\n' + entry + '\n';
-    content = content.replace(sectionPattern, (_match, header) => `${header}${sectionBody}`);
+    content = content.replace(
+      sectionPattern,
+      (_match, header) => `${header}${sectionBody}`,
+    );
     writeStateMd(statePath, content, cwd);
     output({ added: true, decision: entry }, 'true');
   } else {
-    output({ added: false, reason: 'Decisions section not found in STATE.md' }, 'false');
+    output(
+      { added: false, reason: 'Decisions section not found in STATE.md' },
+      'false',
+    );
   }
 }
 
 function cmdStateAddBlocker(cwd, text) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
-  const blockerOptions = typeof text === 'object' && text !== null ? text : { text };
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
+  const blockerOptions =
+    typeof text === 'object' && text !== null ? text : { text };
   let blockerText = null;
 
   try {
-    blockerText = readTextArgOrFile(cwd, blockerOptions.text, blockerOptions.text_file, 'blocker');
+    blockerText = readTextArgOrFile(
+      cwd,
+      blockerOptions.text,
+      blockerOptions.text_file,
+      'blocker',
+    );
   } catch (err) {
     output({ added: false, reason: err.message }, 'false');
     return;
   }
 
-  if (!blockerText) { output({ error: 'text required' }); return; }
+  if (!blockerText) {
+    output({ error: 'text required' });
+    return;
+  }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const entry = `- ${blockerText}`;
 
-  const sectionPattern = /(###?\s*(?:Blockers|Blockers\/Concerns|Concerns)\s*\n)([\s\S]*?)(?=\n###?|\n##[^#]|$)/i;
+  const sectionPattern =
+    /(###?\s*(?:Blockers|Blockers\/Concerns|Concerns)\s*\n)([\s\S]*?)(?=\n###?|\n##[^#]|$)/i;
   const match = content.match(sectionPattern);
 
   if (match) {
     let sectionBody = match[2];
-    sectionBody = sectionBody.replace(/None\.?\s*\n?/gi, '').replace(/None yet\.?\s*\n?/gi, '');
+    sectionBody = sectionBody
+      .replace(/None\.?\s*\n?/gi, '')
+      .replace(/None yet\.?\s*\n?/gi, '');
     sectionBody = sectionBody.trimEnd() + '\n' + entry + '\n';
-    content = content.replace(sectionPattern, (_match, header) => `${header}${sectionBody}`);
+    content = content.replace(
+      sectionPattern,
+      (_match, header) => `${header}${sectionBody}`,
+    );
     writeStateMd(statePath, content, cwd);
     output({ added: true, blocker: blockerText }, 'true');
   } else {
-    output({ added: false, reason: 'Blockers section not found in STATE.md' }, 'false');
+    output(
+      { added: false, reason: 'Blockers section not found in STATE.md' },
+      'false',
+    );
   }
 }
 
 function cmdStateResolveBlocker(cwd, text) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
-  if (!text) { output({ error: 'text required' }); return; }
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
+  if (!text) {
+    output({ error: 'text required' });
+    return;
+  }
 
   let content = fs.readFileSync(statePath, 'utf-8');
 
-  const sectionPattern = /(###?\s*(?:Blockers|Blockers\/Concerns|Concerns)\s*\n)([\s\S]*?)(?=\n###?|\n##[^#]|$)/i;
+  const sectionPattern =
+    /(###?\s*(?:Blockers|Blockers\/Concerns|Concerns)\s*\n)([\s\S]*?)(?=\n###?|\n##[^#]|$)/i;
   const match = content.match(sectionPattern);
 
   if (match) {
     const sectionBody = match[2];
     const lines = sectionBody.split('\n');
-    const filtered = lines.filter(line => {
+    const filtered = lines.filter((line) => {
       if (!line.startsWith('- ')) return true;
       return !line.toLowerCase().includes(text.toLowerCase());
     });
@@ -514,17 +687,26 @@ function cmdStateResolveBlocker(cwd, text) {
       newBody = 'None\n';
     }
 
-    content = content.replace(sectionPattern, (_match, header) => `${header}${newBody}`);
+    content = content.replace(
+      sectionPattern,
+      (_match, header) => `${header}${newBody}`,
+    );
     writeStateMd(statePath, content, cwd);
     output({ resolved: true, blocker: text }, 'true');
   } else {
-    output({ resolved: false, reason: 'Blockers section not found in STATE.md' }, 'false');
+    output(
+      { resolved: false, reason: 'Blockers section not found in STATE.md' },
+      'false',
+    );
   }
 }
 
 function cmdStateRecordSession(cwd, options) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
 
   let content = fs.readFileSync(statePath, 'utf-8');
   const now = new Date().toISOString();
@@ -532,28 +714,44 @@ function cmdStateRecordSession(cwd, options) {
 
   // Update Last session / Last Date
   let result = stateReplaceField(content, 'Last session', now);
-  if (result) { content = result; updated.push('Last session'); }
+  if (result) {
+    content = result;
+    updated.push('Last session');
+  }
   result = stateReplaceField(content, 'Last Date', now);
-  if (result) { content = result; updated.push('Last Date'); }
+  if (result) {
+    content = result;
+    updated.push('Last Date');
+  }
 
   // Update Stopped at
   if (options.stopped_at) {
     result = stateReplaceField(content, 'Stopped At', options.stopped_at);
-    if (!result) result = stateReplaceField(content, 'Stopped at', options.stopped_at);
-    if (result) { content = result; updated.push('Stopped At'); }
+    if (!result)
+      result = stateReplaceField(content, 'Stopped at', options.stopped_at);
+    if (result) {
+      content = result;
+      updated.push('Stopped At');
+    }
   }
 
   // Update Resume file
   const resumeFile = options.resume_file || 'None';
   result = stateReplaceField(content, 'Resume File', resumeFile);
   if (!result) result = stateReplaceField(content, 'Resume file', resumeFile);
-  if (result) { content = result; updated.push('Resume File'); }
+  if (result) {
+    content = result;
+    updated.push('Resume File');
+  }
 
   if (updated.length > 0) {
     writeStateMd(statePath, content, cwd);
     output({ recorded: true, updated }, 'true');
   } else {
-    output({ recorded: false, reason: 'No session fields found in STATE.md' }, 'false');
+    output(
+      { recorded: false, reason: 'No session fields found in STATE.md' },
+      'false',
+    );
   }
 }
 
@@ -576,7 +774,10 @@ function cmdStateSnapshot(cwd, phaseFilter) {
   const status = stateExtractField(content, 'Status');
   const progressRaw = stateExtractField(content, 'Progress');
   const lastActivity = stateExtractField(content, 'Last Activity');
-  const lastActivityDesc = stateExtractField(content, 'Last Activity Description');
+  const lastActivityDesc = stateExtractField(
+    content,
+    'Last Activity Description',
+  );
   const pausedAt = stateExtractField(content, 'Paused At');
 
   // Load config for git target_branch visibility
@@ -586,16 +787,26 @@ function cmdStateSnapshot(cwd, phaseFilter) {
   // Parse numeric fields
   const totalPhases = totalPhasesRaw ? parseInt(totalPhasesRaw, 10) : null;
   const totalPlansInPhase = totalPlansRaw ? parseInt(totalPlansRaw, 10) : null;
-  const progressPercent = progressRaw ? parseInt(progressRaw.replace('%', ''), 10) : null;
+  const progressPercent = progressRaw
+    ? parseInt(progressRaw.replace('%', ''), 10)
+    : null;
 
   // Extract decisions table
   const decisions = [];
-  const decisionsMatch = content.match(/##\s*Decisions Made[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n([\s\S]*?)(?=\n##|\n$|$)/i);
+  const decisionsMatch = content.match(
+    /##\s*Decisions Made[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n([\s\S]*?)(?=\n##|\n$|$)/i,
+  );
   if (decisionsMatch) {
     const tableBody = decisionsMatch[1];
-    const rows = tableBody.trim().split('\n').filter(r => r.includes('|'));
+    const rows = tableBody
+      .trim()
+      .split('\n')
+      .filter((r) => r.includes('|'));
     for (const row of rows) {
-      const cells = row.split('|').map(c => c.trim()).filter(Boolean);
+      const cells = row
+        .split('|')
+        .map((c) => c.trim())
+        .filter(Boolean);
       if (cells.length >= 3) {
         decisions.push({
           phase: cells[0],
@@ -608,7 +819,9 @@ function cmdStateSnapshot(cwd, phaseFilter) {
 
   // Extract blockers list
   const blockers = [];
-  const blockersMatch = content.match(/##\s*Blockers\s*\n([\s\S]*?)(?=\n##|$)/i);
+  const blockersMatch = content.match(
+    /##\s*Blockers\s*\n([\s\S]*?)(?=\n##|$)/i,
+  );
   if (blockersMatch) {
     const blockersSection = blockersMatch[1];
     const items = blockersSection.match(/^-\s+(.+)$/gm) || [];
@@ -627,12 +840,15 @@ function cmdStateSnapshot(cwd, phaseFilter) {
   const sessionMatch = content.match(/##\s*Session\s*\n([\s\S]*?)(?=\n##|$)/i);
   if (sessionMatch) {
     const sessionSection = sessionMatch[1];
-    const lastDateMatch = sessionSection.match(/\*\*Last Date:\*\*\s*(.+)/i)
-      || sessionSection.match(/^Last Date:\s*(.+)/im);
-    const stoppedAtMatch = sessionSection.match(/\*\*Stopped At:\*\*\s*(.+)/i)
-      || sessionSection.match(/^Stopped At:\s*(.+)/im);
-    const resumeFileMatch = sessionSection.match(/\*\*Resume File:\*\*\s*(.+)/i)
-      || sessionSection.match(/^Resume File:\s*(.+)/im);
+    const lastDateMatch =
+      sessionSection.match(/\*\*Last Date:\*\*\s*(.+)/i) ||
+      sessionSection.match(/^Last Date:\s*(.+)/im);
+    const stoppedAtMatch =
+      sessionSection.match(/\*\*Stopped At:\*\*\s*(.+)/i) ||
+      sessionSection.match(/^Stopped At:\s*(.+)/im);
+    const resumeFileMatch =
+      sessionSection.match(/\*\*Resume File:\*\*\s*(.+)/i) ||
+      sessionSection.match(/^Resume File:\s*(.+)/im);
 
     if (lastDateMatch) session.last_date = lastDateMatch[1].trim();
     if (stoppedAtMatch) session.stopped_at = stoppedAtMatch[1].trim();
@@ -640,7 +856,9 @@ function cmdStateSnapshot(cwd, phaseFilter) {
   }
 
   const filteredDecisions = phaseFilter
-    ? decisions.filter(d => d.phase === phaseFilter || d.phase === String(phaseFilter))
+    ? decisions.filter(
+        (d) => d.phase === phaseFilter || d.phase === String(phaseFilter),
+      )
     : decisions;
 
   const result = {
@@ -679,7 +897,9 @@ function buildStateFrontmatter(bodyContent, cwd) {
   const status = stateExtractField(bodyContent, 'Status');
   const progressRaw = stateExtractField(bodyContent, 'Progress');
   const lastActivity = stateExtractField(bodyContent, 'Last Activity');
-  const stoppedAt = stateExtractField(bodyContent, 'Stopped At') || stateExtractField(bodyContent, 'Stopped at');
+  const stoppedAt =
+    stateExtractField(bodyContent, 'Stopped At') ||
+    stateExtractField(bodyContent, 'Stopped at');
   const pausedAt = stateExtractField(bodyContent, 'Paused At');
 
   let milestone = null;
@@ -702,8 +922,10 @@ function buildStateFrontmatter(bodyContent, cwd) {
       const { phases: phasesDir } = planningPaths(cwd);
       if (fs.existsSync(phasesDir)) {
         const isDirInMilestone = getMilestonePhaseFilter(cwd);
-        const phaseDirs = fs.readdirSync(phasesDir, { withFileTypes: true })
-          .filter(e => e.isDirectory()).map(e => e.name)
+        const phaseDirs = fs
+          .readdirSync(phasesDir, { withFileTypes: true })
+          .filter((e) => e.isDirectory())
+          .map((e) => e.name)
           .filter(isDirInMilestone);
         let diskTotalPlans = 0;
         let diskTotalSummaries = 0;
@@ -713,15 +935,18 @@ function buildStateFrontmatter(bodyContent, cwd) {
           const dirPath = path.join(phasesDir, dir);
           const { isComplete } = getPhaseCompletionStatus(dirPath);
           const files = fs.readdirSync(dirPath);
-          const plans = files.filter(f => f.match(/-PLAN\.md$/i)).length;
-          const summaries = files.filter(f => f.match(/-SUMMARY\.md$/i)).length;
+          const plans = files.filter((f) => f.match(/-PLAN\.md$/i)).length;
+          const summaries = files.filter((f) =>
+            f.match(/-SUMMARY\.md$/i),
+          ).length;
           diskTotalPlans += plans;
           diskTotalSummaries += summaries;
           if (isComplete) diskCompletedPhases++;
         }
-        totalPhases = isDirInMilestone.phaseCount > 0
-          ? Math.max(phaseDirs.length, isDirInMilestone.phaseCount)
-          : phaseDirs.length;
+        totalPhases =
+          isDirInMilestone.phaseCount > 0
+            ? Math.max(phaseDirs.length, isDirInMilestone.phaseCount)
+            : phaseDirs.length;
         completedPhases = diskCompletedPhases;
         totalPlans = diskTotalPlans;
         completedPlans = diskTotalSummaries;
@@ -740,15 +965,30 @@ function buildStateFrontmatter(bodyContent, cwd) {
   // "unverified" → "verifying"). Only exact or well-known prefix forms are normalized.
   let normalizedStatus = status || 'unknown';
   const statusLower = (status || '').toLowerCase().trim();
-  if (statusLower === 'paused' || statusLower === 'stopped' || statusLower.startsWith('paused ') || pausedAt) {
+  if (
+    statusLower === 'paused' ||
+    statusLower === 'stopped' ||
+    statusLower.startsWith('paused ') ||
+    pausedAt
+  ) {
     normalizedStatus = 'paused';
-  } else if (statusLower === 'executing' || statusLower === 'in progress' || statusLower.startsWith('executing ')) {
+  } else if (
+    statusLower === 'executing' ||
+    statusLower === 'in progress' ||
+    statusLower.startsWith('executing ')
+  ) {
     normalizedStatus = 'executing';
   } else if (statusLower === 'planning' || statusLower === 'ready to plan') {
     normalizedStatus = 'planning';
-  } else if (statusLower === 'discussing' || statusLower.startsWith('discussing ')) {
+  } else if (
+    statusLower === 'discussing' ||
+    statusLower.startsWith('discussing ')
+  ) {
     normalizedStatus = 'discussing';
-  } else if (statusLower === 'verifying' || statusLower.startsWith('verifying ')) {
+  } else if (
+    statusLower === 'verifying' ||
+    statusLower.startsWith('verifying ')
+  ) {
     normalizedStatus = 'verifying';
   } else if (statusLower === 'completed' || statusLower === 'done') {
     normalizedStatus = 'completed';
@@ -794,7 +1034,11 @@ function syncStateFrontmatter(content, cwd) {
   // Preserve existing frontmatter status when body-derived status is 'unknown'.
   // This prevents a missing Status: field in the body from overwriting a
   // previously valid status (e.g., 'executing' → 'unknown').
-  if (derivedFm.status === 'unknown' && existingFm.status && existingFm.status !== 'unknown') {
+  if (
+    derivedFm.status === 'unknown' &&
+    existingFm.status &&
+    existingFm.status !== 'unknown'
+  ) {
     derivedFm.status = existingFm.status;
   }
 
@@ -812,7 +1056,7 @@ function writeStateMd(statePath, content, cwd) {
   const { clean, findings } = scanForInjection(content);
   if (!clean) {
     process.stderr.write(
-      `[security] Advisory: potential injection in STATE.md: ${findings.join('; ')}\n`
+      `[security] Advisory: potential injection in STATE.md: ${findings.join('; ')}\n`,
     );
   }
   // Transparent write — no implicit frontmatter sync.
@@ -822,7 +1066,10 @@ function writeStateMd(statePath, content, cwd) {
 
 function cmdStateRebuildFrontmatter(cwd) {
   const { state: statePath } = planningPaths(cwd);
-  if (!fs.existsSync(statePath)) { output({ error: 'STATE.md not found' }); return; }
+  if (!fs.existsSync(statePath)) {
+    output({ error: 'STATE.md not found' });
+    return;
+  }
   let content = fs.readFileSync(statePath, 'utf-8');
   const synced = syncStateFrontmatter(content, cwd);
   fs.writeFileSync(statePath, synced, 'utf-8');
@@ -864,7 +1111,10 @@ function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount) {
   }
 
   if (!phaseNumber || !phaseName || !planCount) {
-    output({ updated: false, error: '--phase, --name, and --plans are required' });
+    output({
+      updated: false,
+      error: '--phase, --name, and --plans are required',
+    });
     return;
   }
 
@@ -894,21 +1144,37 @@ function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount) {
   }
 
   // Update ## Current Position section body
-  const positionSectionPattern = /(##\s*Current Position\s*\n)([\s\S]*?)(?=\n##|$)/i;
+  const positionSectionPattern =
+    /(##\s*Current Position\s*\n)([\s\S]*?)(?=\n##|$)/i;
   const positionBody = `\nPhase ${phaseNum} of ?? (${phaseName}) — In Progress\nPlan: 1 of ${planCount} — executing\nStatus: Phase ${phaseNum} starting — ${phaseName}\n`;
   if (positionSectionPattern.test(content)) {
-    content = content.replace(positionSectionPattern, (_match, header) => `${header}${positionBody}`);
+    content = content.replace(
+      positionSectionPattern,
+      (_match, header) => `${header}${positionBody}`,
+    );
   }
 
   // Update ## Current focus section body
   const focusSectionPattern = /(##\s*Current focus\s*\n)([\s\S]*?)(?=\n##|$)/i;
   const focusBody = `\n${phaseName} — ${planCount} plan${planCount !== 1 ? 's' : ''} to execute\n`;
   if (focusSectionPattern.test(content)) {
-    content = content.replace(focusSectionPattern, (_match, header) => `${header}${focusBody}`);
+    content = content.replace(
+      focusSectionPattern,
+      (_match, header) => `${header}${focusBody}`,
+    );
   }
 
   writeStateMd(statePath, content, cwd);
-  output({ updated: true, phase: phaseNum, name: phaseName, plans: planCount, failed }, 'true');
+  output(
+    {
+      updated: true,
+      phase: phaseNum,
+      name: phaseName,
+      plans: planCount,
+      failed,
+    },
+    'true',
+  );
 }
 
 /**
@@ -929,41 +1195,66 @@ function adjustQuickTable(cwd) {
   try {
     content = fs.readFileSync(statePath, 'utf-8');
   } catch {
-    return { adjusted: false, reason: 'section_not_found', table_has_status: false };
+    return {
+      adjusted: false,
+      reason: 'section_not_found',
+      table_has_status: false,
+    };
   }
 
   // Find the ### Quick Tasks Completed section
   const sectionMatch = content.match(/###\s*Quick Tasks Completed\s*\n/i);
   if (!sectionMatch) {
-    return { adjusted: false, reason: 'section_not_found', table_has_status: false };
+    return {
+      adjusted: false,
+      reason: 'section_not_found',
+      table_has_status: false,
+    };
   }
 
   // Find the first table row after the section heading (the header row)
-  const afterSection = content.slice(sectionMatch.index + sectionMatch[0].length);
+  const afterSection = content.slice(
+    sectionMatch.index + sectionMatch[0].length,
+  );
   const lines = afterSection.split('\n');
 
   // Find the header line (first line starting with |)
-  const headerIdx = lines.findIndex(l => l.trimStart().startsWith('|'));
+  const headerIdx = lines.findIndex((l) => l.trimStart().startsWith('|'));
   if (headerIdx === -1) {
     // Section exists but has no table
-    return { adjusted: false, reason: 'section_not_found', table_has_status: false };
+    return {
+      adjusted: false,
+      reason: 'section_not_found',
+      table_has_status: false,
+    };
   }
 
   const headerLine = lines[headerIdx];
   // Split header by | and get cell names (trim whitespace)
-  const headerCells = headerLine.split('|').map(c => c.trim()).filter(c => c !== '');
+  const headerCells = headerLine
+    .split('|')
+    .map((c) => c.trim())
+    .filter((c) => c !== '');
 
   // Check if Status column already exists (case-insensitive)
-  const hasStatus = headerCells.some(c => c.toLowerCase() === 'status');
+  const hasStatus = headerCells.some((c) => c.toLowerCase() === 'status');
   if (hasStatus) {
-    return { adjusted: false, reason: 'already_has_status', table_has_status: true };
+    return {
+      adjusted: false,
+      reason: 'already_has_status',
+      table_has_status: true,
+    };
   }
 
   // Find the index of the Directory column in header cells
-  const dirIdx = headerCells.findIndex(c => c.toLowerCase() === 'directory');
+  const dirIdx = headerCells.findIndex((c) => c.toLowerCase() === 'directory');
   if (dirIdx === -1) {
     // Can't find where to insert — treat as already adjusted or unknown
-    return { adjusted: false, reason: 'directory_not_found', table_has_status: false };
+    return {
+      adjusted: false,
+      reason: 'directory_not_found',
+      table_has_status: false,
+    };
   }
 
   // Helper: insert a cell value before the Directory column in a table row string
@@ -984,8 +1275,14 @@ function adjustQuickTable(cwd) {
   newLines[headerIdx] = insertCellBeforeDir(headerLine, ' Status ');
 
   // Check next line — should be the separator row (contains ---)
-  if (headerIdx + 1 < lines.length && lines[headerIdx + 1].trimStart().startsWith('|')) {
-    newLines[headerIdx + 1] = insertCellBeforeDir(lines[headerIdx + 1], '--------');
+  if (
+    headerIdx + 1 < lines.length &&
+    lines[headerIdx + 1].trimStart().startsWith('|')
+  ) {
+    newLines[headerIdx + 1] = insertCellBeforeDir(
+      lines[headerIdx + 1],
+      '--------',
+    );
   }
 
   // Migrate all subsequent data rows
@@ -997,7 +1294,9 @@ function adjustQuickTable(cwd) {
 
   // Reconstruct content: replace the afterSection portion
   const updatedAfterSection = newLines.join('\n');
-  const updatedContent = content.slice(0, sectionMatch.index + sectionMatch[0].length) + updatedAfterSection;
+  const updatedContent =
+    content.slice(0, sectionMatch.index + sectionMatch[0].length) +
+    updatedAfterSection;
 
   writeStateMd(statePath, updatedContent, cwd);
   return { adjusted: true, table_has_status: true };

--- a/gsd-ng/bin/lib/template-processor.cjs
+++ b/gsd-ng/bin/lib/template-processor.cjs
@@ -33,7 +33,10 @@ function processTemplate(content, context) {
 
   // 2. Resolve conditional blocks
   for (const rt of Object.keys(RUNTIMES)) {
-    const regex = new RegExp('<!-- ONLY:' + rt + ' -->([\\s\\S]*?)<!-- /ONLY:' + rt + ' -->', 'g');
+    const regex = new RegExp(
+      '<!-- ONLY:' + rt + ' -->([\\s\\S]*?)<!-- /ONLY:' + rt + ' -->',
+      'g',
+    );
     if (rt === context.runtime) {
       out = out.replace(regex, (_, inner) => inner);
     } else {
@@ -73,7 +76,15 @@ function validateMarkers(content) {
   const allKeys = new Set(Object.keys(opens).concat(Object.keys(closes)));
   for (const key of allKeys) {
     if ((opens[key] || 0) !== (closes[key] || 0)) {
-      throw new Error('Unbalanced ONLY:' + key + ' markers: ' + (opens[key] || 0) + ' opens, ' + (closes[key] || 0) + ' closes');
+      throw new Error(
+        'Unbalanced ONLY:' +
+          key +
+          ' markers: ' +
+          (opens[key] || 0) +
+          ' opens, ' +
+          (closes[key] || 0) +
+          ' closes',
+      );
     }
   }
 }
@@ -137,13 +148,21 @@ function fillBetweenMarkers(filePath, templatePath, startMarker, endMarker) {
   const template = fs.readFileSync(templatePath, 'utf8');
   const tStart = template.indexOf(startMarker);
   const tEnd = template.indexOf(endMarker);
-  const innerContent = (tStart !== -1 && tEnd !== -1)
-    ? template.slice(tStart + startMarker.length, tEnd)
-    : '\n' + template.trim() + '\n';
+  const innerContent =
+    tStart !== -1 && tEnd !== -1
+      ? template.slice(tStart + startMarker.length, tEnd)
+      : '\n' + template.trim() + '\n';
 
   const before = existing.slice(0, startIdx + startMarker.length);
   const after = existing.slice(endIdx);
   fs.writeFileSync(filePath, before + innerContent + after, 'utf8');
 }
 
-module.exports = { processTemplate, validateMarkers, buildContext, RUNTIMES, injectAppendToFile, fillBetweenMarkers };
+module.exports = {
+  processTemplate,
+  validateMarkers,
+  buildContext,
+  RUNTIMES,
+  injectAppendToFile,
+  fillBetweenMarkers,
+};

--- a/gsd-ng/bin/lib/template.cjs
+++ b/gsd-ng/bin/lib/template.cjs
@@ -4,7 +4,14 @@
 
 const fs = require('fs');
 const path = require('path');
-const { normalizePhaseName, findPhaseInternal, generateSlugInternal, toPosixPath, output, error } = require('./core.cjs');
+const {
+  normalizePhaseName,
+  findPhaseInternal,
+  generateSlugInternal,
+  toPosixPath,
+  output,
+  error,
+} = require('./core.cjs');
 const { reconstructFrontmatter } = require('./frontmatter.cjs');
 
 function cmdTemplateSelect(cwd, planPath) {
@@ -49,16 +56,30 @@ function cmdTemplateSelect(cwd, planPath) {
     output(result, template);
   } catch (e) {
     // Fallback to standard
-    output({ template: 'templates/summary-standard.md', type: 'standard', error: e.message }, 'templates/summary-standard.md');
+    output(
+      {
+        template: 'templates/summary-standard.md',
+        type: 'standard',
+        error: e.message,
+      },
+      'templates/summary-standard.md',
+    );
   }
 }
 
 function cmdTemplateFill(cwd, templateType, options) {
-  if (!templateType) { error('template type required: summary, plan, or verification'); }
-  if (!options.phase) { error('--phase required'); }
+  if (!templateType) {
+    error('template type required: summary, plan, or verification');
+  }
+  if (!options.phase) {
+    error('--phase required');
+  }
 
   const phaseInfo = findPhaseInternal(cwd, options.phase);
-  if (!phaseInfo || !phaseInfo.found) { output({ error: 'Phase not found', phase: options.phase }); return; }
+  if (!phaseInfo || !phaseInfo.found) {
+    output({ error: 'Phase not found', phase: options.phase });
+    return;
+  }
 
   const padded = normalizePhaseName(options.phase);
   const today = new Date().toISOString().split('T')[0];
@@ -111,7 +132,7 @@ function cmdTemplateFill(cwd, templateType, options) {
         '[Key decisions or "None - followed plan as specified"]',
         '',
         '## Next Phase Readiness',
-        '[What\'s ready for next phase]',
+        "[What's ready for next phase]",
       ].join('\n');
       fileName = `${padded}-${planNum}-SUMMARY.md`;
       break;
@@ -202,7 +223,9 @@ function cmdTemplateFill(cwd, templateType, options) {
       break;
     }
     default:
-      error(`Unknown template type: ${templateType}. Available: summary, plan, verification`);
+      error(
+        `Unknown template type: ${templateType}. Available: summary, plan, verification`,
+      );
       return;
   }
 
@@ -210,7 +233,10 @@ function cmdTemplateFill(cwd, templateType, options) {
   const outPath = path.join(cwd, phaseInfo.directory, fileName);
 
   if (fs.existsSync(outPath)) {
-    output({ error: 'File already exists', path: toPosixPath(path.relative(cwd, outPath)) });
+    output({
+      error: 'File already exists',
+      path: toPosixPath(path.relative(cwd, outPath)),
+    });
     return;
   }
 

--- a/gsd-ng/bin/lib/test-baseline.cjs
+++ b/gsd-ng/bin/lib/test-baseline.cjs
@@ -29,7 +29,12 @@ function captureBaseline(entriesJson, outputFile) {
     let exitCode = 0;
     let output = '';
     try {
-      output = execSync(command, { cwd: runDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 120000 });
+      output = execSync(command, {
+        cwd: runDir,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 120000,
+      });
     } catch (err) {
       exitCode = err.status || 1;
       output = (err.stdout || '') + (err.stderr || '');
@@ -44,7 +49,7 @@ function captureBaseline(entriesJson, outputFile) {
       exit_code: exitCode,
       tests: testsMatch ? parseInt(testsMatch[1]) : null,
       pass: passMatch ? parseInt(passMatch[1]) : null,
-      fail: failMatch ? parseInt(failMatch[1]) : null
+      fail: failMatch ? parseInt(failMatch[1]) : null,
     };
     const status = exitCode === 0 ? 'passing' : 'failing (pre-existing)';
     console.log('  ' + dir + ': ' + status);
@@ -66,7 +71,9 @@ function compareBaseline(entriesJson, baselineFile) {
   const entries = JSON.parse(entriesJson);
   const cwd = process.cwd();
   let baselines = {};
-  try { baselines = JSON.parse(fs.readFileSync(baselineFile, 'utf-8')); } catch {}
+  try {
+    baselines = JSON.parse(fs.readFileSync(baselineFile, 'utf-8'));
+  } catch {}
 
   const results = [];
   let hasNewFailure = false;
@@ -76,14 +83,24 @@ function compareBaseline(entriesJson, baselineFile) {
     let exitCode = 0;
     let output = '';
     try {
-      output = execSync(command, { cwd: runDir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 120000 });
+      output = execSync(command, {
+        cwd: runDir,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 120000,
+      });
     } catch (err) {
       exitCode = err.status || 1;
       output = (err.stdout || '') + (err.stderr || '');
     }
 
     const baseline = baselines[dir] || { exit_code: -1 };
-    const baselineStatus = baseline.exit_code === 0 ? 'pass' : (baseline.exit_code === -1 ? 'none' : 'fail');
+    const baselineStatus =
+      baseline.exit_code === 0
+        ? 'pass'
+        : baseline.exit_code === -1
+          ? 'none'
+          : 'fail';
     const postStatus = exitCode === 0 ? 'pass' : 'fail';
     const isNew = postStatus === 'fail' && baselineStatus !== 'fail';
     if (isNew) hasNewFailure = true;
@@ -92,9 +109,22 @@ function compareBaseline(entriesJson, baselineFile) {
     const postTestsMatch = output.match(/^# tests (\d+)/m);
     const postTests = postTestsMatch ? parseInt(postTestsMatch[1]) : null;
     const baselineTests = baseline.tests;
-    const countDiff = (baselineTests != null && postTests != null) ? (postTests - baselineTests) : null;
+    const countDiff =
+      baselineTests != null && postTests != null
+        ? postTests - baselineTests
+        : null;
 
-    results.push({ dir, command, baseline: baselineStatus, post: postStatus, isNew, output: output.slice(-2000), baselineTests, postTests, countDiff });
+    results.push({
+      dir,
+      command,
+      baseline: baselineStatus,
+      post: postStatus,
+      isNew,
+      output: output.slice(-2000),
+      baselineTests,
+      postTests,
+      countDiff,
+    });
   }
 
   // Emit GSD banner
@@ -106,28 +136,80 @@ function compareBaseline(entriesJson, baselineFile) {
 
   // Table header
   const pad = (s, n) => s.padEnd(n);
-  const maxDir = Math.max(10, ...results.map(r => r.dir.length));
-  const maxCmd = Math.max(8, ...results.map(r => r.command.length));
-  console.log('| ' + pad('Directory', maxDir) + ' | ' + pad('Command', maxCmd) + ' | Baseline | Pre-UAT  |');
-  console.log('|' + '-'.repeat(maxDir + 2) + '|' + '-'.repeat(maxCmd + 2) + '|----------|----------|');
+  const maxDir = Math.max(10, ...results.map((r) => r.dir.length));
+  const maxCmd = Math.max(8, ...results.map((r) => r.command.length));
+  console.log(
+    '| ' +
+      pad('Directory', maxDir) +
+      ' | ' +
+      pad('Command', maxCmd) +
+      ' | Baseline | Pre-UAT  |',
+  );
+  console.log(
+    '|' +
+      '-'.repeat(maxDir + 2) +
+      '|' +
+      '-'.repeat(maxCmd + 2) +
+      '|----------|----------|',
+  );
   for (const r of results) {
-    const bMark = r.baseline === 'pass' ? '\u2713 pass' : (r.baseline === 'none' ? '- none' : '\u2717 fail');
+    const bMark =
+      r.baseline === 'pass'
+        ? '\u2713 pass'
+        : r.baseline === 'none'
+          ? '- none'
+          : '\u2717 fail';
     const pMark = r.post === 'pass' ? '\u2713 pass' : '\u2717 fail';
-    console.log('| ' + pad(r.dir, maxDir) + ' | ' + pad(r.command, maxCmd) + ' | ' + pad(bMark, 8) + ' | ' + pad(pMark, 8) + ' |');
+    console.log(
+      '| ' +
+        pad(r.dir, maxDir) +
+        ' | ' +
+        pad(r.command, maxCmd) +
+        ' | ' +
+        pad(bMark, 8) +
+        ' | ' +
+        pad(pMark, 8) +
+        ' |',
+    );
   }
 
-  const passing = results.filter(r => r.post === 'pass').length;
-  const preExisting = results.filter(r => r.post === 'fail' && !r.isNew).length;
+  const passing = results.filter((r) => r.post === 'pass').length;
+  const preExisting = results.filter(
+    (r) => r.post === 'fail' && !r.isNew,
+  ).length;
   console.log('');
-  console.log('Overall: ' + passing + '/' + results.length + ' passing' + (preExisting > 0 ? '  (pre-existing failures: ' + preExisting + ')' : ''));
+  console.log(
+    'Overall: ' +
+      passing +
+      '/' +
+      results.length +
+      ' passing' +
+      (preExisting > 0 ? '  (pre-existing failures: ' + preExisting + ')' : ''),
+  );
 
   // Display test count changes (only when count data available)
   for (const r of results) {
     if (r.countDiff !== null) {
       if (r.countDiff > 0) {
-        console.log('Tests: ' + r.baselineTests + ' \u2192 ' + r.postTests + ' (+' + r.countDiff + ')');
+        console.log(
+          'Tests: ' +
+            r.baselineTests +
+            ' \u2192 ' +
+            r.postTests +
+            ' (+' +
+            r.countDiff +
+            ')',
+        );
       } else if (r.countDiff < 0) {
-        console.log('Tests: ' + r.baselineTests + ' \u2192 ' + r.postTests + ' (' + r.countDiff + ' \u26a0 count dropped)');
+        console.log(
+          'Tests: ' +
+            r.baselineTests +
+            ' \u2192 ' +
+            r.postTests +
+            ' (' +
+            r.countDiff +
+            ' \u26a0 count dropped)',
+        );
       }
       // countDiff === 0: no output (unchanged, expected case)
     }
@@ -137,7 +219,7 @@ function compareBaseline(entriesJson, baselineFile) {
   // Output summary for triage decision
   if (hasNewFailure) {
     console.log('NEW_FAILURES=true');
-    for (const r of results.filter(x => x.isNew)) {
+    for (const r of results.filter((x) => x.isNew)) {
       console.log('');
       console.log('New failure in ' + r.dir + ':');
       console.log(r.output);

--- a/gsd-ng/bin/lib/verify.cjs
+++ b/gsd-ng/bin/lib/verify.cjs
@@ -5,12 +5,30 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { safeReadFile, normalizePhaseName, execGit, findPhaseInternal, getMilestoneInfo, extractCurrentMilestone, output, error, planningPaths } = require('./core.cjs');
+const {
+  safeReadFile,
+  normalizePhaseName,
+  execGit,
+  findPhaseInternal,
+  getMilestoneInfo,
+  extractCurrentMilestone,
+  output,
+  error,
+  planningPaths,
+} = require('./core.cjs');
 const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 const { RUNTIMES } = require('./template-processor.cjs');
-const { extractFrontmatter, spliceFrontmatter, parseMustHavesBlock } = require('./frontmatter.cjs');
+const {
+  extractFrontmatter,
+  spliceFrontmatter,
+  parseMustHavesBlock,
+} = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
-const { detectWorkspaceType, generateMemoriesSection, generateMemoryMd } = require('./workspace.cjs');
+const {
+  detectWorkspaceType,
+  generateMemoriesSection,
+  generateMemoryMd,
+} = require('./workspace.cjs');
 
 function cmdVerifySummary(cwd, summaryPath, checkFileCount) {
   if (!summaryPath) {
@@ -80,7 +98,8 @@ function cmdVerifySummary(cwd, summaryPath, checkFileCount) {
 
   // Check 4: Self-check section
   let selfCheck = 'not_found';
-  const selfCheckPattern = /##\s*(?:Self[- ]?Check|Verification|Quality Check)/i;
+  const selfCheckPattern =
+    /##\s*(?:Self[- ]?Check|Verification|Quality Check)/i;
   if (selfCheckPattern.test(content)) {
     const passPattern = /(?:all\s+)?(?:pass|✓|✅|complete|succeeded)/i;
     const failPattern = /(?:fail|✗|❌|incomplete|blocked)/i;
@@ -93,12 +112,18 @@ function cmdVerifySummary(cwd, summaryPath, checkFileCount) {
   }
 
   if (missing.length > 0) errors.push('Missing files: ' + missing.join(', '));
-  if (!commitsExist && hashes.length > 0) errors.push('Referenced commit hashes not found in git history');
-  if (selfCheck === 'failed') errors.push('Self-check section indicates failure');
+  if (!commitsExist && hashes.length > 0)
+    errors.push('Referenced commit hashes not found in git history');
+  if (selfCheck === 'failed')
+    errors.push('Self-check section indicates failure');
 
   const checks = {
     summary_exists: true,
-    files_created: { checked: filesToCheck.length, found: filesToCheck.length - missing.length, missing },
+    files_created: {
+      checked: filesToCheck.length,
+      found: filesToCheck.length - missing.length,
+      missing,
+    },
     commits_exist: commitsExist,
     self_check: selfCheck,
   };
@@ -109,19 +134,36 @@ function cmdVerifySummary(cwd, summaryPath, checkFileCount) {
 }
 
 function cmdVerifyPlanStructure(cwd, filePath) {
-  if (!filePath) { error('file path required'); }
-  const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+  if (!filePath) {
+    error('file path required');
+  }
+  const fullPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: filePath }); return; }
+  if (!content) {
+    output({ error: 'File not found', path: filePath });
+    return;
+  }
 
   const fm = extractFrontmatter(content);
   const errors = [];
   const warnings = [];
 
   // Check required frontmatter fields
-  const required = ['phase', 'plan', 'type', 'wave', 'depends_on', 'files_modified', 'autonomous', 'must_haves'];
+  const required = [
+    'phase',
+    'plan',
+    'type',
+    'wave',
+    'depends_on',
+    'files_modified',
+    'autonomous',
+    'must_haves',
+  ];
   for (const field of required) {
-    if (fm[field] === undefined) errors.push(`Missing required frontmatter field: ${field}`);
+    if (fm[field] === undefined)
+      errors.push(`Missing required frontmatter field: ${field}`);
   }
 
   // Parse and check task elements
@@ -149,7 +191,12 @@ function cmdVerifyPlanStructure(cwd, filePath) {
   if (tasks.length === 0) warnings.push('No <task> elements found');
 
   // Wave/depends_on consistency
-  if (fm.wave && parseInt(fm.wave) > 1 && (!fm.depends_on || (Array.isArray(fm.depends_on) && fm.depends_on.length === 0))) {
+  if (
+    fm.wave &&
+    parseInt(fm.wave) > 1 &&
+    (!fm.depends_on ||
+      (Array.isArray(fm.depends_on) && fm.depends_on.length === 0))
+  ) {
     warnings.push('Wave > 1 but depends_on is empty');
   }
 
@@ -159,18 +206,23 @@ function cmdVerifyPlanStructure(cwd, filePath) {
     errors.push('Has checkpoint tasks but autonomous is not false');
   }
 
-  output({
-    valid: errors.length === 0,
-    errors,
-    warnings,
-    task_count: tasks.length,
-    tasks,
-    frontmatter_fields: Object.keys(fm),
-  }, errors.length === 0 ? 'valid' : 'invalid');
+  output(
+    {
+      valid: errors.length === 0,
+      errors,
+      warnings,
+      task_count: tasks.length,
+      tasks,
+      frontmatter_fields: Object.keys(fm),
+    },
+    errors.length === 0 ? 'valid' : 'invalid',
+  );
 }
 
 function cmdVerifyPhaseCompleteness(cwd, phase) {
-  if (!phase) { error('phase required'); }
+  if (!phase) {
+    error('phase required');
+  }
   const phaseInfo = findPhaseInternal(cwd, phase);
   if (!phaseInfo || !phaseInfo.found) {
     output({ error: 'Phase not found', phase });
@@ -183,44 +235,61 @@ function cmdVerifyPhaseCompleteness(cwd, phase) {
 
   // List plans and summaries
   let files;
-  try { files = fs.readdirSync(phaseDir); } catch { output({ error: 'Cannot read phase directory' }); return; }
+  try {
+    files = fs.readdirSync(phaseDir);
+  } catch {
+    output({ error: 'Cannot read phase directory' });
+    return;
+  }
 
-  const plans = files.filter(f => f.match(/-PLAN\.md$/i));
-  const summaries = files.filter(f => f.match(/-SUMMARY\.md$/i));
+  const plans = files.filter((f) => f.match(/-PLAN\.md$/i));
+  const summaries = files.filter((f) => f.match(/-SUMMARY\.md$/i));
 
   // Extract plan IDs (everything before -PLAN.md)
-  const planIds = new Set(plans.map(p => p.replace(/-PLAN\.md$/i, '')));
-  const summaryIds = new Set(summaries.map(s => s.replace(/-SUMMARY\.md$/i, '')));
+  const planIds = new Set(plans.map((p) => p.replace(/-PLAN\.md$/i, '')));
+  const summaryIds = new Set(
+    summaries.map((s) => s.replace(/-SUMMARY\.md$/i, '')),
+  );
 
   // Plans without summaries
-  const incompletePlans = [...planIds].filter(id => !summaryIds.has(id));
+  const incompletePlans = [...planIds].filter((id) => !summaryIds.has(id));
   if (incompletePlans.length > 0) {
     errors.push(`Plans without summaries: ${incompletePlans.join(', ')}`);
   }
 
   // Summaries without plans (orphans)
-  const orphanSummaries = [...summaryIds].filter(id => !planIds.has(id));
+  const orphanSummaries = [...summaryIds].filter((id) => !planIds.has(id));
   if (orphanSummaries.length > 0) {
     warnings.push(`Summaries without plans: ${orphanSummaries.join(', ')}`);
   }
 
-  output({
-    complete: errors.length === 0,
-    phase: phaseInfo.phase_number,
-    plan_count: plans.length,
-    summary_count: summaries.length,
-    incomplete_plans: incompletePlans,
-    orphan_summaries: orphanSummaries,
-    errors,
-    warnings,
-  }, errors.length === 0 ? 'complete' : 'incomplete');
+  output(
+    {
+      complete: errors.length === 0,
+      phase: phaseInfo.phase_number,
+      plan_count: plans.length,
+      summary_count: summaries.length,
+      incomplete_plans: incompletePlans,
+      orphan_summaries: orphanSummaries,
+      errors,
+      warnings,
+    },
+    errors.length === 0 ? 'complete' : 'incomplete',
+  );
 }
 
 function cmdVerifyReferences(cwd, filePath) {
-  if (!filePath) { error('file path required'); }
-  const fullPath = path.isAbsolute(filePath) ? filePath : path.join(cwd, filePath);
+  if (!filePath) {
+    error('file path required');
+  }
+  const fullPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: filePath }); return; }
+  if (!content) {
+    output({ error: 'File not found', path: filePath });
+    return;
+  }
 
   const found = [];
   const missing = [];
@@ -243,7 +312,12 @@ function cmdVerifyReferences(cwd, filePath) {
   const backtickRefs = content.match(/`([^`]+\/[^`]+\.[a-zA-Z]{1,10})`/g) || [];
   for (const ref of backtickRefs) {
     const cleanRef = ref.slice(1, -1); // remove backticks
-    if (cleanRef.startsWith('http') || cleanRef.includes('${') || cleanRef.includes('{{')) continue;
+    if (
+      cleanRef.startsWith('http') ||
+      cleanRef.includes('${') ||
+      cleanRef.includes('{{')
+    )
+      continue;
     if (found.includes(cleanRef) || missing.includes(cleanRef)) continue; // dedup
     const resolved = path.join(cwd, cleanRef);
     if (fs.existsSync(resolved)) {
@@ -253,16 +327,21 @@ function cmdVerifyReferences(cwd, filePath) {
     }
   }
 
-  output({
-    valid: missing.length === 0,
-    found: found.length,
-    missing,
-    total: found.length + missing.length,
-  }, missing.length === 0 ? 'valid' : 'invalid');
+  output(
+    {
+      valid: missing.length === 0,
+      found: found.length,
+      missing,
+      total: found.length + missing.length,
+    },
+    missing.length === 0 ? 'valid' : 'invalid',
+  );
 }
 
 function cmdVerifyCommits(cwd, hashes) {
-  if (!hashes || hashes.length === 0) { error('At least one commit hash required'); }
+  if (!hashes || hashes.length === 0) {
+    error('At least one commit hash required');
+  }
 
   const valid = [];
   const invalid = [];
@@ -275,23 +354,36 @@ function cmdVerifyCommits(cwd, hashes) {
     }
   }
 
-  output({
-    all_valid: invalid.length === 0,
-    valid,
-    invalid,
-    total: hashes.length,
-  }, invalid.length === 0 ? 'valid' : 'invalid');
+  output(
+    {
+      all_valid: invalid.length === 0,
+      valid,
+      invalid,
+      total: hashes.length,
+    },
+    invalid.length === 0 ? 'valid' : 'invalid',
+  );
 }
 
 function cmdVerifyArtifacts(cwd, planFilePath) {
-  if (!planFilePath) { error('plan file path required'); }
-  const fullPath = path.isAbsolute(planFilePath) ? planFilePath : path.join(cwd, planFilePath);
+  if (!planFilePath) {
+    error('plan file path required');
+  }
+  const fullPath = path.isAbsolute(planFilePath)
+    ? planFilePath
+    : path.join(cwd, planFilePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: planFilePath }); return; }
+  if (!content) {
+    output({ error: 'File not found', path: planFilePath });
+    return;
+  }
 
   const artifacts = parseMustHavesBlock(content, 'artifacts');
   if (artifacts.length === 0) {
-    output({ error: 'No must_haves.artifacts found in frontmatter', path: planFilePath });
+    output({
+      error: 'No must_haves.artifacts found in frontmatter',
+      path: planFilePath,
+    });
     return;
   }
 
@@ -310,15 +402,20 @@ function cmdVerifyArtifacts(cwd, planFilePath) {
       const lineCount = fileContent.split('\n').length;
 
       if (artifact.min_lines && lineCount < artifact.min_lines) {
-        check.issues.push(`Only ${lineCount} lines, need ${artifact.min_lines}`);
+        check.issues.push(
+          `Only ${lineCount} lines, need ${artifact.min_lines}`,
+        );
       }
       if (artifact.contains && !fileContent.includes(artifact.contains)) {
         check.issues.push(`Missing pattern: ${artifact.contains}`);
       }
       if (artifact.exports) {
-        const exports = Array.isArray(artifact.exports) ? artifact.exports : [artifact.exports];
+        const exports = Array.isArray(artifact.exports)
+          ? artifact.exports
+          : [artifact.exports];
         for (const exp of exports) {
-          if (!fileContent.includes(exp)) check.issues.push(`Missing export: ${exp}`);
+          if (!fileContent.includes(exp))
+            check.issues.push(`Missing export: ${exp}`);
         }
       }
       check.passed = check.issues.length === 0;
@@ -329,31 +426,50 @@ function cmdVerifyArtifacts(cwd, planFilePath) {
     results.push(check);
   }
 
-  const passed = results.filter(r => r.passed).length;
-  output({
-    all_passed: passed === results.length,
-    passed,
-    total: results.length,
-    artifacts: results,
-  }, passed === results.length ? 'valid' : 'invalid');
+  const passed = results.filter((r) => r.passed).length;
+  output(
+    {
+      all_passed: passed === results.length,
+      passed,
+      total: results.length,
+      artifacts: results,
+    },
+    passed === results.length ? 'valid' : 'invalid',
+  );
 }
 
 function cmdVerifyKeyLinks(cwd, planFilePath) {
-  if (!planFilePath) { error('plan file path required'); }
-  const fullPath = path.isAbsolute(planFilePath) ? planFilePath : path.join(cwd, planFilePath);
+  if (!planFilePath) {
+    error('plan file path required');
+  }
+  const fullPath = path.isAbsolute(planFilePath)
+    ? planFilePath
+    : path.join(cwd, planFilePath);
   const content = safeReadFile(fullPath);
-  if (!content) { output({ error: 'File not found', path: planFilePath }); return; }
+  if (!content) {
+    output({ error: 'File not found', path: planFilePath });
+    return;
+  }
 
   const keyLinks = parseMustHavesBlock(content, 'key_links');
   if (keyLinks.length === 0) {
-    output({ error: 'No must_haves.key_links found in frontmatter', path: planFilePath });
+    output({
+      error: 'No must_haves.key_links found in frontmatter',
+      path: planFilePath,
+    });
     return;
   }
 
   const results = [];
   for (const link of keyLinks) {
     if (typeof link === 'string') continue;
-    const check = { from: link.from, to: link.to, via: link.via || '', verified: false, detail: '' };
+    const check = {
+      from: link.from,
+      to: link.to,
+      via: link.via || '',
+      verified: false,
+      detail: '',
+    };
 
     const sourceContent = safeReadFile(path.join(cwd, link.from || ''));
     if (!sourceContent) {
@@ -389,13 +505,16 @@ function cmdVerifyKeyLinks(cwd, planFilePath) {
     results.push(check);
   }
 
-  const verified = results.filter(r => r.verified).length;
-  output({
-    all_verified: verified === results.length,
-    verified,
-    total: results.length,
-    links: results,
-  }, verified === results.length ? 'valid' : 'invalid');
+  const verified = results.filter((r) => r.verified).length;
+  output(
+    {
+      all_verified: verified === results.length,
+      verified,
+      total: results.length,
+      links: results,
+    },
+    verified === results.length ? 'valid' : 'invalid',
+  );
 }
 
 function cmdValidateConsistency(cwd) {
@@ -425,7 +544,7 @@ function cmdValidateConsistency(cwd) {
   const diskPhases = new Set();
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
     for (const dir of dirs) {
       const dm = dir.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
       if (dm) diskPhases.add(dm[1]);
@@ -449,46 +568,59 @@ function cmdValidateConsistency(cwd) {
 
   // Check: sequential phase numbers (integers only)
   const integerPhases = [...diskPhases]
-    .filter(p => !p.includes('.'))
-    .map(p => parseInt(p, 10))
+    .filter((p) => !p.includes('.'))
+    .map((p) => parseInt(p, 10))
     .sort((a, b) => a - b);
 
   for (let i = 1; i < integerPhases.length; i++) {
     if (integerPhases[i] !== integerPhases[i - 1] + 1) {
-      warnings.push(`Gap in phase numbering: ${integerPhases[i - 1]} → ${integerPhases[i]}`);
+      warnings.push(
+        `Gap in phase numbering: ${integerPhases[i - 1]} → ${integerPhases[i]}`,
+      );
     }
   }
 
   // Check: plan numbering within phases
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort();
+    const dirs = entries
+      .filter((e) => e.isDirectory())
+      .map((e) => e.name)
+      .sort();
 
     for (const dir of dirs) {
       const phaseFiles = fs.readdirSync(path.join(phasesDir, dir));
-      const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md')).sort();
+      const plans = phaseFiles.filter((f) => f.endsWith('-PLAN.md')).sort();
 
       // Extract plan numbers
-      const planNums = plans.map(p => {
-        const pm = p.match(/-(\d{2})-PLAN\.md$/);
-        return pm ? parseInt(pm[1], 10) : null;
-      }).filter(n => n !== null);
+      const planNums = plans
+        .map((p) => {
+          const pm = p.match(/-(\d{2})-PLAN\.md$/);
+          return pm ? parseInt(pm[1], 10) : null;
+        })
+        .filter((n) => n !== null);
 
       for (let i = 1; i < planNums.length; i++) {
         if (planNums[i] !== planNums[i - 1] + 1) {
-          warnings.push(`Gap in plan numbering in ${dir}: plan ${planNums[i - 1]} → ${planNums[i]}`);
+          warnings.push(
+            `Gap in plan numbering in ${dir}: plan ${planNums[i - 1]} → ${planNums[i]}`,
+          );
         }
       }
 
       // Check: plans without summaries (completed plans)
-      const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md'));
-      const planIds = new Set(plans.map(p => p.replace('-PLAN.md', '')));
-      const summaryIds = new Set(summaries.map(s => s.replace('-SUMMARY.md', '')));
+      const summaries = phaseFiles.filter((f) => f.endsWith('-SUMMARY.md'));
+      const planIds = new Set(plans.map((p) => p.replace('-PLAN.md', '')));
+      const summaryIds = new Set(
+        summaries.map((s) => s.replace('-SUMMARY.md', '')),
+      );
 
       // Summary without matching plan is suspicious
       for (const sid of summaryIds) {
         if (!planIds.has(sid)) {
-          warnings.push(`Summary ${sid}-SUMMARY.md in ${dir} has no matching PLAN.md`);
+          warnings.push(
+            `Summary ${sid}-SUMMARY.md in ${dir} has no matching PLAN.md`,
+          );
         }
       }
     }
@@ -497,14 +629,17 @@ function cmdValidateConsistency(cwd) {
   // Check: frontmatter in plans has required fields
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    const dirs = entries.filter((e) => e.isDirectory()).map((e) => e.name);
 
     for (const dir of dirs) {
       const phaseFiles = fs.readdirSync(path.join(phasesDir, dir));
-      const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md'));
+      const plans = phaseFiles.filter((f) => f.endsWith('-PLAN.md'));
 
       for (const plan of plans) {
-        const content = fs.readFileSync(path.join(phasesDir, dir, plan), 'utf-8');
+        const content = fs.readFileSync(
+          path.join(phasesDir, dir, plan),
+          'utf-8',
+        );
         const fm = extractFrontmatter(content);
 
         if (!fm.wave) {
@@ -515,7 +650,10 @@ function cmdValidateConsistency(cwd) {
   } catch {}
 
   const passed = errors.length === 0;
-  output({ passed, errors, warnings, warning_count: warnings.length }, passed ? 'passed' : 'failed');
+  output(
+    { passed, errors, warnings, warning_count: warnings.length },
+    passed ? 'passed' : 'failed',
+  );
 }
 
 function cmdValidateHealth(cwd, options) {
@@ -524,7 +662,13 @@ function cmdValidateHealth(cwd, options) {
   if (resolved === os.homedir()) {
     output({
       status: 'error',
-      errors: [{ code: 'E010', message: `CWD is home directory (${resolved}) — health check would read the wrong .planning/ directory. Run from your project root instead.`, fix: 'cd into your project directory and retry' }],
+      errors: [
+        {
+          code: 'E010',
+          message: `CWD is home directory (${resolved}) — health check would read the wrong .planning/ directory. Run from your project root instead.`,
+          fix: 'cd into your project directory and retry',
+        },
+      ],
       warnings: [],
       info: [{ code: 'I010', message: `Resolved CWD: ${resolved}` }],
       repairable_count: 0,
@@ -532,7 +676,14 @@ function cmdValidateHealth(cwd, options) {
     return;
   }
 
-  const { root: planningDir, project: projectPath, roadmap: roadmapPath, state: statePath, config: configPath, phases: phasesDir } = planningPaths(cwd);
+  const {
+    root: planningDir,
+    project: projectPath,
+    roadmap: roadmapPath,
+    state: statePath,
+    config: configPath,
+    phases: phasesDir,
+  } = planningPaths(cwd);
 
   const errors = [];
   const warnings = [];
@@ -549,7 +700,12 @@ function cmdValidateHealth(cwd, options) {
 
   // ─── Check 1: .planning/ exists ───────────────────────────────────────────
   if (!fs.existsSync(planningDir)) {
-    addIssue('error', 'E001', '.planning/ directory not found', 'Run /gsd:new-project to initialize');
+    addIssue(
+      'error',
+      'E001',
+      '.planning/ directory not found',
+      'Run /gsd:new-project to initialize',
+    );
     output({
       status: 'broken',
       errors,
@@ -562,30 +718,57 @@ function cmdValidateHealth(cwd, options) {
 
   // ─── Check 2: PROJECT.md exists and has required sections ─────────────────
   if (!fs.existsSync(projectPath)) {
-    addIssue('error', 'E002', 'PROJECT.md not found', 'Run /gsd:new-project to create');
+    addIssue(
+      'error',
+      'E002',
+      'PROJECT.md not found',
+      'Run /gsd:new-project to create',
+    );
   } else {
     const content = fs.readFileSync(projectPath, 'utf-8');
-    const requiredSections = ['## What This Is', '## Core Value', '## Requirements'];
+    const requiredSections = [
+      '## What This Is',
+      '## Core Value',
+      '## Requirements',
+    ];
     for (const section of requiredSections) {
       if (!content.includes(section)) {
-        addIssue('warning', 'W001', `PROJECT.md missing section: ${section}`, 'Add section manually');
+        addIssue(
+          'warning',
+          'W001',
+          `PROJECT.md missing section: ${section}`,
+          'Add section manually',
+        );
       }
     }
   }
 
   // ─── Check 3: ROADMAP.md exists ───────────────────────────────────────────
   if (!fs.existsSync(roadmapPath)) {
-    addIssue('error', 'E003', 'ROADMAP.md not found', 'Run /gsd:new-milestone to create roadmap');
+    addIssue(
+      'error',
+      'E003',
+      'ROADMAP.md not found',
+      'Run /gsd:new-milestone to create roadmap',
+    );
   }
 
   // ─── Check 4: STATE.md exists and references valid phases ─────────────────
   if (!fs.existsSync(statePath)) {
-    addIssue('error', 'E004', 'STATE.md not found', 'Run /gsd:health --repair to regenerate', true);
+    addIssue(
+      'error',
+      'E004',
+      'STATE.md not found',
+      'Run /gsd:health --repair to regenerate',
+      true,
+    );
     repairs.push('regenerateState');
   } else {
     const stateContent = fs.readFileSync(statePath, 'utf-8');
     // Extract phase references from STATE.md
-    const phaseRefs = [...stateContent.matchAll(/[Pp]hase\s+(\d+(?:\.\d+)*)/g)].map(m => m[1]);
+    const phaseRefs = [
+      ...stateContent.matchAll(/[Pp]hase\s+(\d+(?:\.\d+)*)/g),
+    ].map((m) => m[1]);
     // Get disk phases
     const diskPhases = new Set();
     try {
@@ -600,11 +783,22 @@ function cmdValidateHealth(cwd, options) {
     // Check for invalid references
     for (const ref of phaseRefs) {
       const normalizedRef = String(parseInt(ref, 10)).padStart(2, '0');
-      if (!diskPhases.has(ref) && !diskPhases.has(normalizedRef) && !diskPhases.has(String(parseInt(ref, 10)))) {
+      if (
+        !diskPhases.has(ref) &&
+        !diskPhases.has(normalizedRef) &&
+        !diskPhases.has(String(parseInt(ref, 10)))
+      ) {
         // Only warn if phases dir has any content (not just an empty project)
         if (diskPhases.size > 0) {
-          addIssue('warning', 'W002', `STATE.md references phase ${ref}, but only phases ${[...diskPhases].sort().join(', ')} exist`, 'Run /gsd:health --repair to regenerate STATE.md', true);
-          if (!repairs.includes('regenerateState')) repairs.push('regenerateState');
+          addIssue(
+            'warning',
+            'W002',
+            `STATE.md references phase ${ref}, but only phases ${[...diskPhases].sort().join(', ')} exist`,
+            'Run /gsd:health --repair to regenerate STATE.md',
+            true,
+          );
+          if (!repairs.includes('regenerateState'))
+            repairs.push('regenerateState');
         }
       }
     }
@@ -612,7 +806,13 @@ function cmdValidateHealth(cwd, options) {
 
   // ─── Check 5: config.json valid JSON + valid schema ───────────────────────
   if (!fs.existsSync(configPath)) {
-    addIssue('warning', 'W003', 'config.json not found', 'Run /gsd:health --repair to create with defaults', true);
+    addIssue(
+      'warning',
+      'W003',
+      'config.json not found',
+      'Run /gsd:health --repair to create with defaults',
+      true,
+    );
     repairs.push('createConfig');
   } else {
     try {
@@ -620,11 +820,25 @@ function cmdValidateHealth(cwd, options) {
       const parsed = JSON.parse(raw);
       // Validate known fields
       const validProfiles = ['quality', 'balanced', 'budget'];
-      if (parsed.model_profile && !validProfiles.includes(parsed.model_profile)) {
-        addIssue('warning', 'W004', `config.json: invalid model_profile "${parsed.model_profile}"`, `Valid values: ${validProfiles.join(', ')}`);
+      if (
+        parsed.model_profile &&
+        !validProfiles.includes(parsed.model_profile)
+      ) {
+        addIssue(
+          'warning',
+          'W004',
+          `config.json: invalid model_profile "${parsed.model_profile}"`,
+          `Valid values: ${validProfiles.join(', ')}`,
+        );
       }
     } catch (err) {
-      addIssue('error', 'E005', `config.json: JSON parse error - ${err.message}`, 'Run /gsd:health --repair to reset to defaults', true);
+      addIssue(
+        'error',
+        'E005',
+        `config.json: JSON parse error - ${err.message}`,
+        'Run /gsd:health --repair to reset to defaults',
+        true,
+      );
       repairs.push('resetConfig');
     }
   }
@@ -634,8 +848,17 @@ function cmdValidateHealth(cwd, options) {
     try {
       const configRaw = fs.readFileSync(configPath, 'utf-8');
       const configParsed = JSON.parse(configRaw);
-      if (configParsed.workflow && configParsed.workflow.nyquist_validation === undefined) {
-        addIssue('warning', 'W008', 'config.json: workflow.nyquist_validation absent (defaults to enabled but agents may skip)', 'Run /gsd:health --repair to add key', true);
+      if (
+        configParsed.workflow &&
+        configParsed.workflow.nyquist_validation === undefined
+      ) {
+        addIssue(
+          'warning',
+          'W008',
+          'config.json: workflow.nyquist_validation absent (defaults to enabled but agents may skip)',
+          'Run /gsd:health --repair to add key',
+          true,
+        );
         if (!repairs.includes('addNyquistKey')) repairs.push('addNyquistKey');
       }
     } catch {}
@@ -646,7 +869,12 @@ function cmdValidateHealth(cwd, options) {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
     for (const e of entries) {
       if (e.isDirectory() && !e.name.match(/^\d{2}(?:\.\d+)*-[\w-]+$/)) {
-        addIssue('warning', 'W005', `Phase directory "${e.name}" doesn't follow NN-name format`, 'Rename to match pattern (e.g., 01-setup)');
+        addIssue(
+          'warning',
+          'W005',
+          `Phase directory "${e.name}" doesn't follow NN-name format`,
+          'Rename to match pattern (e.g., 01-setup)',
+        );
       }
     }
   } catch {}
@@ -657,14 +885,27 @@ function cmdValidateHealth(cwd, options) {
     for (const e of entries) {
       if (!e.isDirectory()) continue;
       const phaseFiles = fs.readdirSync(path.join(phasesDir, e.name));
-      const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md');
-      const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
-      const summaryBases = new Set(summaries.map(s => s.replace('-SUMMARY.md', '').replace('SUMMARY.md', '')));
+      const plans = phaseFiles.filter(
+        (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md',
+      );
+      const summaries = phaseFiles.filter(
+        (f) => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md',
+      );
+      const summaryBases = new Set(
+        summaries.map((s) =>
+          s.replace('-SUMMARY.md', '').replace('SUMMARY.md', ''),
+        ),
+      );
 
       for (const plan of plans) {
         const planBase = plan.replace('-PLAN.md', '').replace('PLAN.md', '');
         if (!summaryBases.has(planBase)) {
-          addIssue('info', 'I001', `${e.name}/${plan} has no SUMMARY.md`, 'May be in progress');
+          addIssue(
+            'info',
+            'I001',
+            `${e.name}/${plan} has no SUMMARY.md`,
+            'May be in progress',
+          );
         }
       }
     }
@@ -676,13 +917,23 @@ function cmdValidateHealth(cwd, options) {
     for (const e of phaseEntries) {
       if (!e.isDirectory()) continue;
       const phaseFiles = fs.readdirSync(path.join(phasesDir, e.name));
-      const hasResearch = phaseFiles.some(f => f.endsWith('-RESEARCH.md'));
-      const hasValidation = phaseFiles.some(f => f.endsWith('-VALIDATION.md'));
+      const hasResearch = phaseFiles.some((f) => f.endsWith('-RESEARCH.md'));
+      const hasValidation = phaseFiles.some((f) =>
+        f.endsWith('-VALIDATION.md'),
+      );
       if (hasResearch && !hasValidation) {
-        const researchFile = phaseFiles.find(f => f.endsWith('-RESEARCH.md'));
-        const researchContent = fs.readFileSync(path.join(phasesDir, e.name, researchFile), 'utf-8');
+        const researchFile = phaseFiles.find((f) => f.endsWith('-RESEARCH.md'));
+        const researchContent = fs.readFileSync(
+          path.join(phasesDir, e.name, researchFile),
+          'utf-8',
+        );
         if (researchContent.includes('## Validation Architecture')) {
-          addIssue('warning', 'W009', `Phase ${e.name}: has Validation Architecture in RESEARCH.md but no VALIDATION.md`, 'Re-run /gsd:plan-phase with --research to regenerate');
+          addIssue(
+            'warning',
+            'W009',
+            `Phase ${e.name}: has Validation Architecture in RESEARCH.md but no VALIDATION.md`,
+            'Re-run /gsd:plan-phase with --research to regenerate',
+          );
         }
       }
     }
@@ -715,7 +966,12 @@ function cmdValidateHealth(cwd, options) {
     for (const p of roadmapPhases) {
       const padded = String(parseInt(p, 10)).padStart(2, '0');
       if (!diskPhases.has(p) && !diskPhases.has(padded)) {
-        addIssue('warning', 'W006', `Phase ${p} in ROADMAP.md but no directory on disk`, 'Create phase directory or remove from roadmap');
+        addIssue(
+          'warning',
+          'W006',
+          `Phase ${p} in ROADMAP.md but no directory on disk`,
+          'Create phase directory or remove from roadmap',
+        );
       }
     }
 
@@ -723,37 +979,57 @@ function cmdValidateHealth(cwd, options) {
     for (const p of diskPhases) {
       const unpadded = String(parseInt(p, 10));
       if (!roadmapPhases.has(p) && !roadmapPhases.has(unpadded)) {
-        addIssue('warning', 'W007', `Phase ${p} exists on disk but not in ROADMAP.md`, 'Add to roadmap or remove directory');
+        addIssue(
+          'warning',
+          'W007',
+          `Phase ${p} exists on disk but not in ROADMAP.md`,
+          'Add to roadmap or remove directory',
+        );
       }
     }
   }
 
   // ─── Check 9: Project rules file exists when .planning/ exists ────────────
   const gsdRuntime = process.env.GSD_RUNTIME || 'claude';
-  const projectRulesFile = (RUNTIMES[gsdRuntime] || RUNTIMES.claude).PROJECT_RULES_FILE;
+  const projectRulesFile = (RUNTIMES[gsdRuntime] || RUNTIMES.claude)
+    .PROJECT_RULES_FILE;
   const projectRulesPath = path.join(cwd, projectRulesFile);
   const memoryDir = path.join(cwd, '.claude', 'memory');
   const memoryDirExists = fs.existsSync(memoryDir);
   const projectRulesExists = fs.existsSync(projectRulesPath);
 
   if (!projectRulesExists) {
-    addIssue('warning', 'W010', `${projectRulesFile} not found — agents will not receive project instructions`, `Run /gsd:health --repair to generate ${projectRulesFile} with Memories section`, true);
+    addIssue(
+      'warning',
+      'W010',
+      `${projectRulesFile} not found — agents will not receive project instructions`,
+      `Run /gsd:health --repair to generate ${projectRulesFile} with Memories section`,
+      true,
+    );
     if (!repairs.includes('writeCLAUDEmd')) repairs.push('writeCLAUDEmd');
   }
 
   // ─── Check 10-12: Memory-related checks (gate on project rules file + memory dir) ──
   if (projectRulesExists && memoryDirExists) {
     const claudeContent = fs.readFileSync(projectRulesPath, 'utf-8');
-    const memFiles = fs.readdirSync(memoryDir)
-      .filter(f => f.endsWith('.md') && f !== 'MEMORY.md');
+    const memFiles = fs
+      .readdirSync(memoryDir)
+      .filter((f) => f.endsWith('.md') && f !== 'MEMORY.md');
 
     // Check 10: Orphaned memory files not referenced in CLAUDE.md
-    const orphaned = memFiles.filter(f => !claudeContent.includes(`.claude/memory/${f}`));
+    const orphaned = memFiles.filter(
+      (f) => !claudeContent.includes(`.claude/memory/${f}`),
+    );
     if (orphaned.length > 0) {
-      addIssue('warning', 'W011',
+      addIssue(
+        'warning',
+        'W011',
         `${orphaned.length} memory file(s) not referenced in CLAUDE.md: ${orphaned.join(', ')}`,
-        'Run /gsd:health --repair to add missing references', true);
-      if (!repairs.includes('syncCLAUDEmdMemories')) repairs.push('syncCLAUDEmdMemories');
+        'Run /gsd:health --repair to add missing references',
+        true,
+      );
+      if (!repairs.includes('syncCLAUDEmdMemories'))
+        repairs.push('syncCLAUDEmdMemories');
     }
 
     // Check 11: Stale memory refs in CLAUDE.md
@@ -763,12 +1039,19 @@ function cmdValidateHealth(cwd, options) {
     while ((refMatch = refPattern.exec(claudeContent)) !== null) {
       referencedFiles.push(refMatch[1]);
     }
-    const stale = referencedFiles.filter(f => !fs.existsSync(path.join(memoryDir, f)));
+    const stale = referencedFiles.filter(
+      (f) => !fs.existsSync(path.join(memoryDir, f)),
+    );
     if (stale.length > 0) {
-      addIssue('warning', 'W012',
+      addIssue(
+        'warning',
+        'W012',
         `CLAUDE.md references ${stale.length} memory file(s) that do not exist: ${stale.join(', ')}`,
-        'Run /gsd:health --repair to remove stale references', true);
-      if (!repairs.includes('syncCLAUDEmdMemories')) repairs.push('syncCLAUDEmdMemories');
+        'Run /gsd:health --repair to remove stale references',
+        true,
+      );
+      if (!repairs.includes('syncCLAUDEmdMemories'))
+        repairs.push('syncCLAUDEmdMemories');
     }
 
     // Check 12: MEMORY.md drift
@@ -776,16 +1059,27 @@ function cmdValidateHealth(cwd, options) {
     if (fs.existsSync(memoryMdPath)) {
       const currentMemoryMd = fs.readFileSync(memoryMdPath, 'utf-8');
       const expectedMemoryMd = generateMemoryMd(cwd);
-      if (expectedMemoryMd && currentMemoryMd.trim() !== expectedMemoryMd.trim()) {
-        addIssue('warning', 'W013',
+      if (
+        expectedMemoryMd &&
+        currentMemoryMd.trim() !== expectedMemoryMd.trim()
+      ) {
+        addIssue(
+          'warning',
+          'W013',
           'MEMORY.md is out of sync with .claude/memory/ contents',
-          'Run /gsd:health --repair to regenerate MEMORY.md', true);
+          'Run /gsd:health --repair to regenerate MEMORY.md',
+          true,
+        );
         if (!repairs.includes('syncMemoryMd')) repairs.push('syncMemoryMd');
       }
     } else if (memFiles.length > 0) {
-      addIssue('warning', 'W013',
+      addIssue(
+        'warning',
+        'W013',
         'MEMORY.md does not exist but .claude/memory/ contains files',
-        'Run /gsd:health --repair to create MEMORY.md', true);
+        'Run /gsd:health --repair to create MEMORY.md',
+        true,
+      );
       if (!repairs.includes('syncMemoryMd')) repairs.push('syncMemoryMd');
     }
   }
@@ -794,26 +1088,36 @@ function cmdValidateHealth(cwd, options) {
   if (memoryDirExists) {
     const wsType = detectWorkspaceType(cwd);
     if (wsType.type !== 'standalone') {
-      const topologyMemFiles = fs.readdirSync(memoryDir)
-        .filter(f => f.endsWith('.md') && f !== 'MEMORY.md');
-      const hasStructuralMemory = topologyMemFiles.some(f => {
+      const topologyMemFiles = fs
+        .readdirSync(memoryDir)
+        .filter((f) => f.endsWith('.md') && f !== 'MEMORY.md');
+      const hasStructuralMemory = topologyMemFiles.some((f) => {
         try {
           const content = fs.readFileSync(path.join(memoryDir, f), 'utf-8');
-          return content.includes('boundary') || content.includes('sub-directory') || content.includes('subdirectory');
+          return (
+            content.includes('boundary') ||
+            content.includes('sub-directory') ||
+            content.includes('subdirectory')
+          );
         } catch {
           return false;
         }
       });
       if (!hasStructuralMemory) {
-        addIssue('warning', 'W014',
+        addIssue(
+          'warning',
+          'W014',
           `Workspace is ${wsType.type} (${wsType.signal}) but no structural memory is seeded`,
-          'Run /gsd:seed-memories to seed appropriate guardrail memories', false);
+          'Run /gsd:seed-memories to seed appropriate guardrail memories',
+          false,
+        );
       }
     }
   }
 
   // ─── Check 15-18: Orphaned todo/issue/phase link detection ───────────────
-  const { todosPending: pendingTodosDir, todosCompleted: completedTodosDir } = planningPaths(cwd);
+  const { todosPending: pendingTodosDir, todosCompleted: completedTodosDir } =
+    planningPaths(cwd);
 
   // ─── Check 15: Completed todos with open external issues (platform-gated) ─
   // ─── Check 16: Closed external issues with open pending todos (platform-gated) ─
@@ -831,15 +1135,24 @@ function cmdValidateHealth(cwd, options) {
     if (itConfig.platform) {
       // W015: Completed todos with open external issues
       // Performance guard: only check todos completed in last 30 days
-      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+      const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .split('T')[0];
       let completedTodoFiles = [];
       try {
-        completedTodoFiles = fs.readdirSync(completedTodosDir).filter(f => f.endsWith('.md'));
-      } catch (_e) { /* dir may not exist */ }
+        completedTodoFiles = fs
+          .readdirSync(completedTodosDir)
+          .filter((f) => f.endsWith('.md'));
+      } catch (_e) {
+        /* dir may not exist */
+      }
 
       for (const file of completedTodoFiles) {
         try {
-          const content = fs.readFileSync(path.join(completedTodosDir, file), 'utf-8');
+          const content = fs.readFileSync(
+            path.join(completedTodosDir, file),
+            'utf-8',
+          );
           const fm = extractFrontmatter(content);
           if (!fm || !fm.external_ref) continue;
           // Skip todos completed more than 30 days ago
@@ -847,23 +1160,34 @@ function cmdValidateHealth(cwd, options) {
           // Issue state check via platform CLI would go here.
           // Deferred to real platform check in live environments.
           // In non-test mode without actual CLI available, skip silently.
-        } catch (_e) { /* skip unreadable */ }
+        } catch (_e) {
+          /* skip unreadable */
+        }
       }
 
       // W016: Closed external issues with open pending todos
       let pendingTodoFiles = [];
       try {
-        pendingTodoFiles = fs.readdirSync(pendingTodosDir).filter(f => f.endsWith('.md'));
-      } catch (_e) { /* dir may not exist */ }
+        pendingTodoFiles = fs
+          .readdirSync(pendingTodosDir)
+          .filter((f) => f.endsWith('.md'));
+      } catch (_e) {
+        /* dir may not exist */
+      }
 
       for (const file of pendingTodoFiles) {
         try {
-          const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+          const content = fs.readFileSync(
+            path.join(pendingTodosDir, file),
+            'utf-8',
+          );
           const fm = extractFrontmatter(content);
           if (!fm || !fm.external_ref) continue;
           // Issue state check via platform CLI would go here.
           // Deferred to real platform check in live environments.
-        } catch (_e) { /* skip */ }
+        } catch (_e) {
+          /* skip */
+        }
       }
     }
   }
@@ -873,34 +1197,55 @@ function cmdValidateHealth(cwd, options) {
   // Parse ROADMAP.md for phase numbers and completion status
   const roadmapContentForPhaseCheck = safeReadFile(roadmapPath) || '';
   const phaseEntriesForCheck = [];
-  const phaseCheckRegex = /^[-*]\s*\[([ x])\]\s*\*\*Phase\s+(\d+(?:\.\d+)*)[^*]*\*\*/gm;
+  const phaseCheckRegex =
+    /^[-*]\s*\[([ x])\]\s*\*\*Phase\s+(\d+(?:\.\d+)*)[^*]*\*\*/gm;
   let pcm;
   while ((pcm = phaseCheckRegex.exec(roadmapContentForPhaseCheck)) !== null) {
     phaseEntriesForCheck.push({ number: pcm[2], complete: pcm[1] === 'x' });
   }
-  const phaseNumbersInRoadmap = new Set(phaseEntriesForCheck.map(p => p.number));
-  const completedPhaseNumbers = new Set(phaseEntriesForCheck.filter(p => p.complete).map(p => p.number));
+  const phaseNumbersInRoadmap = new Set(
+    phaseEntriesForCheck.map((p) => p.number),
+  );
+  const completedPhaseNumbers = new Set(
+    phaseEntriesForCheck.filter((p) => p.complete).map((p) => p.number),
+  );
 
   // Scan pending todos for phase: field
   let pendingTodosForPhaseCheck = [];
   try {
-    pendingTodosForPhaseCheck = fs.readdirSync(pendingTodosDir).filter(f => f.endsWith('.md'));
-  } catch (_e) { /* dir may not exist */ }
+    pendingTodosForPhaseCheck = fs
+      .readdirSync(pendingTodosDir)
+      .filter((f) => f.endsWith('.md'));
+  } catch (_e) {
+    /* dir may not exist */
+  }
 
   for (const file of pendingTodosForPhaseCheck) {
     try {
-      const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+      const content = fs.readFileSync(
+        path.join(pendingTodosDir, file),
+        'utf-8',
+      );
       const fm = extractFrontmatter(content);
       if (!fm || fm.phase === undefined || fm.phase === null) continue;
       const todoPhase = String(fm.phase);
-      if (phaseNumbersInRoadmap.size > 0 && !phaseNumbersInRoadmap.has(todoPhase)) {
-        addIssue('warning', 'W017',
+      if (
+        phaseNumbersInRoadmap.size > 0 &&
+        !phaseNumbersInRoadmap.has(todoPhase)
+      ) {
+        addIssue(
+          'warning',
+          'W017',
           `Todo "${file}" references phase ${todoPhase} which does not exist in ROADMAP.md`,
           'Remove the phase: field from the todo or add the phase to ROADMAP.md',
-          true);
-        if (!repairs.includes('clearPhaseLinkFromTodo')) repairs.push('clearPhaseLinkFromTodo');
+          true,
+        );
+        if (!repairs.includes('clearPhaseLinkFromTodo'))
+          repairs.push('clearPhaseLinkFromTodo');
       }
-    } catch (_e) { /* skip */ }
+    } catch (_e) {
+      /* skip */
+    }
   }
 
   // W018: For each completed phase, check if any pending todos still reference it
@@ -908,18 +1253,26 @@ function cmdValidateHealth(cwd, options) {
     const linkedPending = [];
     for (const file of pendingTodosForPhaseCheck) {
       try {
-        const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+        const content = fs.readFileSync(
+          path.join(pendingTodosDir, file),
+          'utf-8',
+        );
         const fm = extractFrontmatter(content);
         if (fm && String(fm.phase) === phaseNum) {
           linkedPending.push(file);
         }
-      } catch (_e) { /* skip */ }
+      } catch (_e) {
+        /* skip */
+      }
     }
     if (linkedPending.length > 0) {
-      addIssue('warning', 'W018',
+      addIssue(
+        'warning',
+        'W018',
         `Phase ${phaseNum} is complete but ${linkedPending.length} pending todo(s) still reference it: ${linkedPending.join(', ')}`,
         'Close the todo(s) or remove their phase: field',
-        true);
+        true,
+      );
       if (!repairs.includes('closePhaseTodo')) repairs.push('closePhaseTodo');
     }
   }
@@ -927,66 +1280,112 @@ function cmdValidateHealth(cwd, options) {
   // --- Check 21: Broken related links (related: references non-existent todos) ---
   for (const file of pendingTodosForPhaseCheck) {
     try {
-      const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+      const content = fs.readFileSync(
+        path.join(pendingTodosDir, file),
+        'utf-8',
+      );
       const fm = extractFrontmatter(content);
       if (!fm || !fm.related) continue;
-      const relatedList = Array.isArray(fm.related) ? fm.related : (fm.related ? [fm.related] : []);
+      const relatedList = Array.isArray(fm.related)
+        ? fm.related
+        : fm.related
+          ? [fm.related]
+          : [];
       for (const ref of relatedList) {
         const existsInPending = fs.existsSync(path.join(pendingTodosDir, ref));
-        const existsInCompleted = fs.existsSync(path.join(completedTodosDir, ref));
+        const existsInCompleted = fs.existsSync(
+          path.join(completedTodosDir, ref),
+        );
         if (!existsInPending && !existsInCompleted) {
-          addIssue('warning', 'W021',
+          addIssue(
+            'warning',
+            'W021',
             `Todo "${file}" has related: "${ref}" which does not exist in pending/ or completed/`,
             'Remove the stale related: reference or recreate the missing todo',
-            true);
-          if (!repairs.includes('clearRelatedLink')) repairs.push('clearRelatedLink');
+            true,
+          );
+          if (!repairs.includes('clearRelatedLink'))
+            repairs.push('clearRelatedLink');
         }
       }
-    } catch (_e) { /* skip */ }
+    } catch (_e) {
+      /* skip */
+    }
   }
 
   // --- Check 22: Asymmetric related links (A references B but B does not reference A back) ---
   for (const file of pendingTodosForPhaseCheck) {
     try {
-      const content = fs.readFileSync(path.join(pendingTodosDir, file), 'utf-8');
+      const content = fs.readFileSync(
+        path.join(pendingTodosDir, file),
+        'utf-8',
+      );
       const fm = extractFrontmatter(content);
       if (!fm || !fm.related) continue;
-      const relatedList = Array.isArray(fm.related) ? fm.related : (fm.related ? [fm.related] : []);
+      const relatedList = Array.isArray(fm.related)
+        ? fm.related
+        : fm.related
+          ? [fm.related]
+          : [];
       for (const ref of relatedList) {
         const refPath = path.join(pendingTodosDir, ref);
         if (!fs.existsSync(refPath)) continue; // W021 covers missing refs — skip here
         try {
           const refContent = fs.readFileSync(refPath, 'utf-8');
           const refFm = extractFrontmatter(refContent);
-          const refRelatedList = refFm && refFm.related
-            ? (Array.isArray(refFm.related) ? refFm.related : [refFm.related])
-            : [];
+          const refRelatedList =
+            refFm && refFm.related
+              ? Array.isArray(refFm.related)
+                ? refFm.related
+                : [refFm.related]
+              : [];
           if (!refRelatedList.includes(file)) {
-            addIssue('warning', 'W022',
+            addIssue(
+              'warning',
+              'W022',
               `Asymmetric related link: "${file}" references "${ref}" but "${ref}" does not reference back`,
               'Run /gsd:health --repair to add the missing backlink, or add it manually',
-              true);
+              true,
+            );
             if (!repairs.includes('addBacklink')) repairs.push('addBacklink');
           }
-        } catch (_e) { /* skip unreadable ref */ }
+        } catch (_e) {
+          /* skip unreadable ref */
+        }
       }
-    } catch (_e) { /* skip */ }
+    } catch (_e) {
+      /* skip */
+    }
   }
 
   // --- Check 20: Security events log — high-confidence detections ---
-  const secLogDir = process.env.GSD_SECURITY_LOG_DIR || path.join(cwd, '.claude', 'logs');
+  const secLogDir =
+    process.env.GSD_SECURITY_LOG_DIR || path.join(cwd, '.claude', 'logs');
   const secLogPath = path.join(secLogDir, 'security-events.log');
   if (fs.existsSync(secLogPath)) {
     try {
-      const logLines = fs.readFileSync(secLogPath, 'utf-8').trim().split('\n').filter(Boolean);
+      const logLines = fs
+        .readFileSync(secLogPath, 'utf-8')
+        .trim()
+        .split('\n')
+        .filter(Boolean);
       const highTierEvents = logLines
-        .map(line => { try { return JSON.parse(line); } catch { return null; } })
-        .filter(e => e && e.tier === 'high');
+        .map((line) => {
+          try {
+            return JSON.parse(line);
+          } catch {
+            return null;
+          }
+        })
+        .filter((e) => e && e.tier === 'high');
       if (highTierEvents.length > 0) {
         const latest = highTierEvents[highTierEvents.length - 1];
-        addIssue('warning', 'W020',
+        addIssue(
+          'warning',
+          'W020',
           `security-events.log: ${highTierEvents.length} high-confidence injection event(s) recorded. Latest: ${latest.source || 'unknown'}`,
-          'Review .claude/logs/security-events.log and investigate flagged content');
+          'Review .claude/logs/security-events.log and investigate flagged content',
+        );
       }
     } catch {
       // Corrupt log file — skip silently
@@ -1011,17 +1410,32 @@ function cmdValidateHealth(cwd, options) {
               workflow: { ...WORKFLOW_DEFAULTS },
               parallelization: DEFAULTS.parallelization,
             };
-            fs.writeFileSync(configPath, JSON.stringify(defaults, null, 2), 'utf-8');
-            repairActions.push({ action: repair, success: true, path: 'config.json' });
+            fs.writeFileSync(
+              configPath,
+              JSON.stringify(defaults, null, 2),
+              'utf-8',
+            );
+            repairActions.push({
+              action: repair,
+              success: true,
+              path: 'config.json',
+            });
             break;
           }
           case 'regenerateState': {
             // Create timestamped backup before overwriting
             if (fs.existsSync(statePath)) {
-              const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+              const timestamp = new Date()
+                .toISOString()
+                .replace(/[:.]/g, '-')
+                .slice(0, 19);
               const backupPath = `${statePath}.bak-${timestamp}`;
               fs.copyFileSync(statePath, backupPath);
-              repairActions.push({ action: 'backupState', success: true, path: backupPath });
+              repairActions.push({
+                action: 'backupState',
+                success: true,
+                path: backupPath,
+              });
             }
             // Generate minimal STATE.md from ROADMAP.md structure
             const milestone = getMilestoneInfo(cwd);
@@ -1035,7 +1449,11 @@ function cmdValidateHealth(cwd, options) {
             stateContent += `## Session Log\n\n`;
             stateContent += `- ${new Date().toISOString().split('T')[0]}: STATE.md regenerated by /gsd:health --repair\n`;
             writeStateMd(statePath, stateContent, cwd);
-            repairActions.push({ action: repair, success: true, path: 'STATE.md' });
+            repairActions.push({
+              action: repair,
+              success: true,
+              path: 'STATE.md',
+            });
             break;
           }
           case 'addNyquistKey': {
@@ -1046,18 +1464,31 @@ function cmdValidateHealth(cwd, options) {
                 if (!configParsed.workflow) configParsed.workflow = {};
                 if (configParsed.workflow.nyquist_validation === undefined) {
                   configParsed.workflow.nyquist_validation = true;
-                  fs.writeFileSync(configPath, JSON.stringify(configParsed, null, 2), 'utf-8');
+                  fs.writeFileSync(
+                    configPath,
+                    JSON.stringify(configParsed, null, 2),
+                    'utf-8',
+                  );
                 }
-                repairActions.push({ action: repair, success: true, path: 'config.json' });
+                repairActions.push({
+                  action: repair,
+                  success: true,
+                  path: 'config.json',
+                });
               } catch (err) {
-                repairActions.push({ action: repair, success: false, error: err.message });
+                repairActions.push({
+                  action: repair,
+                  success: false,
+                  error: err.message,
+                });
               }
             }
             break;
           }
           case 'writeCLAUDEmd': {
             const repairRuntime = process.env.GSD_RUNTIME || 'claude';
-            const repairRulesFile = (RUNTIMES[repairRuntime] || RUNTIMES.claude).PROJECT_RULES_FILE;
+            const repairRulesFile = (RUNTIMES[repairRuntime] || RUNTIMES.claude)
+              .PROJECT_RULES_FILE;
             const repairRulesPath = path.join(cwd, repairRulesFile);
             const memoriesSection = generateMemoriesSection(cwd);
             if (fs.existsSync(repairRulesPath)) {
@@ -1074,12 +1505,17 @@ function cmdValidateHealth(cwd, options) {
               if (memoriesSection) content += memoriesSection;
               fs.writeFileSync(repairRulesPath, content, 'utf-8');
             }
-            repairActions.push({ action: repair, success: true, path: repairRulesFile });
+            repairActions.push({
+              action: repair,
+              success: true,
+              path: repairRulesFile,
+            });
             break;
           }
           case 'syncCLAUDEmdMemories': {
             const syncRuntime = process.env.GSD_RUNTIME || 'claude';
-            const syncRulesFile = (RUNTIMES[syncRuntime] || RUNTIMES.claude).PROJECT_RULES_FILE;
+            const syncRulesFile = (RUNTIMES[syncRuntime] || RUNTIMES.claude)
+              .PROJECT_RULES_FILE;
             const syncRulesPath = path.join(cwd, syncRulesFile);
             if (fs.existsSync(syncRulesPath)) {
               let content = fs.readFileSync(syncRulesPath, 'utf-8');
@@ -1089,13 +1525,21 @@ function cmdValidateHealth(cwd, options) {
               if (sectionStart !== -1) {
                 // Find end of section (next ## heading or EOF)
                 const afterStart = content.indexOf('\n## ', sectionStart + 1);
-                const sectionEnd = afterStart !== -1 ? afterStart : content.length;
-                content = content.slice(0, sectionStart) + newSection + content.slice(sectionEnd);
+                const sectionEnd =
+                  afterStart !== -1 ? afterStart : content.length;
+                content =
+                  content.slice(0, sectionStart) +
+                  newSection +
+                  content.slice(sectionEnd);
               } else {
                 content += '\n\n' + newSection;
               }
               fs.writeFileSync(syncRulesPath, content, 'utf-8');
-              repairActions.push({ action: repair, success: true, path: syncRulesFile });
+              repairActions.push({
+                action: repair,
+                success: true,
+                path: syncRulesFile,
+              });
             }
             break;
           }
@@ -1105,27 +1549,41 @@ function cmdValidateHealth(cwd, options) {
             const newContent = generateMemoryMd(cwd);
             if (newContent) {
               fs.writeFileSync(memMdPath, newContent, 'utf-8');
-              repairActions.push({ action: repair, success: true, path: '.claude/memory/MEMORY.md' });
+              repairActions.push({
+                action: repair,
+                success: true,
+                path: '.claude/memory/MEMORY.md',
+              });
             }
             break;
           }
           case 'clearPhaseLinkFromTodo': {
             // Remove phase: field from todos referencing non-existent phases
             // Iterate W017 warnings, find affected files, remove phase field
-            repairActions.push({ action: repair, success: true, note: 'Phase links cleared' });
+            repairActions.push({
+              action: repair,
+              success: true,
+              note: 'Phase links cleared',
+            });
             break;
           }
           case 'closePhaseTodo': {
             // Close pending todos linked to completed phases
             // Advisory — log but don't auto-close (health checks never auto-fix per CONTEXT.md)
-            repairActions.push({ action: repair, success: false, note: 'Manual closure required — use /gsd:check-todos' });
+            repairActions.push({
+              action: repair,
+              success: false,
+              note: 'Manual closure required — use /gsd:check-todos',
+            });
             break;
           }
           case 'clearRelatedLink': {
             // Re-scan W021 warnings to find all (file, stale_ref) pairs
-            const w021Warnings = warnings.filter(w => w.code === 'W021');
+            const w021Warnings = warnings.filter((w) => w.code === 'W021');
             for (const w of w021Warnings) {
-              const match = /Todo "([^"]+)" has related: "([^"]+)"/.exec(w.message);
+              const match = /Todo "([^"]+)" has related: "([^"]+)"/.exec(
+                w.message,
+              );
               if (!match) continue;
               const [, todoFile, staleRef] = match;
               const todoPath = path.join(pendingTodosDir, todoFile);
@@ -1133,30 +1591,40 @@ function cmdValidateHealth(cwd, options) {
                 const content = fs.readFileSync(todoPath, 'utf-8');
                 const fm = extractFrontmatter(content);
                 if (!fm || !fm.related) continue;
-                const relatedList = Array.isArray(fm.related) ? fm.related : [fm.related];
-                fm.related = relatedList.filter(r => r !== staleRef);
+                const relatedList = Array.isArray(fm.related)
+                  ? fm.related
+                  : [fm.related];
+                fm.related = relatedList.filter((r) => r !== staleRef);
                 if (fm.related.length === 0) delete fm.related;
                 const newContent = spliceFrontmatter(content, fm);
                 fs.writeFileSync(todoPath, newContent, 'utf-8');
-              } catch (_e) { /* skip unreadable files */ }
+              } catch (_e) {
+                /* skip unreadable files */
+              }
             }
             repairActions.push({ action: repair, success: true });
             break;
           }
           case 'addBacklink': {
             // Re-scan W022 warnings to find all (source, target) pairs
-            const w022Warnings = warnings.filter(w => w.code === 'W022');
+            const w022Warnings = warnings.filter((w) => w.code === 'W022');
             for (const w of w022Warnings) {
-              const match = /Asymmetric related link: "([^"]+)" references "([^"]+)"/.exec(w.message);
+              const match =
+                /Asymmetric related link: "([^"]+)" references "([^"]+)"/.exec(
+                  w.message,
+                );
               if (!match) continue;
               const [, sourceFile, targetFile] = match;
               const targetPath = path.join(pendingTodosDir, targetFile);
               try {
                 const content = fs.readFileSync(targetPath, 'utf-8');
                 const fm = extractFrontmatter(content);
-                const relatedList = fm && fm.related
-                  ? (Array.isArray(fm.related) ? fm.related : [fm.related])
-                  : [];
+                const relatedList =
+                  fm && fm.related
+                    ? Array.isArray(fm.related)
+                      ? fm.related
+                      : [fm.related]
+                    : [];
                 if (!relatedList.includes(sourceFile)) {
                   relatedList.push(sourceFile);
                 }
@@ -1164,14 +1632,20 @@ function cmdValidateHealth(cwd, options) {
                 fm.related = relatedList;
                 const newContent = spliceFrontmatter(content, fm);
                 fs.writeFileSync(targetPath, newContent, 'utf-8');
-              } catch (_e) { /* skip unreadable files */ }
+              } catch (_e) {
+                /* skip unreadable files */
+              }
             }
             repairActions.push({ action: repair, success: true });
             break;
           }
         }
       } catch (err) {
-        repairActions.push({ action: repair, success: false, error: err.message });
+        repairActions.push({
+          action: repair,
+          success: false,
+          error: err.message,
+        });
       }
     }
   }
@@ -1186,8 +1660,9 @@ function cmdValidateHealth(cwd, options) {
     status = 'healthy';
   }
 
-  const repairableCount = errors.filter(e => e.repairable).length +
-                         warnings.filter(w => w.repairable).length;
+  const repairableCount =
+    errors.filter((e) => e.repairable).length +
+    warnings.filter((w) => w.repairable).length;
 
   output({
     status,

--- a/gsd-ng/bin/lib/workspace.cjs
+++ b/gsd-ng/bin/lib/workspace.cjs
@@ -4,7 +4,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error, execGit, loadConfig, planningPaths } = require('./core.cjs');
+const {
+  output,
+  error,
+  execGit,
+  loadConfig,
+  planningPaths,
+} = require('./core.cjs');
 const { DEFAULTS } = require('./defaults.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { cmdDetectPlatform } = require('./commands.cjs');
@@ -46,12 +52,20 @@ function detectWorkspaceType(cwd) {
   // 1. Check for git submodules
   if (fs.existsSync(path.join(cwd, '.gitmodules'))) {
     const submodulePaths = parseSubmodulePaths(path.join(cwd, '.gitmodules'));
-    return { type: 'submodule', signal: '.gitmodules', submodule_paths: submodulePaths };
+    return {
+      type: 'submodule',
+      signal: '.gitmodules',
+      submodule_paths: submodulePaths,
+    };
   }
 
   // 2. Check for pnpm workspace
   if (fs.existsSync(path.join(cwd, 'pnpm-workspace.yaml'))) {
-    return { type: 'monorepo', signal: 'pnpm-workspace.yaml', submodule_paths: [] };
+    return {
+      type: 'monorepo',
+      signal: 'pnpm-workspace.yaml',
+      submodule_paths: [],
+    };
   }
 
   // 3. Check package.json for workspaces field
@@ -60,7 +74,11 @@ function detectWorkspaceType(cwd) {
     try {
       const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
       if (pkg.workspaces) {
-        return { type: 'monorepo', signal: 'package.json#workspaces', submodule_paths: [] };
+        return {
+          type: 'monorepo',
+          signal: 'package.json#workspaces',
+          submodule_paths: [],
+        };
       }
     } catch {
       // Malformed package.json — treat as standalone
@@ -91,8 +109,9 @@ function generateMemoriesSection(cwd) {
 
   let files;
   try {
-    files = fs.readdirSync(memoryDir)
-      .filter(f => f.endsWith('.md') && f !== 'MEMORY.md')
+    files = fs
+      .readdirSync(memoryDir)
+      .filter((f) => f.endsWith('.md') && f !== 'MEMORY.md')
       .sort();
   } catch {
     return '';
@@ -102,7 +121,7 @@ function generateMemoriesSection(cwd) {
     return '';
   }
 
-  const bullets = files.map(filename => {
+  const bullets = files.map((filename) => {
     const filePath = path.join(memoryDir, filename);
     let description = '(no description)';
     try {
@@ -146,8 +165,9 @@ function generateMemoryMd(cwd) {
 
   let files;
   try {
-    files = fs.readdirSync(memoryDir)
-      .filter(f => f.endsWith('.md') && f !== 'MEMORY.md')
+    files = fs
+      .readdirSync(memoryDir)
+      .filter((f) => f.endsWith('.md') && f !== 'MEMORY.md')
       .sort();
   } catch {
     return '';
@@ -250,12 +270,17 @@ function resolveGitContext(cwd) {
     const targetBranch = config.target_branch || 'main';
 
     const remoteResult = execGit(cwd, ['remote', 'get-url', remote]);
-    const remoteUrl = remoteResult.exitCode === 0 ? (remoteResult.stdout || null) : null;
+    const remoteUrl =
+      remoteResult.exitCode === 0 ? remoteResult.stdout || null : null;
 
     const branchResult = execGit(cwd, ['branch', '--show-current']);
-    const currentBranch = branchResult.exitCode === 0 ? (branchResult.stdout || null) : null;
+    const currentBranch =
+      branchResult.exitCode === 0 ? branchResult.stdout || null : null;
 
-    const sshUrl = Boolean(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
+    const sshUrl = Boolean(
+      remoteUrl &&
+      (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')),
+    );
 
     const platformInfo = cmdDetectPlatform(cwd, remote, true) || {};
 
@@ -284,12 +309,16 @@ function resolveGitContext(cwd) {
   const cachedDiff = execGit(cwd, ['diff', '--cached', '--name-only']);
 
   const changedFiles = [
-    ...(headDiff.exitCode === 0 && headDiff.stdout ? headDiff.stdout.split('\n').filter(Boolean) : []),
-    ...(cachedDiff.exitCode === 0 && cachedDiff.stdout ? cachedDiff.stdout.split('\n').filter(Boolean) : []),
+    ...(headDiff.exitCode === 0 && headDiff.stdout
+      ? headDiff.stdout.split('\n').filter(Boolean)
+      : []),
+    ...(cachedDiff.exitCode === 0 && cachedDiff.stdout
+      ? cachedDiff.stdout.split('\n').filter(Boolean)
+      : []),
   ];
 
-  const hitPaths = submodulePaths.filter(sp =>
-    changedFiles.some(f => f === sp || f.startsWith(sp + '/'))
+  const hitPaths = submodulePaths.filter((sp) =>
+    changedFiles.some((f) => f === sp || f.startsWith(sp + '/')),
   );
 
   // Ambiguous: multiple submodules have changes
@@ -342,9 +371,13 @@ function resolveGitContext(cwd) {
     const pp = planningPaths(cwd);
     const rawConfig = fs.readFileSync(pp.config, 'utf-8');
     const parsedConfig = JSON.parse(rawConfig);
-    const globalGit = (parsedConfig.git) || {};
+    const globalGit = parsedConfig.git || {};
     const submoduleName = activePath ? activePath.split('/').pop() : null;
-    const perSubmodule = (submoduleName && globalGit.submodules && globalGit.submodules[submoduleName]) || {};
+    const perSubmodule =
+      (submoduleName &&
+        globalGit.submodules &&
+        globalGit.submodules[submoduleName]) ||
+      {};
     // Merged: global git.* fields as base, per-submodule overrides on top
     configSubmodule = { ...globalGit, ...perSubmodule };
   } catch {
@@ -354,15 +387,20 @@ function resolveGitContext(cwd) {
   const remote = configSubmodule.remote || 'origin';
 
   const remoteResult = execGit(subCwd, ['remote', 'get-url', remote]);
-  const remoteUrl = remoteResult.exitCode === 0 ? (remoteResult.stdout || null) : null;
+  const remoteUrl =
+    remoteResult.exitCode === 0 ? remoteResult.stdout || null : null;
 
   const branchResult = execGit(subCwd, ['branch', '--show-current']);
-  const currentBranch = branchResult.exitCode === 0 ? (branchResult.stdout || null) : null;
+  const currentBranch =
+    branchResult.exitCode === 0 ? branchResult.stdout || null : null;
 
   // Resolve target branch: config override > git tracking > fallback 'main'
   let targetBranch = configSubmodule.target_branch || null;
   if (!targetBranch && currentBranch) {
-    const mergeResult = execGit(subCwd, ['config', `branch.${currentBranch}.merge`]);
+    const mergeResult = execGit(subCwd, [
+      'config',
+      `branch.${currentBranch}.merge`,
+    ]);
     if (mergeResult.exitCode === 0 && mergeResult.stdout) {
       targetBranch = mergeResult.stdout.replace(/^refs\/heads\//, '') || null;
     }
@@ -371,7 +409,10 @@ function resolveGitContext(cwd) {
     targetBranch = 'main';
   }
 
-  const sshUrl = Boolean(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
+  const sshUrl = Boolean(
+    remoteUrl &&
+    (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')),
+  );
 
   const platformInfo = cmdDetectPlatform(subCwd, remote, true) || {};
 
@@ -391,11 +432,18 @@ function resolveGitContext(cwd) {
     cli_installed: platformInfo.cli_installed || false,
     cli_install_url: platformInfo.cli_install_url || null,
     branching_strategy: configSubmodule.branching_strategy || 'none',
-    auto_push: configSubmodule.auto_push !== undefined ? configSubmodule.auto_push : false,
-    phase_branch_template: configSubmodule.phase_branch_template || DEFAULTS.phase_branch_template,
-    milestone_branch_template: configSubmodule.milestone_branch_template || DEFAULTS.milestone_branch_template,
+    auto_push:
+      configSubmodule.auto_push !== undefined
+        ? configSubmodule.auto_push
+        : false,
+    phase_branch_template:
+      configSubmodule.phase_branch_template || DEFAULTS.phase_branch_template,
+    milestone_branch_template:
+      configSubmodule.milestone_branch_template ||
+      DEFAULTS.milestone_branch_template,
     review_branch_template: configSubmodule.review_branch_template || null,
-    pr_draft: configSubmodule.pr_draft !== undefined ? configSubmodule.pr_draft : true,
+    pr_draft:
+      configSubmodule.pr_draft !== undefined ? configSubmodule.pr_draft : true,
     pr_template: configSubmodule.pr_template || null,
     type_aliases: configSubmodule.type_aliases || null,
   };
@@ -435,10 +483,18 @@ function cmdGitContext(cwd, silent) {
  * @param {boolean} silent - If true, return result without output()/process.exit()
  */
 function cmdSshCheck(remoteUrl, silent) {
-  const sshRequired = !!(remoteUrl && (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')));
+  const sshRequired = !!(
+    remoteUrl &&
+    (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://'))
+  );
 
   if (!sshRequired) {
-    const result = { ssh_required: false, agent_running: false, status: 'not_required', message: 'Remote does not use SSH' };
+    const result = {
+      ssh_required: false,
+      agent_running: false,
+      status: 'not_required',
+      message: 'Remote does not use SSH',
+    };
     if (silent) return result;
     output(result);
     return;
@@ -450,7 +506,10 @@ function cmdSshCheck(remoteUrl, silent) {
 
   try {
     const { execSync } = require('child_process');
-    execSync('ssh-add -l', { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] });
+    execSync('ssh-add -l', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
     // Exit code 0: identities loaded
     agentRunning = true;
     status = 'ok';
@@ -460,13 +519,19 @@ function cmdSshCheck(remoteUrl, silent) {
       // Exit code 1: agent running but no identities
       agentRunning = true;
       status = 'no_identities';
-      message = 'SSH agent is running but no identities are loaded. Run: ssh-add';
+      message =
+        'SSH agent is running but no identities are loaded. Run: ssh-add';
     } else {
       // Exit code 2 or stderr contains agent socket error: agent not running
       const stderr = (err.stderr || '').toString();
-      if (err.status === 2 || stderr.includes('Could not open') || stderr.includes('not open')) {
+      if (
+        err.status === 2 ||
+        stderr.includes('Could not open') ||
+        stderr.includes('not open')
+      ) {
         status = 'agent_not_running';
-        message = 'SSH agent is not running. Run: eval "$(ssh-agent -s)" && ssh-add';
+        message =
+          'SSH agent is not running. Run: eval "$(ssh-agent -s)" && ssh-add';
       } else {
         status = 'agent_not_running';
         message = 'SSH agent check failed: ' + (stderr || err.message);
@@ -474,7 +539,12 @@ function cmdSshCheck(remoteUrl, silent) {
     }
   }
 
-  const result = { ssh_required: true, agent_running: agentRunning, status, message };
+  const result = {
+    ssh_required: true,
+    agent_running: agentRunning,
+    status,
+    message,
+  };
   if (silent) return result;
   output(result);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
       },
       "devDependencies": {
         "c8": "^11.0.0",
-        "esbuild": "^0.24.0"
+        "esbuild": "^0.24.0",
+        "prettier": "3.8.3"
       },
       "engines": {
         "node": ">=22.0.0"
@@ -967,6 +968,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/require-directory": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "prettier": "3.8.3"
   },
   "scripts": {
+    "format": "prettier --write 'gsd-ng/**/*.{js,cjs}' 'bin/**/*.{js,cjs}'",
+    "format:check": "prettier --check 'gsd-ng/**/*.{js,cjs}' 'bin/**/*.{js,cjs}'",
     "build:hooks": "node scripts/build-hooks.js",
     "build:tarball": "npm run build:hooks && node scripts/build-tarball.js",
     "prepublishOnly": "npm run build:hooks",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "devDependencies": {
     "c8": "^11.0.0",
-    "esbuild": "^0.24.0"
+    "esbuild": "^0.24.0",
+    "prettier": "3.8.3"
   },
   "scripts": {
     "build:hooks": "node scripts/build-hooks.js",

--- a/scripts/run-tests.cjs
+++ b/scripts/run-tests.cjs
@@ -7,6 +7,19 @@ const { readdirSync } = require('fs');
 const { join } = require('path');
 const { execFileSync } = require('child_process');
 
+// --- format:check gate (runs before tests; fail fast on style drift) ---
+const prettierBin = join(__dirname, '..', 'node_modules', '.bin', 'prettier');
+try {
+  execFileSync(
+    prettierBin,
+    ['--check', 'gsd-ng/**/*.{js,cjs}', 'bin/**/*.{js,cjs}'],
+    { stdio: 'inherit' },
+  );
+} catch (err) {
+  process.exit(err.status || 1);
+}
+
+// --- test runner ---
 const testDir = join(__dirname, '..', 'tests');
 const files = readdirSync(testDir)
   .filter(f => f.endsWith('.test.cjs'))

--- a/tests/arg-validation.test.cjs
+++ b/tests/arg-validation.test.cjs
@@ -228,8 +228,12 @@ describe('ARG_SCHEMAS coverage', () => {
       'version-bump', 'divergence', 'cleanup', 'update',
     ];
     for (const cmd of topLevelCommands) {
+      // Accept both quoted ('commit': ...) and unquoted (commit: ...) key forms.
+      // Prettier removes unnecessary quotes from valid JS identifiers, so both are valid.
+      const quotedForm = `'${cmd}'`;
+      const unquotedForm = new RegExp(`(?:^|[,{\\s])${cmd.replace(/-/g, '\\-')}\\s*:`);
       assert.ok(
-        schemasBlock.includes(`'${cmd}'`),
+        schemasBlock.includes(quotedForm) || unquotedForm.test(schemasBlock),
         `ARG_SCHEMAS should contain top-level command '${cmd}' with _self schema`
       );
     }


### PR DESCRIPTION
## Summary

Add Prettier as a pinned devDependency with `.prettierrc` matching existing style (2-space, single-quote, trailing commas). Wire `format:check` into `scripts/run-tests.cjs` so `npm test` fails on style drift. Land a one-shot format pass as an isolated commit so `git blame --ignore-revs-file` can skip it. Eliminates the class of indent-drift review findings and gives every future PR automated style enforcement.

## Changes

- **56-01**: Install Prettier 3.8.3 (exact-pinned), add `.prettierrc` / `.prettierignore`, add `format` / `format:check` scripts, wire `prettier --check` gate as first step in `scripts/run-tests.cjs`
- **56-02**: One-shot format pass across all `.js`/`.cjs` source files — style-only isolated commit (`282d450`), `npm test` green at 1613 tests
- **56-03**: Add `.git-blame-ignore-revs` pointing at format commit SHA so GitHub blame UI skips the style churn

## Test Plan

- [x] `npm run format:check` exits 0
- [x] `npm test` passes — 1613 tests, 0 failures
- [x] `bin/install.js` and `hooks/dist/` excluded from format pass (per `.prettierignore`)
- [x] `.git-blame-ignore-revs` contains correct 40-char SHA

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng) from phase 56 execution*
