### PR TITLE
fix(security): add protected-branch ask rules (git push to main/master/develop, gh pr merge --admin)

### DIFF
--- a/gsd-ng/templates/settings-sandbox.json
+++ b/gsd-ng/templates/settings-sandbox.json
@@ -4,6 +4,15 @@
     "autoAllowBashIfSandboxed": true
   },
   "permissions": {
+    "ask": [
+      "Bash(git push * main*)",
+      "Bash(git push * master*)",
+      "Bash(git push * develop*)",
+      "Bash(git -C * push * main*)",
+      "Bash(git -C * push * master*)",
+      "Bash(git -C * push * develop*)",
+      "Bash(gh pr merge *--admin*)"
+    ],
     "allow": [
       "Bash(node *)",
       "Bash(git *)",

--- a/tests/install-js.test.cjs
+++ b/tests/install-js.test.cjs
@@ -344,6 +344,92 @@ test('PERM-07: local install seeds granular gh subcommand patterns (not blanket 
   }
 });
 
+// ── PERM-08: settings-sandbox.json template ships ask rules for protected-branch
+//            pushes and admin merges (2026-05-01 incident response).
+//
+//            Background: On 2026-05-01 Claude bypassed develop's GitHub branch
+//            protection (admin-role token had bypass capability) and pushed
+//            Phase 49 work directly to develop, then opened a wrong-target PR.
+//            Recovery required force-pushing develop back.
+//
+//            Fix: Layer-3 local guardrails. Claude Code's permission precedence
+//            is `deny > ask > allow`, so these `ask` patterns override the
+//            broad `Bash(git *)` allow rule and force a confirmation prompt
+//            before any push to a protected branch lands.
+
+const PERM_08_EXPECTED_ASK = [
+  'Bash(git push * main*)',
+  'Bash(git push * master*)',
+  'Bash(git push * develop*)',
+  'Bash(git -C * push * main*)',
+  'Bash(git -C * push * master*)',
+  'Bash(git -C * push * develop*)',
+  'Bash(gh pr merge *--admin*)',
+];
+
+test('PERM-08: settings-sandbox.json template ships protected-branch ask rules (template shape)', () => {
+  const templatePath = path.resolve(
+    __dirname,
+    '..',
+    'gsd-ng',
+    'templates',
+    'settings-sandbox.json',
+  );
+  const template = JSON.parse(fs.readFileSync(templatePath, 'utf8'));
+  assert.ok(
+    Array.isArray(template.permissions.ask),
+    'template.permissions.ask must be an array (PERM-08)',
+  );
+  assert.strictEqual(
+    template.permissions.ask.length,
+    PERM_08_EXPECTED_ASK.length,
+    `template.permissions.ask must have exactly ${PERM_08_EXPECTED_ASK.length} entries (PERM-08) — catches accidental additions/removals`,
+  );
+  for (const pattern of PERM_08_EXPECTED_ASK) {
+    assert.ok(
+      template.permissions.ask.includes(pattern),
+      `template.permissions.ask must include ${pattern} (PERM-08)`,
+    );
+  }
+});
+
+test('PERM-08: local install propagates protected-branch ask rules into .claude/settings.json (round-trip)', () => {
+  const tmpDir = fs.mkdtempSync(path.join(BASE_TMPDIR, 'gsd-js-perm08-'));
+  try {
+    const result = spawnSync(
+      process.execPath,
+      [INSTALLER, '--runtime', 'claude', '--local'],
+      {
+        encoding: 'utf8',
+        timeout: 15000,
+        cwd: tmpDir,
+        env: Object.assign({}, process.env, { HOME: os.homedir() }),
+      },
+    );
+    assert.strictEqual(
+      result.status,
+      0,
+      'install.js --local must exit 0 (PERM-08)\nstderr: ' +
+        (result.stderr || ''),
+    );
+
+    const settingsPath = path.join(tmpDir, '.claude', 'settings.json');
+    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    assert.ok(
+      Array.isArray(settings.permissions.ask),
+      'settings.permissions.ask must be an array after install (PERM-08)',
+    );
+    for (const pattern of PERM_08_EXPECTED_ASK) {
+      assert.ok(
+        settings.permissions.ask.includes(pattern),
+        `settings.permissions.ask must include ${pattern} after install (PERM-08)`,
+      );
+    }
+  } finally {
+    cleanup(tmpDir);
+  }
+});
+
 // ── PERM-01: local install seeds permissions.allow with template entries ──────
 
 test('PERM-01: local install seeds permissions.allow with template entries (Bash(node *) and Agent(*))', () => {


### PR DESCRIPTION
## Summary

Add 7 protected-branch `ask` patterns to the bundled `settings-sandbox.json` template so Claude Code prompts before pushing to `main`/`master`/`develop` or merging a PR with `gh pr merge --admin`.

This is a local Layer-3 guardrail (Layer 1 = GitHub branch protection without bypass; Layer 2 = token scope reduction). `ask` rules take precedence over the broad `Bash(git *)` allow rule already in the template, forcing a confirmation prompt before any push to a protected branch.

Triggered by a 2026-05-01 incident where Claude bypassed develop's GitHub branch protection (admin-role token had bypass capability), pushed phase 49 work directly to develop, and opened a wrong-target PR. Recovery required force-pushing develop back.

## Patterns added

```json
"ask": [
  "Bash(git push * main*)",
  "Bash(git push * master*)",
  "Bash(git push * develop*)",
  "Bash(git -C * push * main*)",
  "Bash(git -C * push * master*)",
  "Bash(git -C * push * develop*)",
  "Bash(gh pr merge *--admin*)"
]
```

**Coverage:**
- Each `Bash(git push * <branch>*)` matches direct, `-u`, refspec (`branch:branch`, `HEAD:branch`), force-with-lease, and trailing-flag forms because Claude Code's `*` is greedy across whitespace.
- `Bash(git -C * push * <branch>*)` covers the submodule case (`git -C gsd-ng push origin develop`).
- `Bash(gh pr merge *--admin*)` is GitHub-specific. Verified that `glab mr merge`, `fj pr merge`, and `tea pr merge` have no `--admin` or force-bypass flag — adding ask rules for them would be no-op theater.
- Force-push to non-protected branches stays silent (per spec: "for the force option it should cover only develop/master/main").
- Bare `git push` (no args) is intentionally NOT covered — pattern matchers can't see the current branch. GitHub branch protection (Layer 1) is the defense for that case.

## Project policy

ALLOW-13 retirement note (REQUIREMENTS.md):
> Template remains allow-only; sandbox contains blast radius. **If hard-blocking becomes needed, use `ask` rules not `deny`.**

This change uses `ask`, leaves `deny` undefined, and respects PERM-06's `template.permissions.deny === undefined` invariant. Fully consistent with the retirement.

`gh api` policy unchanged in this PR — the "split gh api into reads-allowed / writes-asked" idea was discussed and explicitly deferred to a future phase (see 54-RESEARCH:61).

## Tests

New `PERM-08` test in `tests/install-js.test.cjs` with two subtests:
- **Template shape:** asserts `template.permissions.ask` is an array of length 7 containing all 7 expected patterns. Length assertion catches accidental additions/removals.
- **Install round-trip:** runs `install.js --runtime claude --local` in a tmpdir, reads the resulting `.claude/settings.json`, asserts `permissions.ask` contains all 7 patterns. Validates that the existing three-section sync in `install.js` (lines 1602-1666) correctly propagates the new array.

Both subtests share a module-scope `PERM_08_EXPECTED_ASK` constant — single source of truth between template and test, prevents drift.

## Test plan

- [x] `cd gsd-ng && node --test tests/install-js.test.cjs` — 65/65 pass (PERM-06 still passes; both PERM-08 subtests pass)
- [x] `cd gsd-ng && npm test` — 1926/1926 pass; +0 regressions
- [x] Manual install round-trip: `jq '.permissions.ask | length'` on freshly installed `settings.json` returns `7`
- [ ] CI green on all matrix jobs (ubuntu/macos × Node 22/24)

## Files modified

- `gsd-ng/templates/settings-sandbox.json` — adds `permissions.ask` (7 entries)
- `tests/install-js.test.cjs` — adds PERM-08 test (2 subtests, ~50 lines)

No code changes to `bin/install.js` (already supports `ask` sync), `bin/lib/allowlist.cjs`, or any runtime file.

---
*GSD quick task: 260501-ian (verify mode). Plan check: PASSED iter 1. Verifier: 5/5 must-haves passed.*
