### PR TITLE
Phase 59: runtime-agnostic content sweep

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -196,16 +196,18 @@ function resolveInstalledVersion(baseVersion) {
 // to avoid repeated git probes and guarantee consistency across all surfaces.
 const INSTALLED_VERSION = resolveInstalledVersion(pkg.version);
 
-console.log(buildBanner(INSTALLED_VERSION));
+if (require.main === module) {
+  console.log(buildBanner(INSTALLED_VERSION));
 
-if (hasUninstall) {
-  console.log(`  ${yellow}Mode: Uninstall${reset}\n`);
-}
+  if (hasUninstall) {
+    console.log(`  ${yellow}Mode: Uninstall${reset}\n`);
+  }
 
-// Show help if requested
-if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx gsd-ng [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}                       Install globally (to ~/.claude)\n    ${cyan}-l, --local${reset}                        Install locally (to current directory)\n    ${cyan}-u, --uninstall${reset}                    Uninstall GSD (requires --global or --local)\n    ${cyan}-h, --help${reset}                         Show this help message\n    ${cyan}--force-statusline${reset}                 Replace existing statusline config\n    ${cyan}--snapshot${reset}                         Force +hash build metadata in VERSION (auto-detected on non-tag commits)\n    ${cyan}--no-seed-permissions-config${reset}       Skip permissions.allow seeding\n    ${cyan}--no-seed-sandbox-config${reset}           Skip sandbox.enabled seeding (permissions still seeded)\n    ${cyan}--clean${reset}                            Wipe the GSD-managed tree before install (debugging / fresh-state reset)\n    ${cyan}--runtime <runtime>${reset}                Select runtime: claude or copilot (REQUIRED for non-interactive)\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx gsd-ng\n\n    ${dim}# Install Claude runtime globally${reset}\n    npx gsd-ng --runtime claude --global\n\n    ${dim}# Install Claude runtime to current project only${reset}\n    npx gsd-ng --runtime claude --local\n\n    ${dim}# Install for GitHub Copilot CLI (local)${reset}\n    npx gsd-ng --runtime copilot --local\n\n    ${dim}# Install for GitHub Copilot CLI (global)${reset}\n    npx gsd-ng --runtime copilot --global\n\n    ${dim}# Uninstall GSD globally${reset}\n    npx gsd-ng --runtime claude --global --uninstall\n\n    ${dim}# Uninstall Copilot CLI runtime globally${reset}\n    npx gsd-ng --runtime copilot --global --uninstall\n\n  ${yellow}Notes:${reset}\n    Sandbox mode is enabled by default. Use --no-seed-sandbox-config to skip it.\n`);
-  process.exit(0);
+  // Show help if requested
+  if (hasHelp) {
+    console.log(`  ${yellow}Usage:${reset} npx gsd-ng [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}                       Install globally (to ~/.claude)\n    ${cyan}-l, --local${reset}                        Install locally (to current directory)\n    ${cyan}-u, --uninstall${reset}                    Uninstall GSD (requires --global or --local)\n    ${cyan}-h, --help${reset}                         Show this help message\n    ${cyan}--force-statusline${reset}                 Replace existing statusline config\n    ${cyan}--snapshot${reset}                         Force +hash build metadata in VERSION (auto-detected on non-tag commits)\n    ${cyan}--no-seed-permissions-config${reset}       Skip permissions.allow seeding\n    ${cyan}--no-seed-sandbox-config${reset}           Skip sandbox.enabled seeding (permissions still seeded)\n    ${cyan}--clean${reset}                            Wipe the GSD-managed tree before install (debugging / fresh-state reset)\n    ${cyan}--runtime <runtime>${reset}                Select runtime: claude or copilot (REQUIRED for non-interactive)\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx gsd-ng\n\n    ${dim}# Install Claude runtime globally${reset}\n    npx gsd-ng --runtime claude --global\n\n    ${dim}# Install Claude runtime to current project only${reset}\n    npx gsd-ng --runtime claude --local\n\n    ${dim}# Install for GitHub Copilot CLI (local)${reset}\n    npx gsd-ng --runtime copilot --local\n\n    ${dim}# Install for GitHub Copilot CLI (global)${reset}\n    npx gsd-ng --runtime copilot --global\n\n    ${dim}# Uninstall GSD globally${reset}\n    npx gsd-ng --runtime claude --global --uninstall\n\n    ${dim}# Uninstall Copilot CLI runtime globally${reset}\n    npx gsd-ng --runtime copilot --global --uninstall\n\n  ${yellow}Notes:${reset}\n    Sandbox mode is enabled by default. Use --no-seed-sandbox-config to skip it.\n`);
+    process.exit(0);
+  }
 }
 
 /**
@@ -1024,16 +1026,10 @@ function convertClaudeToCopilotContent(content, isGlobal = false) {
     out = out.replace(/\.\/\.claude\//g, './.github/');
   }
 
-  // Slash command prefix: gsd: → gsd- (applies to all Markdown content)
-  out = out.replace(/gsd:/g, 'gsd-');
-
   // Resolve {{variables}} and <!-- ONLY:x --> conditional blocks via template-processor.
   // Path rewriting stays above (separate per design — CONTEXT.md Decision #7).
   const ctx = buildContext('copilot');
   out = processTemplate(out, ctx);
-
-  // Standalone CLAUDE.md references → copilot-instructions.md
-  out = out.replace(/\bCLAUDE\.md\b/g, 'copilot-instructions.md');
 
   return out;
 }
@@ -2028,53 +2024,57 @@ function promptLocation(callback) {
   });
 }
 
-// Main logic
-if (hasGlobal && hasLocal) {
-  console.error(`  ${yellow}Cannot specify both --global and --local${reset}`);
-  process.exit(1);
-} else if (hasUninstall) {
-  if (!hasGlobal && !hasLocal) {
-    console.error(`  ${yellow}--uninstall requires --global or --local${reset}`);
+// Main logic — only runs when executed directly, not when require()d by tests
+if (require.main === module) {
+  if (hasGlobal && hasLocal) {
+    console.error(`  ${yellow}Cannot specify both --global and --local${reset}`);
     process.exit(1);
-  }
-  if (!runtime) {
-    console.error(`  ${yellow}Error: --runtime required. Use --runtime claude or --runtime copilot${reset}`);
-    process.exit(1);
-  }
-  uninstall(hasGlobal);
-} else if (hasGlobal || hasLocal) {
-  // Non-interactive: --runtime is REQUIRED
-  if (!runtime) {
-    console.error(`  ${yellow}Error: --runtime required. Use --runtime claude or --runtime copilot${reset}`);
-    process.exit(1);
-  }
-  installAndFinish(hasGlobal, false);
-} else {
-  // Interactive
-  if (!process.stdin.isTTY) {
-    console.error(`  ${yellow}Non-interactive terminal detected. Use --runtime with --global or --local.${reset}\n`);
-    console.error(`  ${dim}Examples:${reset}\n    npx gsd-ng --runtime claude --global\n    npx gsd-ng --runtime claude --local\n    npx gsd-ng --runtime copilot --local\n`);
-    process.exit(1);
+  } else if (hasUninstall) {
+    if (!hasGlobal && !hasLocal) {
+      console.error(`  ${yellow}--uninstall requires --global or --local${reset}`);
+      process.exit(1);
+    }
+    if (!runtime) {
+      console.error(`  ${yellow}Error: --runtime required. Use --runtime claude or --runtime copilot${reset}`);
+      process.exit(1);
+    }
+    uninstall(hasGlobal);
+  } else if (hasGlobal || hasLocal) {
+    // Non-interactive: --runtime is REQUIRED
+    if (!runtime) {
+      console.error(`  ${yellow}Error: --runtime required. Use --runtime claude or --runtime copilot${reset}`);
+      process.exit(1);
+    }
+    installAndFinish(hasGlobal, false);
   } else {
-    // Interactive flow: runtime -> location -> sandbox (Claude only)
-    promptRuntime((selectedRuntime) => {
-      runtime = selectedRuntime;
-      promptLocation((isGlobal) => {
-        if (runtime === 'claude') {
-          // Claude: ask about sandbox mode
-          const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-          askSandboxMode(rl, (enableSandbox) => {
-            rl.close();
-            if (!enableSandbox) {
-              noSeedSandboxConfig = true;
-            }
+    // Interactive
+    if (!process.stdin.isTTY) {
+      console.error(`  ${yellow}Non-interactive terminal detected. Use --runtime with --global or --local.${reset}\n`);
+      console.error(`  ${dim}Examples:${reset}\n    npx gsd-ng --runtime claude --global\n    npx gsd-ng --runtime claude --local\n    npx gsd-ng --runtime copilot --local\n`);
+      process.exit(1);
+    } else {
+      // Interactive flow: runtime -> location -> sandbox (Claude only)
+      promptRuntime((selectedRuntime) => {
+        runtime = selectedRuntime;
+        promptLocation((isGlobal) => {
+          if (runtime === 'claude') {
+            // Claude: ask about sandbox mode
+            const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+            askSandboxMode(rl, (enableSandbox) => {
+              rl.close();
+              if (!enableSandbox) {
+                noSeedSandboxConfig = true;
+              }
+              installAndFinish(isGlobal, true);
+            });
+          } else {
+            // Copilot has no sandbox model -- skip sandbox prompt
             installAndFinish(isGlobal, true);
-          });
-        } else {
-          // Copilot has no sandbox model -- skip sandbox prompt
-          installAndFinish(isGlobal, true);
-        }
+          }
+        });
       });
-    });
+    }
   }
 }
+
+module.exports = { convertClaudeToCopilotContent };

--- a/commands/gsd/add-tests.md
+++ b/commands/gsd/add-tests.md
@@ -13,8 +13,8 @@ allowed-tools:
   - AskUserQuestion
 argument-instructions: |
   Parse the argument as a phase number (integer, decimal, or letter-suffix), plus optional free-text instructions.
-  Example: /gsd:add-tests 12
-  Example: /gsd:add-tests 12 focus on edge cases in the pricing module
+  Example: {{COMMAND_PREFIX}}add-tests 12
+  Example: {{COMMAND_PREFIX}}add-tests 12 focus on edge cases in the pricing module
 ---
 
 

--- a/commands/gsd/complete-milestone.md
+++ b/commands/gsd/complete-milestone.md
@@ -70,19 +70,19 @@ Key constraints:
 0. **Check for audit:**
 
    - Look for `.planning/v{{version}}-MILESTONE-AUDIT.md`
-   - If missing or stale: recommend `/gsd:audit-milestone` first
-   - If audit status is `gaps_found`: recommend `/gsd:plan-milestone-gaps` first
+   - If missing or stale: recommend `{{COMMAND_PREFIX}}audit-milestone` first
+   - If audit status is `gaps_found`: recommend `{{COMMAND_PREFIX}}plan-milestone-gaps` first
    - If audit status is `passed`: proceed to step 1
 
    ```markdown
    ## Pre-flight Check
 
    {If no v{{version}}-MILESTONE-AUDIT.md:}
-   ⚠ No milestone audit found. Run `/gsd:audit-milestone` first to verify
+   ⚠ No milestone audit found. Run `{{COMMAND_PREFIX}}audit-milestone` first to verify
    requirements coverage, cross-phase integration, and E2E flows.
 
    {If audit has gaps:}
-   ⚠ Milestone audit found gaps. Run `/gsd:plan-milestone-gaps` to create
+   ⚠ Milestone audit found gaps. Run `{{COMMAND_PREFIX}}plan-milestone-gaps` to create
    phases that close the gaps, or proceed anyway to accept as tech debt.
 
    {If audit passed:}
@@ -136,7 +136,7 @@ Key constraints:
    - Ask about pushing tag
 
 8. **Offer next steps:**
-   - `/gsd:new-milestone` — start next milestone (questioning → research → requirements → roadmap)
+   - `{{COMMAND_PREFIX}}new-milestone` — start next milestone (questioning → research → requirements → roadmap)
 
 </process>
 
@@ -160,5 +160,5 @@ Key constraints:
 - **Archive before deleting:** Always create archive files before updating/deleting originals
 - **One-line summary:** Collapsed milestone in ROADMAP.md should be single line with link
 - **Context efficiency:** Archive keeps ROADMAP.md and REQUIREMENTS.md constant size per milestone
-- **Fresh requirements:** Next milestone starts with `/gsd:new-milestone` which includes requirements definition
+- **Fresh requirements:** Next milestone starts with `{{COMMAND_PREFIX}}new-milestone` which includes requirements definition
   </critical_rules>

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -148,7 +148,7 @@ Agent(
 - Display root cause and evidence summary
 - Offer options:
   - "Fix now" - spawn fix subagent
-  - "Plan fix" - suggest /gsd:plan-phase --gaps
+  - "Plan fix" - suggest {{COMMAND_PREFIX}}plan-phase --gaps
   - "Manual fix" - done
 
 **If `## CHECKPOINT REACHED`:**

--- a/commands/gsd/do.md
+++ b/commands/gsd/do.md
@@ -14,7 +14,7 @@ Analyze freeform natural language input and dispatch to the most appropriate GSD
 
 Acts as a smart dispatcher — never does the work itself. Matches intent to the best GSD command using routing rules, confirms the match, then hands off.
 
-Use when you know what you want but don't know which `/gsd:*` command to run.
+Use when you know what you want but don't know which `{{COMMAND_PREFIX}}*` command to run.
 </objective>
 
 <execution_context>

--- a/commands/gsd/map-codebase.md
+++ b/commands/gsd/map-codebase.md
@@ -58,8 +58,8 @@ Focus area: $ARGUMENTS (optional - if provided, tells agents to focus on specifi
 Check for .planning/STATE.md - loads context if project already initialized
 
 **This command can run:**
-- Before /gsd:new-project (brownfield codebases) - creates codebase map first
-- After /gsd:new-project (greenfield codebases) - updates codebase map as code evolves
+- Before {{COMMAND_PREFIX}}new-project (brownfield codebases) - creates codebase map first
+- After {{COMMAND_PREFIX}}new-project (greenfield codebases) - updates codebase map as code evolves
 - Anytime to refresh codebase understanding
 </context>
 
@@ -87,7 +87,7 @@ Check for .planning/STATE.md - loads context if project already initialized
 4. Wait for agents to complete, collect confirmations (NOT document contents)
 5. Verify all 7 documents exist with line counts
 6. Commit codebase map
-7. Offer next steps (typically: /gsd:new-project or /gsd:plan-phase)
+7. Offer next steps (typically: {{COMMAND_PREFIX}}new-project or {{COMMAND_PREFIX}}plan-phase)
 </process>
 
 <success_criteria>

--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -23,7 +23,7 @@ Brownfield equivalent of new-project. Project exists, PROJECT.md has history. Ga
 - `.planning/ROADMAP.md` — phase structure (continues numbering)
 - `.planning/STATE.md` — reset for new milestone
 
-**After:** `/gsd:plan-phase [N]` to start execution.
+**After:** `{{COMMAND_PREFIX}}plan-phase [N]` to start execution.
 </objective>
 
 <execution_context>

--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -27,7 +27,7 @@ Initialize a new project through unified flow: questioning → research (optiona
 - `.planning/ROADMAP.md` — phase structure
 - `.planning/STATE.md` — project memory
 
-**After this command:** Run `/gsd:plan-phase 1` to start execution.
+**After this command:** Run `{{COMMAND_PREFIX}}plan-phase 1` to start execution.
 </objective>
 
 <execution_context>

--- a/commands/gsd/plan-milestone-gaps.md
+++ b/commands/gsd/plan-milestone-gaps.md
@@ -12,11 +12,11 @@ allowed-tools:
 
 
 <objective>
-Create all phases necessary to close gaps identified by `/gsd:audit-milestone`.
+Create all phases necessary to close gaps identified by `{{COMMAND_PREFIX}}audit-milestone`.
 
 Reads MILESTONE-AUDIT.md, groups gaps into logical phases, creates phase entries in ROADMAP.md, and offers to plan each phase.
 
-One command creates all fix phases — no manual `/gsd:add-phase` per gap.
+One command creates all fix phases — no manual `{{COMMAND_PREFIX}}add-phase` per gap.
 </objective>
 
 <execution_context>

--- a/commands/gsd/reapply-patches.md
+++ b/commands/gsd/reapply-patches.md
@@ -55,7 +55,7 @@ Read `backup-meta.json` from the patches directory.
 ```
 No local patches found. Nothing to reapply.
 
-Local patches are automatically saved when you run /gsd:update
+Local patches are automatically saved when you run {{COMMAND_PREFIX}}update
 after modifying any GSD workflow, command, or agent files.
 ```
 Exit.
@@ -103,7 +103,7 @@ For each file in `backup-meta.json`:
 After reapplying, regenerate the file manifest so future updates correctly detect these as user modifications:
 
 ```bash
-# The manifest will be regenerated on next /gsd:update
+# The manifest will be regenerated on next {{COMMAND_PREFIX}}update
 # For now, just note which files were modified
 ```
 

--- a/commands/gsd/research-phase.md
+++ b/commands/gsd/research-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:research-phase
-description: Research how to implement a phase (standalone - usually use /gsd:plan-phase instead)
+description: Research how to implement a phase (standalone - usually use {{COMMAND_PREFIX}}plan-phase instead)
 argument-hint: "[phase]"
 allowed-tools:
   - Read
@@ -11,7 +11,7 @@ allowed-tools:
 <objective>
 Research how to implement a phase. Spawns gsd-phase-researcher agent with phase context.
 
-**Note:** This is a standalone research command. For most workflows, use `/gsd:plan-phase` which integrates research automatically.
+**Note:** This is a standalone research command. For most workflows, use `{{COMMAND_PREFIX}}plan-phase` which integrates research automatically.
 
 **Use this command when:**
 - You want to research without planning yet
@@ -109,7 +109,7 @@ Mode: ecosystem
 </additional_context>
 
 <downstream_consumer>
-Your RESEARCH.md will be loaded by `/gsd:plan-phase` which uses specific sections:
+Your RESEARCH.md will be loaded by `{{COMMAND_PREFIX}}plan-phase` which uses specific sections:
 - `## Standard Stack` → Plans use these libraries
 - `## Architecture Patterns` → Task structure follows these
 - `## Don't Hand-Roll` → Tasks NEVER build custom solutions for listed problems

--- a/commands/gsd/seed-memories.md
+++ b/commands/gsd/seed-memories.md
@@ -12,7 +12,7 @@ argument-hint: "[--force]"
 ---
 
 
-Detect workspace topology (submodule, monorepo, standalone) and seed appropriate structure-hazard memories into the active runtime's memory directory. Updates both the project rules file (`CLAUDE.md` for Claude, `.github/copilot-instructions.md` for Copilot) and the memory index (`MEMORY.md`) underneath that memory directory.
+Detect workspace topology (submodule, monorepo, standalone) and seed appropriate structure-hazard memories into the active runtime's memory directory. Updates the project rules file (`{{PROJECT_RULES_FILE}}`) and the memory index (`MEMORY.md`) underneath that memory directory.
 
 This skill is re-runnable; runtime topology may have changed since install. All runtime-divergent paths are detected fresh at skill-execution time (Step 5 below) — the skill does NOT rely on install-time template variables.
 
@@ -30,25 +30,30 @@ This skill is re-runnable; runtime topology may have changed since install. All 
 
    Check workspace topology:
    - If `.claude/` directory exists at workspace root → runtime is Claude.
-   - If `.github/copilot-instructions.md` exists at workspace root → runtime is Copilot.
+<!-- ONLY:copilot -->
+   - If `{{PROJECT_RULES_FILE}}` exists at workspace root → runtime is Copilot.
+<!-- /ONLY:copilot -->
    - If both exist, prefer the runtime that owns the active session (consult `.planning/config.json` `runtime:` field).
 
    Per detected runtime, use the correct paths:
 
-   | Runtime | Project rules file                  | Memory directory  | Section style                                                                  |
-   |---------|--------------------------------------|-------------------|--------------------------------------------------------------------------------|
-   | Claude  | `CLAUDE.md`                          | `.claude/memory/` | Top-level Markdown headings (`## GSD`, `## Memories`)                          |
-   | Copilot | `.github/copilot-instructions.md`    | `.github/memory/` | Inside `<!-- GSD Configuration -->` / `<!-- /GSD Configuration -->` markers    |
+   | Runtime        | Project rules file         | Memory directory   | Section style                                                               |
+   |----------------|----------------------------|--------------------|-----------------------------------------------------------------------------|
+   | Active runtime | `{{PROJECT_RULES_FILE}}`   | `{{MEMORY_DIR}}`   | `{{GSD_BLOCK_OPEN}}` / `{{GSD_BLOCK_CLOSE}}` delimiters                    |
 
    Scan the runtime's memory directory (`.claude/memory/*.md` for Claude, `.github/memory/*.md` for Copilot) and regenerate the project rules file's Memories section (append if file exists, create if not). Also write/update the `## GSD` metadata section above the Memories section using the workspace type from Step 1:
    - For non-standalone workspaces: `## GSD\n\n**Workspace type:** {type}\n**Detection signal:** {signal}`
    - For standalone workspaces: `## GSD\n\n**Workspace type:** standalone`
+<!-- ONLY:claude -->
    - **Heading-based (Claude):** If the project rules file already has a `## GSD` section, replace it in-place. If not, insert it before the `## Memories` section.
-   - **Marker-based (Copilot):** Write the GSD + Memories content inside the `<!-- GSD Configuration -->` / `<!-- /GSD Configuration -->` marker pair using insert/replace-in-place logic. If the markers are absent, append the marker block at end of file. This preserves existing non-GSD content in `.github/copilot-instructions.md`.
+<!-- /ONLY:claude -->
+<!-- ONLY:copilot -->
+   - **Marker-based (Copilot):** Write the GSD + Memories content inside the `<!-- GSD Configuration -->` / `<!-- /GSD Configuration -->` marker pair using insert/replace-in-place logic. If the markers are absent, append the marker block at end of file. This preserves existing non-GSD content in `{{PROJECT_RULES_FILE}}`.
+<!-- /ONLY:copilot -->
 6. Regenerate `MEMORY.md` inside the detected memory directory from the current memory files.
 7. Commit changes using the detected project rules file as the updated file.
 
 **If `--force` flag:** Skip confirmation, bypass skip detection, and overwrite existing memory files even if existing memories already cover the concept.
 **Otherwise:** Show what would be seeded and ask user to confirm via {{USER_QUESTION_TOOL}} before writing.
 
-Run from: `/gsd:seed-memories`
+Run from: `{{COMMAND_PREFIX}}seed-memories`

--- a/commands/gsd/verify-work.md
+++ b/commands/gsd/verify-work.md
@@ -19,7 +19,7 @@ Validate built features through conversational testing with persistent state.
 
 Purpose: Confirm what Claude built actually works from user's perspective. One test at a time, plain text responses, no interrogation. When issues are found, automatically diagnose, plan fixes, and prepare for execution.
 
-Output: {phase_num}-UAT.md tracking all test results. If issues found: diagnosed gaps, verified fix plans ready for /gsd:execute-phase
+Output: {phase_num}-UAT.md tracking all test results. If issues found: diagnosed gaps, verified fix plans ready for {{COMMAND_PREFIX}}execute-phase
 </objective>
 
 <tool_usage>

--- a/gsd-ng/references/claude-model-profiles.md
+++ b/gsd-ng/references/claude-model-profiles.md
@@ -70,7 +70,7 @@ Overrides take precedence over the profile. Valid values: `opus`, `sonnet`, `hai
 
 ## Switching Profiles
 
-Runtime: `/gsd:set-profile <profile>`
+Runtime: `{{COMMAND_PREFIX}}set-profile <profile>`
 
 Per-project default: Set in `.planning/config.json`:
 ```json

--- a/gsd-ng/references/continuation-format.md
+++ b/gsd-ng/references/continuation-format.md
@@ -44,7 +44,7 @@ Standard format for presenting next steps after completing a command or workflow
 
 **02-03: Refresh Token Rotation** — Add /api/auth/refresh with sliding expiry
 
-`/gsd:execute-phase 2`
+`{{COMMAND_PREFIX}}execute-phase 2`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -52,7 +52,7 @@ Standard format for presenting next steps after completing a command or workflow
 
 **Also available:**
 - Review plan before executing
-- `/gsd:list-phase-assumptions 2` — check assumptions
+- `{{COMMAND_PREFIX}}list-phase-assumptions 2` — check assumptions
 
 ---
 ```
@@ -69,7 +69,7 @@ Add note that this is the last plan and what comes after:
 **02-03: Refresh Token Rotation** — Add /api/auth/refresh with sliding expiry
 <sub>Final plan in Phase 2</sub>
 
-`/gsd:execute-phase 2`
+`{{COMMAND_PREFIX}}execute-phase 2`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -91,15 +91,15 @@ Add note that this is the last plan and what comes after:
 
 **Phase 2: Authentication** — JWT login flow with refresh tokens
 
-`/gsd:plan-phase 2`
+`{{COMMAND_PREFIX}}plan-phase 2`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:discuss-phase 2` — gather context first
-- `/gsd:research-phase 2` — investigate unknowns
+- `{{COMMAND_PREFIX}}discuss-phase 2` — gather context first
+- `{{COMMAND_PREFIX}}research-phase 2` — investigate unknowns
 - Review roadmap
 
 ---
@@ -120,15 +120,15 @@ Show completion status before next action:
 
 **Phase 3: Core Features** — User dashboard, settings, and data export
 
-`/gsd:plan-phase 3`
+`{{COMMAND_PREFIX}}plan-phase 3`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:discuss-phase 3` — gather context first
-- `/gsd:research-phase 3` — investigate unknowns
+- `{{COMMAND_PREFIX}}discuss-phase 3` — gather context first
+- `{{COMMAND_PREFIX}}research-phase 3` — investigate unknowns
 - Review what Phase 2 built
 
 ---
@@ -145,11 +145,11 @@ When there's no clear primary action:
 
 **Phase 3: Core Features** — User dashboard, settings, and data export
 
-**To plan directly:** `/gsd:plan-phase 3`
+**To plan directly:** `{{COMMAND_PREFIX}}plan-phase 3`
 
-**To discuss context first:** `/gsd:discuss-phase 3`
+**To discuss context first:** `{{COMMAND_PREFIX}}discuss-phase 3`
 
-**To research unknowns:** `/gsd:research-phase 3`
+**To research unknowns:** `{{COMMAND_PREFIX}}research-phase 3`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -169,7 +169,7 @@ All 4 phases shipped
 
 **Start v1.1** — questioning → research → requirements → roadmap
 
-`/gsd:new-milestone`
+`{{COMMAND_PREFIX}}new-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -214,7 +214,7 @@ Extract: `**02-03: Refresh Token Rotation** — Add /api/auth/refresh with slidi
 ## To Continue
 
 Run `/clear`, then paste:
-/gsd:execute-phase 2
+{{COMMAND_PREFIX}}execute-phase 2
 ```
 
 User has no idea what 02-03 is about.
@@ -222,7 +222,7 @@ User has no idea what 02-03 is about.
 ### Don't: Missing /clear explanation
 
 ```
-`/gsd:plan-phase 3`
+`{{COMMAND_PREFIX}}plan-phase 3`
 
 Run /clear first.
 ```
@@ -242,7 +242,7 @@ Sounds like an afterthought. Use "Also available:" instead.
 
 ```
 ```
-/gsd:plan-phase 3
+{{COMMAND_PREFIX}}plan-phase 3
 ```
 ```
 

--- a/gsd-ng/references/planning-config.md
+++ b/gsd-ng/references/planning-config.md
@@ -87,6 +87,29 @@ The CLI checks `commit_docs` config and gitignore status internally — no manua
 
 </commit_docs_behavior>
 
+<workflow_config>
+
+**Workflow Toggles:**
+
+Boolean toggles that gate optional steps in GSD workflows. Set to `false` to disable. Defaults preserve current behavior — adding the key is opt-out.
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `workflow.research` | `true` | Spawn researcher subagent during `plan-phase` |
+| `workflow.plan_check` | `true` | Spawn plan checker during `plan-phase` |
+| `workflow.verifier` | `true` | Spawn verifier subagent during `execute-phase` |
+| `workflow.nyquist_validation` | `true` | Validation-architecture research during `plan-phase` |
+| `workflow.ui_phase` | `true` | Generate UI-SPEC.md design contracts for frontend phases |
+| `workflow.ui_safety_gate` | `true` | Prompt to run `{{COMMAND_PREFIX}}ui-phase` before planning frontend phases |
+| `workflow.node_repair` | `true` | Auto-attempt RETRY/DECOMPOSE/PRUNE on verification failure during `execute-plan` |
+| `workflow.node_repair_budget` | `2` | Max repair attempts per failing task before ESCALATE |
+| `workflow.incremental_remap` | `true` | Auto-update codebase docs after phase completion via `gsd-incremental-mapper` agents. Set `false` to skip — useful when codebase docs are intentionally manual or when phase work doesn't touch documented modules. |
+| `workflow.auto_advance` | `false` | Auto-chain phases without user confirmation (yolo mode) |
+
+**Settings UI exposure:** Most toggles surface in `{{COMMAND_PREFIX}}settings`. Internal performance/quality tweaks (`node_repair`, `node_repair_budget`) are config-only — edit `.planning/config.json` directly.
+
+</workflow_config>
+
 <search_behavior>
 
 **When `search_gitignored: false` (default):**
@@ -238,7 +261,7 @@ GSD uses a two-layer branch model for team collaboration:
 
 1. **Work branch** (Layer 1): GSD's internal branch for atomic per-task commits. Controlled by existing `branching_strategy`, `phase_branch_template`, `milestone_branch_template`. Based from `target_branch` instead of current HEAD.
 
-2. **Review branch** (Layer 2): Team-facing branch created by `/gsd:create-pr`. Named via `review_branch_template`. Contains squashed commits for clean PR history.
+2. **Review branch** (Layer 2): Team-facing branch created by `{{COMMAND_PREFIX}}create-pr`. Named via `review_branch_template`. Contains squashed commits for clean PR history.
 
 **Target Branch:**
 
@@ -247,7 +270,7 @@ The `target_branch` determines:
 - PR target: PRs opened against this branch
 - Merge target in `complete-milestone`
 
-Per-milestone override: `/gsd:new-milestone --target-branch develop`
+Per-milestone override: `{{COMMAND_PREFIX}}new-milestone --target-branch develop`
 
 **Review Branch Template Variables:**
 

--- a/gsd-ng/references/ui-brand.md
+++ b/gsd-ng/references/ui-brand.md
@@ -115,8 +115,8 @@ Always at end of major completions.
 ───────────────────────────────────────────────────────────────
 
 **Also available:**
-- `/gsd:alternative-1` — description
-- `/gsd:alternative-2` — description
+- `{{COMMAND_PREFIX}}alternative-1` — description
+- `{{COMMAND_PREFIX}}alternative-2` — description
 
 ───────────────────────────────────────────────────────────────
 ```

--- a/gsd-ng/workflows/add-phase.md
+++ b/gsd-ng/workflows/add-phase.md
@@ -11,15 +11,15 @@ Read all files referenced by the invoking prompt's execution_context before star
 <step name="parse_arguments">
 Parse the command arguments:
 - All arguments become the phase description
-- Example: `/gsd:add-phase Add authentication` → description = "Add authentication"
-- Example: `/gsd:add-phase Fix critical performance issues` → description = "Fix critical performance issues"
+- Example: `{{COMMAND_PREFIX}}add-phase Add authentication` → description = "Add authentication"
+- Example: `{{COMMAND_PREFIX}}add-phase Fix critical performance issues` → description = "Fix critical performance issues"
 
 If no arguments provided:
 
 ```
 ERROR: Phase description required
-Usage: /gsd:add-phase <description>
-Example: /gsd:add-phase Add authentication system
+Usage: {{COMMAND_PREFIX}}add-phase <description>
+Example: {{COMMAND_PREFIX}}add-phase Add authentication system
 ```
 
 Exit.
@@ -42,7 +42,7 @@ fi
 Check `roadmap_exists` from init JSON. If false:
 ```
 ERROR: No roadmap found (.planning/ROADMAP.md)
-Run /gsd:new-project to initialize.
+Run {{COMMAND_PREFIX}}new-project to initialize.
 ```
 Exit.
 </step>
@@ -93,14 +93,14 @@ Roadmap updated: .planning/ROADMAP.md
 
 **Phase {N}: {description}**
 
-`/gsd:plan-phase {N}`
+`{{COMMAND_PREFIX}}plan-phase {N}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:add-phase <description>` — add another phase
+- `{{COMMAND_PREFIX}}add-phase <description>` — add another phase
 - Review roadmap
 
 ---

--- a/gsd-ng/workflows/add-tests.md
+++ b/gsd-ng/workflows/add-tests.md
@@ -1,7 +1,7 @@
 <purpose>
 Generate unit and E2E tests for a completed phase based on its SUMMARY.md, CONTEXT.md, and implementation. Classifies each changed file into TDD (unit), E2E (browser), or Skip categories, presents a test plan for user approval, then generates tests following RED-GREEN conventions.
 
-Users currently hand-craft `/gsd:quick` prompts for test generation after each phase. This workflow standardizes the process with proper classification, quality gates, and gap reporting.
+Users currently hand-craft `{{COMMAND_PREFIX}}quick` prompts for test generation after each phase. This workflow standardizes the process with proper classification, quality gates, and gap reporting.
 </purpose>
 
 @~/.claude/gsd-ng/references/ask-user-question.md
@@ -17,15 +17,15 @@ Parse `$ARGUMENTS` for:
 - Phase number (integer, decimal, or letter-suffix) → store as `$PHASE_ARG`
 - Remaining text after phase number → store as `$EXTRA_INSTRUCTIONS` (optional)
 
-Example: `/gsd:add-tests 12 focus on edge cases` → `$PHASE_ARG=12`, `$EXTRA_INSTRUCTIONS="focus on edge cases"`
+Example: `{{COMMAND_PREFIX}}add-tests 12 focus on edge cases` → `$PHASE_ARG=12`, `$EXTRA_INSTRUCTIONS="focus on edge cases"`
 
 If no phase argument provided:
 
 ```
 ERROR: Phase number required
-Usage: /gsd:add-tests <phase> [additional instructions]
-Example: /gsd:add-tests 12
-Example: /gsd:add-tests 12 focus on edge cases in the pricing module
+Usage: {{COMMAND_PREFIX}}add-tests <phase> [additional instructions]
+Example: {{COMMAND_PREFIX}}add-tests 12
+Example: {{COMMAND_PREFIX}}add-tests 12 focus on edge cases in the pricing module
 ```
 
 Exit.
@@ -62,7 +62,7 @@ Read the phase artifacts (in order of priority):
 If no SUMMARY.md exists:
 ```
 ERROR: No SUMMARY.md found for phase ${PHASE_ARG}
-This command works on completed phases. Run /gsd:execute-phase first.
+This command works on completed phases. Run {{COMMAND_PREFIX}}execute-phase first.
 ```
 Exit.
 
@@ -318,7 +318,7 @@ Present next steps:
 ## ▶ Next Up
 
 {if bugs discovered:}
-**Fix discovered bugs:** `/gsd:quick fix the {N} test failures discovered in phase ${phase_number}`
+**Fix discovered bugs:** `{{COMMAND_PREFIX}}quick fix the {N} test failures discovered in phase ${phase_number}`
 
 {if blocked tests:}
 **Resolve test blockers:** {description of what's needed}
@@ -331,8 +331,8 @@ Present next steps:
 ---
 
 **Also available:**
-- `/gsd:add-tests {next_phase}` — test another phase
-- `/gsd:verify-work {phase_number}` — run UAT verification
+- `{{COMMAND_PREFIX}}add-tests {next_phase}` — test another phase
+- `{{COMMAND_PREFIX}}verify-work {phase_number}` — run UAT verification
 
 ---
 ```

--- a/gsd-ng/workflows/add-todo.md
+++ b/gsd-ng/workflows/add-todo.md
@@ -36,7 +36,7 @@ Note existing areas from the todos array for consistency in infer_area step.
 
 <step name="extract_content">
 **With arguments:** Use as the title/focus.
-- `/gsd:add-todo Add auth token refresh` → title = "Add auth token refresh"
+- `{{COMMAND_PREFIX}}add-todo Add auth token refresh` → title = "Add auth token refresh"
 
 **Without arguments:** Analyze recent conversation to extract:
 - The specific problem, idea, or task discussed
@@ -136,7 +136,7 @@ files:
 **Recurring todos:** If the user specifies this should be a recurring or permanent reminder, add `recurring: true` and `interval: {duration}` to the frontmatter (uncomment and fill those fields). Valid interval formats: `7d`, `14d`, `30d`, `90d` (any Nd/Nw/Nm/Ny format — d=days, w=weeks, m=months, y=years). Do NOT add `last_completed` — it will be set automatically on first completion. Recurring todos stay in `pending/` after completion and resurface when their interval elapses.
 
 The `--recurring` and `--interval` flags are recognized when invoking via arguments:
-- `/gsd:add-todo Check upstream changes --recurring --interval 30d`
+- `{{COMMAND_PREFIX}}add-todo Check upstream changes --recurring --interval 30d`
 </step>
 
 <step name="update_state">
@@ -209,10 +209,10 @@ Then use AskUserQuestion:
 - options:
   - "Continue with current work" -- return to what you were doing; exit workflow
   - "Add another todo" -- capture another todo now
-  - "View all todos" -- run /gsd:check-todos
+  - "View all todos" -- run {{COMMAND_PREFIX}}check-todos
 
-If user selects "Add another todo": loop back to the `extract_content` step within this same workflow invocation (do NOT invoke a fresh /gsd:add-todo).
-If user selects "View all todos": invoke /gsd:check-todos (the workflow reference, not inline summary).
+If user selects "Add another todo": loop back to the `extract_content` step within this same workflow invocation (do NOT invoke a fresh {{COMMAND_PREFIX}}add-todo).
+If user selects "View all todos": invoke {{COMMAND_PREFIX}}check-todos (the workflow reference, not inline summary).
 If user selects "Continue with current work": exit the workflow.
 </step>
 

--- a/gsd-ng/workflows/audit-milestone.md
+++ b/gsd-ng/workflows/audit-milestone.md
@@ -156,7 +156,7 @@ Classify per phase:
 
 Add to audit YAML: `nyquist: { compliant_phases, partial_phases, missing_phases, overall }`
 
-Discovery only — never auto-calls `/gsd:validate-phase`.
+Discovery only — never auto-calls `{{COMMAND_PREFIX}}validate-phase`.
 
 ## 6. Aggregate into v{version}-MILESTONE-AUDIT.md
 
@@ -227,7 +227,7 @@ All requirements covered. Cross-phase integration verified. E2E flows complete.
 
 **Complete milestone** — archive and tag
 
-`/gsd:complete-milestone {version}`
+`{{COMMAND_PREFIX}}complete-milestone {version}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -262,9 +262,9 @@ All requirements covered. Cross-phase integration verified. E2E flows complete.
 
 | Phase | VALIDATION.md | Compliant | Action |
 |-------|---------------|-----------|--------|
-| {phase} | exists/missing | true/false/partial | `/gsd:validate-phase {N}` |
+| {phase} | exists/missing | true/false/partial | `{{COMMAND_PREFIX}}validate-phase {N}` |
 
-Phases needing validation: run `/gsd:validate-phase {N}` for each flagged phase.
+Phases needing validation: run `{{COMMAND_PREFIX}}validate-phase {N}` for each flagged phase.
 
 ───────────────────────────────────────────────────────────────
 
@@ -272,7 +272,7 @@ Phases needing validation: run `/gsd:validate-phase {N}` for each flagged phase.
 
 **Plan gap closure** — create phases to complete milestone
 
-`/gsd:plan-milestone-gaps`
+`{{COMMAND_PREFIX}}plan-milestone-gaps`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -280,7 +280,7 @@ Phases needing validation: run `/gsd:validate-phase {N}` for each flagged phase.
 
 **Also available:**
 - cat .planning/v{version}-MILESTONE-AUDIT.md — see full report
-- /gsd:complete-milestone {version} — proceed anyway (accept tech debt)
+- {{COMMAND_PREFIX}}complete-milestone {version} — proceed anyway (accept tech debt)
 
 ───────────────────────────────────────────────────────────────
 
@@ -310,11 +310,11 @@ All requirements met. No critical blockers. Accumulated tech debt needs review.
 
 **A. Complete milestone** — accept debt, track in backlog
 
-`/gsd:complete-milestone {version}`
+`{{COMMAND_PREFIX}}complete-milestone {version}`
 
 **B. Plan cleanup phase** — address debt before completing
 
-`/gsd:plan-milestone-gaps`
+`{{COMMAND_PREFIX}}plan-milestone-gaps`
 
 <sub>`/clear` first → fresh context window</sub>
 

--- a/gsd-ng/workflows/check-todos.md
+++ b/gsd-ng/workflows/check-todos.md
@@ -27,14 +27,14 @@ If `count` is 0 and recurring count is 0:
 ```
 No pending todos.
 
-Todos are captured during work sessions with /gsd:add-todo.
+Todos are captured during work sessions with {{COMMAND_PREFIX}}add-todo.
 
 ---
 
 Would you like to:
 
-1. Continue with current phase (/gsd:progress)
-2. Add a todo now (/gsd:add-todo)
+1. Continue with current phase ({{COMMAND_PREFIX}}progress)
+2. Add a todo now ({{COMMAND_PREFIX}}add-todo)
 ```
 Exit.
 </step>
@@ -66,7 +66,7 @@ Pending Todos:
 ---
 
 Reply with a number to view details, or:
-- `/gsd:check-todos [area]` to filter by area
+- `{{COMMAND_PREFIX}}check-todos [area]` to filter by area
 - `q` to exit
 ```
 </step>
@@ -143,9 +143,9 @@ Use AskUserQuestion:
 - header: "Action"
 - question: "This todo relates to Phase [N]: [name]. What would you like to do?"
 - options (always show ALL, place recommended option FIRST):
-  - "Debug this[(Recommended) if recommended]" — "Investigate and fix via /gsd:debug"
-  - "Handle as quick task[(Recommended) if recommended]" — "Small ad-hoc fix via /gsd:quick"
-  - "Plan as phase[(Recommended) if recommended]" — "Create planned work via /gsd:plan-phase"
+  - "Debug this[(Recommended) if recommended]" — "Investigate and fix via {{COMMAND_PREFIX}}debug"
+  - "Handle as quick task[(Recommended) if recommended]" — "Small ad-hoc fix via {{COMMAND_PREFIX}}quick"
+  - "Plan as phase[(Recommended) if recommended]" — "Create planned work via {{COMMAND_PREFIX}}plan-phase"
   - "Work on it now" — "Start working immediately (existing behavior)"
   - "Add to phase plan" — "Include when planning Phase [N]"
   - "Brainstorm approach" — "Think through before deciding"
@@ -157,11 +157,11 @@ Use AskUserQuestion:
 - header: "Action"
 - question: "What would you like to do with this todo?"
 - options (always show ALL, place recommended option FIRST):
-  - "Debug this[(Recommended) if recommended]" — "Investigate and fix via /gsd:debug"
-  - "Handle as quick task[(Recommended) if recommended]" — "Small ad-hoc fix via /gsd:quick"
-  - "Plan as phase[(Recommended) if recommended]" — "Create planned work via /gsd:plan-phase"
+  - "Debug this[(Recommended) if recommended]" — "Investigate and fix via {{COMMAND_PREFIX}}debug"
+  - "Handle as quick task[(Recommended) if recommended]" — "Small ad-hoc fix via {{COMMAND_PREFIX}}quick"
+  - "Plan as phase[(Recommended) if recommended]" — "Create planned work via {{COMMAND_PREFIX}}plan-phase"
   - "Work on it now" — "Start working immediately (existing behavior)"
-  - "Create a phase" — "Add as new roadmap phase via /gsd:add-phase"
+  - "Create a phase" — "Add as new roadmap phase via {{COMMAND_PREFIX}}add-phase"
   - "Brainstorm approach" — "Think through before deciding"
   - "Put it back" — "Return to list"
 
@@ -170,9 +170,9 @@ Use AskUserQuestion:
 If user selects "Debug this", "Handle as quick task", or "Plan as phase":
 
 Determine the command and compose the launch instruction:
-- Debug: `/gsd:debug --todo-file {filename} {todo title}`
-- Quick: `/gsd:quick --todo-file {filename} {todo title}`
-- Plan as phase: `/gsd:plan-phase` (todo becomes phase scope)
+- Debug: `{{COMMAND_PREFIX}}debug --todo-file {filename} {todo title}`
+- Quick: `{{COMMAND_PREFIX}}quick --todo-file {filename} {todo title}`
+- Plan as phase: `{{COMMAND_PREFIX}}plan-phase` (todo becomes phase scope)
 
 Display in "Next Up" style:
 
@@ -245,7 +245,7 @@ Present problem/solution context. Begin work or ask how to proceed.
 Note todo reference in phase planning notes. Keep in pending. Return to list or exit.
 
 **Create a phase:**
-Display: `/gsd:add-phase [description from todo]`
+Display: `{{COMMAND_PREFIX}}add-phase [description from todo]`
 Keep in pending. User runs command in fresh context.
 
 **Brainstorm approach:**

--- a/gsd-ng/workflows/complete-milestone.md
+++ b/gsd-ng/workflows/complete-milestone.md
@@ -84,7 +84,7 @@ Requirements: {N}/{M} v1 requirements checked off
 
 MUST present 3 options:
 1. **Proceed anyway** — mark milestone complete with known gaps
-2. **Run audit first** — `/gsd:audit-milestone` to assess gap severity
+2. **Run audit first** — `{{COMMAND_PREFIX}}audit-milestone` to assess gap severity
 3. **Abort** — return to development
 
 If user selects "Proceed anyway": note incomplete requirements in MILESTONES.md under `### Known Gaps` with REQ-IDs and descriptions.
@@ -398,7 +398,7 @@ mv .planning/phases/{phase-dir} .planning/milestones/v[X.Y]-phases/
 ```
 Verify: `✅ Phase directories archived to .planning/milestones/v[X.Y]-phases/`
 
-If "Skip": Phase directories remain in `.planning/phases/` as raw execution history. Use `/gsd:cleanup` later to archive retroactively.
+If "Skip": Phase directories remain in `.planning/phases/` as raw execution history. Use `{{COMMAND_PREFIX}}cleanup` later to archive retroactively.
 
 After archival, the AI still handles:
 - Reorganizing ROADMAP.md with milestone grouping (requires judgment)
@@ -901,7 +901,7 @@ Tag: v[X.Y]
 
 **Start Next Milestone** — questioning → research → requirements → roadmap
 
-`/gsd:new-milestone`
+`{{COMMAND_PREFIX}}new-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -953,6 +953,6 @@ Milestone completion is successful when:
 - [ ] Known gaps recorded in MILESTONES.md if user proceeded with incomplete requirements
 - [ ] RETROSPECTIVE.md updated with milestone section
 - [ ] Cross-milestone trends updated
-- [ ] User knows next step (/gsd:new-milestone)
+- [ ] User knows next step ({{COMMAND_PREFIX}}new-milestone)
 
 </success_criteria>

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -373,7 +373,7 @@ PUSH_EXIT=$?
 
 if [ $PUSH_EXIT -ne 0 ]; then
   echo "Error: Push failed — $PUSH_OUT"
-  echo "Fix the issue and retry: /gsd:create-pr ${PHASE_ARG}"
+  echo "Fix the issue and retry: {{COMMAND_PREFIX}}create-pr ${PHASE_ARG}"
   # Return to work branch before exiting
   git -C "$GIT_CWD" checkout "$CURRENT_BRANCH" 2>/dev/null || true
   exit 1

--- a/gsd-ng/workflows/diagnose-issues.md
+++ b/gsd-ng/workflows/diagnose-issues.md
@@ -201,7 +201,7 @@ Agents only diagnose—plan-phase --gaps handles fixes (no fix application).
 
 **Agent times out:**
 - Check DEBUG-{slug}.md for partial progress
-- Can resume with /gsd:debug
+- Can resume with {{COMMAND_PREFIX}}debug
 
 **All agents fail:**
 - Something systemic (permissions, git, etc.)

--- a/gsd-ng/workflows/discovery-phase.md
+++ b/gsd-ng/workflows/discovery-phase.md
@@ -4,7 +4,7 @@ Produces DISCOVERY.md (for Level 2-3) that informs PLAN.md creation.
 
 Called from plan-phase.md's mandatory_discovery step with a depth parameter.
 
-NOTE: For comprehensive ecosystem research ("how do experts build this"), use /gsd:research-phase instead, which produces RESEARCH.md.
+NOTE: For comprehensive ecosystem research ("how do experts build this"), use {{COMMAND_PREFIX}}research-phase instead, which produces RESEARCH.md.
 </purpose>
 
 @~/.claude/gsd-ng/references/ask-user-question.md
@@ -254,8 +254,8 @@ Confidence: [level]
 
 What's next?
 
-1. Discuss phase context (/gsd:discuss-phase [current-phase])
-2. Create phase plan (/gsd:plan-phase [current-phase])
+1. Discuss phase context ({{COMMAND_PREFIX}}discuss-phase [current-phase])
+2. Create phase plan ({{COMMAND_PREFIX}}plan-phase [current-phase])
 3. Refine discovery (dig deeper)
 4. Review discovery
 

--- a/gsd-ng/workflows/discuss-phase.md
+++ b/gsd-ng/workflows/discuss-phase.md
@@ -116,7 +116,7 @@ Never proceed with an empty answer.
 
 <process>
 
-**Express path available:** If you already have a PRD or acceptance criteria document, use `/gsd:plan-phase {phase} --prd path/to/prd.md` to skip this discussion and go straight to planning.
+**Express path available:** If you already have a PRD or acceptance criteria document, use `{{COMMAND_PREFIX}}plan-phase {phase} --prd path/to/prd.md` to skip this discussion and go straight to planning.
 
 <step name="initialize" priority="first">
 Phase number from argument (required).
@@ -138,7 +138,7 @@ Parse JSON for: `commit_docs`, `phase_found`, `phase_dir`, `phase_number`, `phas
 ```
 Phase [X] not found in roadmap.
 
-Use /gsd:progress to see available phases.
+Use {{COMMAND_PREFIX}}progress to see available phases.
 ```
 Exit workflow.
 
@@ -185,7 +185,7 @@ Check `has_plans` and `plan_count` from init. **If `has_plans` is true:**
 - header: "Plans exist"
 - question: "Phase [X] already has {plan_count} plan(s) created without user context. Your decisions here won't affect existing plans unless you replan."
 - options:
-  - "Continue and replan after" — Capture context, then run /gsd:plan-phase {X} to replan
+  - "Continue and replan after" — Capture context, then run {{COMMAND_PREFIX}}plan-phase {X} to replan
   - "View existing plans" — Show plans before deciding
   - "Cancel" — Skip discuss-phase
 
@@ -858,15 +858,15 @@ Created: .planning/phases/${PADDED_PHASE}-${SLUG}/${PADDED_PHASE}-CONTEXT.md
 
 **Phase ${PHASE}: [Name]** — [Goal from ROADMAP.md]
 
-`/gsd:plan-phase ${PHASE}`
+`{{COMMAND_PREFIX}}plan-phase ${PHASE}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:plan-phase ${PHASE} --skip-research` — plan without research
-- `/gsd:ui-phase ${PHASE}` — generate UI design contract before planning (if phase has frontend work)
+- `{{COMMAND_PREFIX}}plan-phase ${PHASE} --skip-research` — plan without research
+- `{{COMMAND_PREFIX}}ui-phase ${PHASE}` — generate UI design contract before planning (if phase has frontend work)
 - Review/edit CONTEXT.md before continuing
 
 ---
@@ -945,23 +945,23 @@ This keeps the auto-advance chain flat — discuss, plan, and execute all run at
 
   Auto-advance pipeline finished: discuss → plan → execute
 
-  Next: /gsd:discuss-phase ${NEXT_PHASE} --auto
+  Next: {{COMMAND_PREFIX}}discuss-phase ${NEXT_PHASE} --auto
   <sub>`/clear` first → fresh context window</sub>
   ```
 - **PLANNING COMPLETE** → Planning done, execution didn't complete:
   ```
   Auto-advance partial: Planning complete, execution did not finish.
-  Continue: /gsd:execute-phase ${PHASE}
+  Continue: {{COMMAND_PREFIX}}execute-phase ${PHASE}
   ```
 - **PLANNING INCONCLUSIVE / CHECKPOINT** → Stop chain:
   ```
   Auto-advance stopped: Planning needs input.
-  Continue: /gsd:plan-phase ${PHASE}
+  Continue: {{COMMAND_PREFIX}}plan-phase ${PHASE}
   ```
 - **GAPS FOUND** → Stop chain:
   ```
   Auto-advance stopped: Gaps found during execution.
-  Continue: /gsd:plan-phase ${PHASE} --gaps
+  Continue: {{COMMAND_PREFIX}}plan-phase ${PHASE} --gaps
   ```
 
 **If neither `--auto` nor config enabled:**

--- a/gsd-ng/workflows/do.md
+++ b/gsd-ng/workflows/do.md
@@ -39,31 +39,31 @@ Evaluate `$ARGUMENTS` against these routing rules. Apply the **first matching** 
 
 | If the text describes... | Route to | Why |
 |--------------------------|----------|-----|
-| Starting a new project, "set up", "initialize" | `/gsd:new-project` | Needs full project initialization |
-| Mapping or analyzing an existing codebase | `/gsd:map-codebase` | Codebase discovery |
-| A bug, error, crash, failure, or something broken | `/gsd:debug` | Needs systematic investigation |
-| Exploring, researching, comparing, or "how does X work" | `/gsd:research-phase` | Domain research before planning |
-| Discussing vision, "how should X look", brainstorming | `/gsd:discuss-phase` | Needs context gathering |
-| A complex task: refactoring, migration, multi-file architecture, system redesign | `/gsd:add-phase` | Needs a full phase with plan/build cycle |
-| Planning a specific phase or "plan phase N" | `/gsd:plan-phase` | Direct planning request |
-| Executing a phase or "build phase N", "run phase N" | `/gsd:execute-phase` | Direct execution request |
-| Running all remaining phases automatically | `/gsd:autonomous` | Full autonomous execution |
-| A review or quality concern about existing work | `/gsd:verify-work` | Needs verification |
-| Checking progress, status, "where am I" | `/gsd:progress` | Status check |
-| Resuming work, "pick up where I left off" | `/gsd:resume-work` | Session restoration |
-| A note, idea, or "remember to..." | `/gsd:add-todo` | Capture for later |
-| Adding tests, "write tests", "test coverage" | `/gsd:add-tests` | Test generation |
-| Completing a milestone, shipping, releasing | `/gsd:complete-milestone` | Milestone lifecycle |
-| A specific, actionable, small task (add feature, fix typo, update config) | `/gsd:quick` | Self-contained, single executor |
+| Starting a new project, "set up", "initialize" | `{{COMMAND_PREFIX}}new-project` | Needs full project initialization |
+| Mapping or analyzing an existing codebase | `{{COMMAND_PREFIX}}map-codebase` | Codebase discovery |
+| A bug, error, crash, failure, or something broken | `{{COMMAND_PREFIX}}debug` | Needs systematic investigation |
+| Exploring, researching, comparing, or "how does X work" | `{{COMMAND_PREFIX}}research-phase` | Domain research before planning |
+| Discussing vision, "how should X look", brainstorming | `{{COMMAND_PREFIX}}discuss-phase` | Needs context gathering |
+| A complex task: refactoring, migration, multi-file architecture, system redesign | `{{COMMAND_PREFIX}}add-phase` | Needs a full phase with plan/build cycle |
+| Planning a specific phase or "plan phase N" | `{{COMMAND_PREFIX}}plan-phase` | Direct planning request |
+| Executing a phase or "build phase N", "run phase N" | `{{COMMAND_PREFIX}}execute-phase` | Direct execution request |
+| Running all remaining phases automatically | `{{COMMAND_PREFIX}}autonomous` | Full autonomous execution |
+| A review or quality concern about existing work | `{{COMMAND_PREFIX}}verify-work` | Needs verification |
+| Checking progress, status, "where am I" | `{{COMMAND_PREFIX}}progress` | Status check |
+| Resuming work, "pick up where I left off" | `{{COMMAND_PREFIX}}resume-work` | Session restoration |
+| A note, idea, or "remember to..." | `{{COMMAND_PREFIX}}add-todo` | Capture for later |
+| Adding tests, "write tests", "test coverage" | `{{COMMAND_PREFIX}}add-tests` | Test generation |
+| Completing a milestone, shipping, releasing | `{{COMMAND_PREFIX}}complete-milestone` | Milestone lifecycle |
+| A specific, actionable, small task (add feature, fix typo, update config) | `{{COMMAND_PREFIX}}quick` | Self-contained, single executor |
 
-**Requires `.planning/` directory:** All routes except `/gsd:new-project`, `/gsd:map-codebase`, and `/gsd:help`. If the project doesn't exist and the route requires it, suggest `/gsd:new-project` first.
+**Requires `.planning/` directory:** All routes except `{{COMMAND_PREFIX}}new-project`, `{{COMMAND_PREFIX}}map-codebase`, and `{{COMMAND_PREFIX}}help`. If the project doesn't exist and the route requires it, suggest `{{COMMAND_PREFIX}}new-project` first.
 
 **Ambiguity handling:** If the text could reasonably match multiple routes, ask the user via AskUserQuestion with the top 2-3 options. For example:
 
 ```
 "Refactor the authentication system" could be:
-1. /gsd:add-phase — Full planning cycle (recommended for multi-file refactors)
-2. /gsd:quick — Quick execution (if scope is small and clear)
+1. {{COMMAND_PREFIX}}add-phase — Full planning cycle (recommended for multi-file refactors)
+2. {{COMMAND_PREFIX}}quick — Quick execution (if scope is small and clear)
 
 Which approach fits better?
 ```
@@ -86,7 +86,7 @@ Which approach fits better?
 <step name="dispatch">
 **Invoke the chosen command.**
 
-Run the selected `/gsd:*` command, passing `$ARGUMENTS` as args.
+Run the selected `{{COMMAND_PREFIX}}*` command, passing `$ARGUMENTS` as args.
 
 If the chosen command expects a phase number and one wasn't provided in the text, extract it from context or ask via AskUserQuestion.
 

--- a/gsd-ng/workflows/execute-phase.md
+++ b/gsd-ng/workflows/execute-phase.md
@@ -168,7 +168,7 @@ Parse JSON for: `phase`, `plans[]` (each with `id`, `wave`, `autonomous`, `objec
 ```
 WARNING: Same-wave file overlap detected — {overlap.plans[0]} and {overlap.plans[1]} share: {overlap.files.join(', ')}
 These plans may cause Edit conflicts or Write overwrites during parallel execution.
-Consider re-planning with /gsd:plan-phase to separate into sequential waves.
+Consider re-planning with {{COMMAND_PREFIX}}plan-phase to separate into sequential waves.
 ```
 Continue execution (advisory-only, not blocking) — the planner should have prevented this, so runtime overlap is informational.
 
@@ -560,7 +560,7 @@ grep "^status:" "$PHASE_DIR"/*-VERIFICATION.md | cut -d: -f2 | tr -d ' '
 |--------|--------|
 | `passed` | → update_roadmap |
 | `human_needed` | Present items for human testing, get approval or feedback |
-| `gaps_found` | Present gap summary, offer `/gsd:plan-phase {phase} --gaps` |
+| `gaps_found` | Present gap summary, offer `{{COMMAND_PREFIX}}plan-phase {phase} --gaps` |
 
 **If human_needed:**
 ```
@@ -586,15 +586,15 @@ All automated checks passed. {N} items need human testing:
 ---
 ## ▶ Next Up
 
-`/gsd:plan-phase {X} --gaps`
+`{{COMMAND_PREFIX}}plan-phase {X} --gaps`
 
 <sub>`/clear` first → fresh context window</sub>
 
 Also: `cat {phase_dir}/{phase_num}-VERIFICATION.md` — full report
-Also: `/gsd:verify-work {X}` — manual testing first
+Also: `{{COMMAND_PREFIX}}verify-work {X}` — manual testing first
 ```
 
-Gap closure cycle: `/gsd:plan-phase {X} --gaps` reads VERIFICATION.md → creates gap plans with `gap_closure: true` → user runs `/gsd:execute-phase {X} --gaps-only` → verifier re-runs.
+Gap closure cycle: `{{COMMAND_PREFIX}}plan-phase {X} --gaps` reads VERIFICATION.md → creates gap plans with `gap_closure: true` → user runs `{{COMMAND_PREFIX}}execute-phase {X} --gaps-only` → verifier re-runs.
 </step>
 
 <step name="update_roadmap">
@@ -648,7 +648,14 @@ If `AUTO_SYNC` is `"false"`: skip entirely, no output.
 </step>
 
 <step name="incremental_remap">
-After phase completion is committed, trigger incremental codebase re-mapping if codebase docs exist:
+
+```bash
+INCREMENTAL_REMAP=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.incremental_remap --default "true")
+```
+
+If `[ "$INCREMENTAL_REMAP" != "true" ]`: skip this step silently and proceed to `offer_next`.
+
+If `[ "$INCREMENTAL_REMAP" = "true" ]` (default): After phase completion is committed, trigger incremental codebase re-mapping if codebase docs exist:
 
 ```bash
 STALE_COUNT=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" staleness-check --count)
@@ -701,7 +708,7 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: incremental codebase
 
 <step name="offer_next">
 
-**Exception:** If `gaps_found`, the `verify_phase_goal` step already presents the gap-closure path (`/gsd:plan-phase {X} --gaps`). No additional routing needed — skip auto-advance.
+**Exception:** If `gaps_found`, the `verify_phase_goal` step already presents the gap-closure path (`{{COMMAND_PREFIX}}plan-phase {X} --gaps`). No additional routing needed — skip auto-advance.
 
 **No-transition check (spawned by auto-advance chain):**
 
@@ -729,7 +736,7 @@ STOP. Do not proceed to auto-advance or transition.
 If `branching_strategy` is not `"none"` AND push succeeded (or `auto_push` is enabled):
 ```
 ---
-**Create a PR:** `/gsd:create-pr {phase}` — squash work into review branch and open PR
+**Create a PR:** `{{COMMAND_PREFIX}}create-pr {phase}` — squash work into review branch and open PR
 ---
 ```
 
@@ -764,10 +771,10 @@ Read and follow `~/.claude/gsd-ng/workflows/transition.md`, passing through the 
 ```
 ## ✓ Phase {X}: {Name} Complete
 
-/gsd:progress — see updated roadmap
-/gsd:discuss-phase {next} — discuss next phase before planning
-/gsd:plan-phase {next} — plan next phase
-/gsd:execute-phase {next} — execute next phase
+{{COMMAND_PREFIX}}progress — see updated roadmap
+{{COMMAND_PREFIX}}discuss-phase {next} — discuss next phase before planning
+{{COMMAND_PREFIX}}plan-phase {next} — plan next phase
+{{COMMAND_PREFIX}}execute-phase {next} — execute next phase
 ```
 </step>
 
@@ -1003,7 +1010,7 @@ Orchestrator: ~10-15% context. Subagents: fresh 200k each. No polling (Task bloc
 </failure_handling>
 
 <resumption>
-Re-run `/gsd:execute-phase {phase}` → discover_plans finds completed SUMMARYs → skips them → resumes from first incomplete plan → continues wave execution.
+Re-run `{{COMMAND_PREFIX}}execute-phase {phase}` → discover_plans finds completed SUMMARYs → skips them → resumes from first incomplete plan → continues wave execution.
 
 STATE.md tracks: last completed plan, current wave, pending checkpoints.
 </resumption>

--- a/gsd-ng/workflows/execute-plan.md
+++ b/gsd-ng/workflows/execute-plan.md
@@ -496,9 +496,9 @@ ls -1 .planning/phases/[current-phase-dir]/*-SUMMARY.md 2>/dev/null | wc -l
 
 | Condition | Route | Action |
 |-----------|-------|--------|
-| summaries < plans | **A: More plans** | Find next PLAN without SUMMARY. Yolo: auto-continue. Interactive: show next plan, suggest `/gsd:execute-phase {phase}` + `/gsd:verify-work`. STOP here. |
-| summaries = plans, current < highest phase | **B: Phase done** | Show completion, suggest `/gsd:plan-phase {Z+1}` + `/gsd:verify-work {Z}` + `/gsd:discuss-phase {Z+1}` |
-| summaries = plans, current = highest phase | **C: Milestone done** | Show banner, suggest `/gsd:complete-milestone` + `/gsd:verify-work` + `/gsd:add-phase` |
+| summaries < plans | **A: More plans** | Find next PLAN without SUMMARY. Yolo: auto-continue. Interactive: show next plan, suggest `{{COMMAND_PREFIX}}execute-phase {phase}` + `{{COMMAND_PREFIX}}verify-work`. STOP here. |
+| summaries = plans, current < highest phase | **B: Phase done** | Show completion, suggest `{{COMMAND_PREFIX}}plan-phase {Z+1}` + `{{COMMAND_PREFIX}}verify-work {Z}` + `{{COMMAND_PREFIX}}discuss-phase {Z+1}` |
+| summaries = plans, current = highest phase | **C: Milestone done** | Show banner, suggest `{{COMMAND_PREFIX}}complete-milestone` + `{{COMMAND_PREFIX}}verify-work` + `{{COMMAND_PREFIX}}add-phase` |
 
 All routes: `/clear` first for fresh context.
 </step>

--- a/gsd-ng/workflows/health.md
+++ b/gsd-ng/workflows/health.md
@@ -62,10 +62,10 @@ Errors: N | Warnings: N | Info: N
 ## Errors
 
 - [E001] config.json: JSON parse error at line 5
-  Fix: Run /gsd:health --repair to reset to defaults
+  Fix: Run {{COMMAND_PREFIX}}health --repair to reset to defaults
 
 - [E002] PROJECT.md not found
-  Fix: Run /gsd:new-project to create
+  Fix: Run {{COMMAND_PREFIX}}new-project to create
 ```
 
 **If warnings exist:**
@@ -73,7 +73,7 @@ Errors: N | Warnings: N | Info: N
 ## Warnings
 
 - [W001] STATE.md references phase 5, but only phases 1-3 exist
-  Fix: Run /gsd:health --repair to regenerate
+  Fix: Run {{COMMAND_PREFIX}}health --repair to regenerate
 
 - [W005] Phase directory "1-setup" doesn't follow NN-name format
   Fix: Rename to match pattern (e.g., 01-setup)
@@ -90,7 +90,7 @@ Errors: N | Warnings: N | Info: N
 **Footer (if repairable issues exist and --repair was NOT used):**
 ```
 ---
-N issues can be auto-repaired. Run: /gsd:health --repair
+N issues can be auto-repaired. Run: {{COMMAND_PREFIX}}health --repair
 ```
 </step>
 
@@ -100,7 +100,7 @@ N issues can be auto-repaired. Run: /gsd:health --repair
 Ask user if they want to run repairs:
 
 ```
-Would you like to run /gsd:health --repair to fix N issues automatically?
+Would you like to run {{COMMAND_PREFIX}}health --repair to fix N issues automatically?
 ```
 
 If yes, re-run with --repair flag and display results.
@@ -138,9 +138,9 @@ Report final status.
 | W007 | warning | Phase on disk but not in ROADMAP | No |
 | W008 | warning | config.json: workflow.nyquist_validation absent (defaults to enabled but agents may skip) | Yes |
 | W009 | warning | Phase has Validation Architecture in RESEARCH.md but no VALIDATION.md | No |
-| W010 | warning | CLAUDE.md not found — agents missing project instructions | Yes |
-| W011 | warning | Memory files not referenced in CLAUDE.md | Yes |
-| W012 | warning | CLAUDE.md references non-existent memory files | Yes |
+| W010 | warning | `{{PROJECT_RULES_FILE}}` not found — agents missing project instructions | Yes |
+| W011 | warning | Memory files not referenced in `{{PROJECT_RULES_FILE}}` | Yes |
+| W012 | warning | `{{PROJECT_RULES_FILE}}` references non-existent memory files | Yes |
 | W013 | warning | MEMORY.md out of sync with .claude/memory/ contents | Yes |
 | W014 | warning | Workspace topology detected but no structural memory seeded | No |
 | I001 | info | Plan without SUMMARY (may be in progress) | No |
@@ -155,14 +155,14 @@ Report final status.
 | resetConfig | Delete + recreate config.json | Loses custom settings |
 | regenerateState | Create STATE.md from ROADMAP structure | Loses session history |
 | addNyquistKey | Add workflow.nyquist_validation: true to config.json | None — matches existing default |
-| writeCLAUDEmd | Create CLAUDE.md with Memories section from .claude/memory/ | None — generates from existing files |
-| syncCLAUDEmdMemories | Update CLAUDE.md Memories section to match .claude/memory/ | Replaces Memories section in-place |
+| writeCLAUDEmd | Create `{{PROJECT_RULES_FILE}}` with Memories section from .claude/memory/ | None — generates from existing files |
+| syncCLAUDEmdMemories | Update `{{PROJECT_RULES_FILE}}` Memories section to match .claude/memory/ | Replaces Memories section in-place |
 | syncMemoryMd | Regenerate .claude/memory/MEMORY.md from .claude/memory/ files | Overwrites MEMORY.md |
 
 **Not repairable (too risky):**
 - PROJECT.md, ROADMAP.md content
 - Phase directory renaming
 - Orphaned plan cleanup
-- Topology drift (W014) — complex; suggests running /gsd:seed-memories manually
+- Topology drift (W014) — complex; suggests running {{COMMAND_PREFIX}}seed-memories manually
 
 </repair_actions>

--- a/gsd-ng/workflows/help.md
+++ b/gsd-ng/workflows/help.md
@@ -27,9 +27,9 @@ Present the command reference to the user:
 
 ## Quick Start
 
-1. `/gsd:new-project` - Initialize project (includes research, requirements, roadmap)
-2. `/gsd:plan-phase 1` - Create detailed plan for first phase
-3. `/gsd:execute-phase 1` - Execute the phase
+1. `{{COMMAND_PREFIX}}new-project` - Initialize project (includes research, requirements, roadmap)
+2. `{{COMMAND_PREFIX}}plan-phase 1` - Create detailed plan for first phase
+3. `{{COMMAND_PREFIX}}execute-phase 1` - Execute the phase
 
 ## Staying Updated
 

--- a/gsd-ng/workflows/import-issue.md
+++ b/gsd-ng/workflows/import-issue.md
@@ -26,7 +26,7 @@ Platform detected: {platform || 'none'}
 CLI installed: {cli_installed}
 {If cli_install_url: "Install: {cli_install_url}"}
 
-Configure platform via /gsd:settings or install the CLI tool.
+Configure platform via {{COMMAND_PREFIX}}settings or install the CLI tool.
 ```
 </step>
 
@@ -132,7 +132,7 @@ Skipped: {M}
 |---|-------|-----------|-------------|
 | 1 | Fix auth | 2026-03-18-fix-auth.md | github:#42 |
 
-Next: /gsd:check-todos to review imported items
+Next: {{COMMAND_PREFIX}}check-todos to review imported items
 ```
 </step>
 

--- a/gsd-ng/workflows/insert-phase.md
+++ b/gsd-ng/workflows/insert-phase.md
@@ -13,7 +13,7 @@ Parse the command arguments:
 - First argument: integer phase number to insert after
 - Remaining arguments: phase description
 
-Example: `/gsd:insert-phase 72 Fix critical auth bug`
+Example: `{{COMMAND_PREFIX}}insert-phase 72 Fix critical auth bug`
 -> after = 72
 -> description = "Fix critical auth bug"
 
@@ -21,8 +21,8 @@ If arguments missing:
 
 ```
 ERROR: Both phase number and description required
-Usage: /gsd:insert-phase <after> <description>
-Example: /gsd:insert-phase 72 Fix critical auth bug
+Usage: {{COMMAND_PREFIX}}insert-phase <after> <description>
+Example: {{COMMAND_PREFIX}}insert-phase 72 Fix critical auth bug
 ```
 
 Exit.
@@ -99,7 +99,7 @@ Project state updated: .planning/STATE.md
 
 **Phase {decimal_phase}: {description}** -- urgent insertion
 
-`/gsd:plan-phase {decimal_phase}`
+`{{COMMAND_PREFIX}}plan-phase {decimal_phase}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -117,11 +117,11 @@ Project state updated: .planning/STATE.md
 
 <anti_patterns>
 
-- Don't use this for planned work at end of milestone (use /gsd:add-phase)
+- Don't use this for planned work at end of milestone (use {{COMMAND_PREFIX}}add-phase)
 - Don't insert before Phase 1 (decimal 0.1 makes no sense)
 - Don't renumber existing phases
 - Don't modify the target phase content
-- Don't create plans yet (that's /gsd:plan-phase)
+- Don't create plans yet (that's {{COMMAND_PREFIX}}plan-phase)
 - Don't commit changes (user decides when to commit)
 </anti_patterns>
 

--- a/gsd-ng/workflows/list-phase-assumptions.md
+++ b/gsd-ng/workflows/list-phase-assumptions.md
@@ -14,8 +14,8 @@ Phase number: $ARGUMENTS (required)
 ```
 Error: Phase number required.
 
-Usage: /gsd:list-phase-assumptions [phase-number]
-Example: /gsd:list-phase-assumptions 3
+Usage: {{COMMAND_PREFIX}}list-phase-assumptions [phase-number]
+Example: {{COMMAND_PREFIX}}list-phase-assumptions 3
 ```
 
 Exit workflow.
@@ -155,8 +155,8 @@ Present next steps:
 
 ```
 What's next?
-1. Discuss context (/gsd:discuss-phase ${PHASE}) - Let me ask you questions to build comprehensive context
-2. Plan this phase (/gsd:plan-phase ${PHASE}) - Create detailed execution plans
+1. Discuss context ({{COMMAND_PREFIX}}discuss-phase ${PHASE}) - Let me ask you questions to build comprehensive context
+2. Plan this phase ({{COMMAND_PREFIX}}plan-phase ${PHASE}) - Create detailed execution plans
 3. Re-examine assumptions - I'll analyze again with your corrections
 4. Done for now
 ```

--- a/gsd-ng/workflows/map-codebase.md
+++ b/gsd-ng/workflows/map-codebase.md
@@ -310,14 +310,14 @@ Created .planning/codebase/:
 
 **Initialize project** — use codebase context for planning
 
-`/gsd:new-project`
+`{{COMMAND_PREFIX}}new-project`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- Re-run mapping: `/gsd:map-codebase`
+- Re-run mapping: `{{COMMAND_PREFIX}}map-codebase`
 - Review specific file: `cat .planning/codebase/STACK.md`
 - Edit any document before proceeding
 

--- a/gsd-ng/workflows/new-milestone.md
+++ b/gsd-ng/workflows/new-milestone.md
@@ -22,7 +22,7 @@ Read all files referenced by the invoking prompt's execution_context before star
 - Read PROJECT.md (existing project, validated requirements, decisions)
 - Read MILESTONES.md (what shipped previously)
 - Read STATE.md (pending todos, blockers)
-- Check for MILESTONE-CONTEXT.md (from /gsd:discuss-milestone)
+- Check for MILESTONE-CONTEXT.md (from {{COMMAND_PREFIX}}discuss-milestone)
 
 ## 2. Gather Milestone Goals
 
@@ -128,7 +128,7 @@ AskUserQuestion: "Research the domain ecosystem for new features before defining
 - "Skip research (current default)" — Go straight to requirements
 - "Research first" — Discover patterns, features, architecture for NEW capabilities
 
-**IMPORTANT:** Do NOT persist this choice to config.json. The `workflow.research` setting is a persistent user preference that controls plan-phase behavior across the project. Changing it here would silently alter future `/gsd:plan-phase` behavior. To change the default, use `/gsd:settings`.
+**IMPORTANT:** Do NOT persist this choice to config.json. The `workflow.research` setting is a persistent user preference that controls plan-phase behavior across the project. Changing it here would silently alter future `{{COMMAND_PREFIX}}plan-phase` behavior. To change the default, use `{{COMMAND_PREFIX}}settings`.
 
 **If user chose "Research first":**
 
@@ -387,11 +387,11 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: create milestone v[X
 
 **Phase [N]: [Phase Name]** — [Goal]
 
-`/gsd:discuss-phase [N]` — gather context and clarify approach
+`{{COMMAND_PREFIX}}discuss-phase [N]` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
-Also: `/gsd:plan-phase [N]` — skip discussion, plan directly
+Also: `{{COMMAND_PREFIX}}plan-phase [N]` — skip discussion, plan directly
 ```
 
 </process>
@@ -408,7 +408,7 @@ Also: `/gsd:plan-phase [N]` — skip discussion, plan directly
 - [ ] User feedback incorporated (if any)
 - [ ] ROADMAP.md phases continue from previous milestone
 - [ ] All commits made (if planning docs committed)
-- [ ] User knows next step: `/gsd:discuss-phase [N]`
+- [ ] User knows next step: `{{COMMAND_PREFIX}}discuss-phase [N]`
 - [ ] If --target-branch provided: git.target_branch updated in config.json
 
 **Atomic commits:** Each phase commits its artifacts immediately.

--- a/gsd-ng/workflows/new-project.md
+++ b/gsd-ng/workflows/new-project.md
@@ -25,7 +25,7 @@ Check if `--auto` flag is present in $ARGUMENTS.
 
 **Document requirement:**
 Auto mode requires an idea document — either:
-- File reference: `/gsd:new-project --auto @prd.md`
+- File reference: `{{COMMAND_PREFIX}}new-project --auto @prd.md`
 - Pasted/written text in the prompt
 
 If no document content provided, error:
@@ -34,8 +34,8 @@ If no document content provided, error:
 Error: --auto requires an idea document.
 
 Usage:
-  /gsd:new-project --auto @your-idea.md
-  /gsd:new-project --auto [paste or write your idea here]
+  {{COMMAND_PREFIX}}new-project --auto @your-idea.md
+  {{COMMAND_PREFIX}}new-project --auto [paste or write your idea here]
 
 The document should describe what you want to build.
 ```
@@ -60,7 +60,7 @@ fi
 
 Parse JSON for: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `project_exists`, `has_codebase_map`, `planning_exists`, `has_existing_code`, `has_package_file`, `is_brownfield`, `needs_codebase_map`, `has_git`, `project_path`.
 
-**If `project_exists` is true:** Error — project already initialized. Use `/gsd:progress`.
+**If `project_exists` is true:** Error — project already initialized. Use `{{COMMAND_PREFIX}}progress`.
 
 **If `has_git` is false:** Initialize git:
 ```bash
@@ -77,12 +77,12 @@ Use AskUserQuestion:
 - header: "Codebase"
 - question: "I detected existing code in this directory. Would you like to map the codebase first?"
 - options:
-  - "Map codebase first" — Run /gsd:map-codebase to understand existing architecture (Recommended)
+  - "Map codebase first" — Run {{COMMAND_PREFIX}}map-codebase to understand existing architecture (Recommended)
   - "Skip mapping" — Proceed with project initialization
 
 **If "Map codebase first":**
 ```
-Run `/gsd:map-codebase` first, then return to `/gsd:new-project`
+Run `{{COMMAND_PREFIX}}map-codebase` first, then return to `{{COMMAND_PREFIX}}new-project`
 ```
 Exit command.
 
@@ -504,7 +504,7 @@ Create `.planning/config.json` with all settings:
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "chore: add project config" --files .planning/config.json
 ```
 
-**Note:** Run `/gsd:settings` anytime to update these preferences.
+**Note:** Run `{{COMMAND_PREFIX}}settings` anytime to update these preferences.
 
 ## 5.5. Resolve Model Profile
 
@@ -1198,7 +1198,7 @@ Present completion summary:
 ╚══════════════════════════════════════════╝
 ```
 
-Exit skill and invoke SlashCommand("/gsd:discuss-phase 1 --auto")
+Exit skill and invoke SlashCommand("{{COMMAND_PREFIX}}discuss-phase 1 --auto")
 
 **If interactive mode:**
 
@@ -1209,14 +1209,14 @@ Exit skill and invoke SlashCommand("/gsd:discuss-phase 1 --auto")
 
 **Phase 1: [Phase Name]** — [Goal from ROADMAP.md]
 
-`/gsd:discuss-phase 1` — gather context and clarify approach
+`{{COMMAND_PREFIX}}discuss-phase 1` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- /gsd:plan-phase 1 — skip discussion, plan directly
+- {{COMMAND_PREFIX}}plan-phase 1 — skip discussion, plan directly
 
 ───────────────────────────────────────────────────────────────
 ```
@@ -1263,7 +1263,7 @@ Exit skill and invoke SlashCommand("/gsd:discuss-phase 1 --auto")
 - [ ] `{{PROJECT_RULES_FILE}}` generated with Memories section referencing all `{{MEMORY_DIR}}*.md` files → **committed**
 - [ ] `{{MEMORY_DIR}}MEMORY.md` generated as memory index → **committed**
 - [ ] Workspace topology detected and appropriate memories seeded (if non-standalone)
-- [ ] User knows next step is `/gsd:discuss-phase 1`
+- [ ] User knows next step is `{{COMMAND_PREFIX}}discuss-phase 1`
 
 **Atomic commits:** Each phase commits its artifacts immediately. If context is lost, artifacts persist.
 

--- a/gsd-ng/workflows/note.md
+++ b/gsd-ng/workflows/note.md
@@ -43,7 +43,7 @@ promoted: false
 | Arguments are empty (no text at all) | **list** |
 | Anything else | **append** (the text IS the note) |
 
-**Critical**: `list` is only a subcommand when it's the ENTIRE argument. `/gsd:note list of groceries` saves a note with text "list of groceries". Same for `promote` — only a subcommand when followed by exactly one number.
+**Critical**: `list` is only a subcommand when it's the ENTIRE argument. `{{COMMAND_PREFIX}}note list of groceries` saves a note with text "list of groceries". Same for `promote` — only a subcommand when followed by exactly one number.
 </step>
 
 <step name="append">
@@ -87,7 +87,7 @@ Project (.planning/notes/):
 Global (~/.claude/notes/):
   4. [2026-02-08 10:00] cross-project idea about shared config
 
-{count} active note(s). Use `/gsd:note promote <N>` to convert to a todo.
+{count} active note(s). Use `{{COMMAND_PREFIX}}note promote <N>` to convert to a todo.
 ```
 
 If a scope has no directory or no entries, show: `(no notes)`
@@ -99,7 +99,7 @@ If a scope has no directory or no entries, show: `(no notes)`
 1. Run the **list** logic to build the numbered index (both scopes)
 2. Find entry N from the numbered list
 3. If N is invalid or refers to an already-promoted note, tell the user and stop
-4. **Requires `.planning/` directory** — if it doesn't exist, warn: "Todos require a GSD project. Run `/gsd:new-project` to initialize one."
+4. **Requires `.planning/` directory** — if it doesn't exist, warn: "Todos require a GSD project. Run `{{COMMAND_PREFIX}}new-project` to initialize one."
 5. Ensure `.planning/todos/pending/` directory exists
 6. Generate todo ID: `{NNN}-{slug}` where NNN is the next sequential number (scan both `.planning/todos/pending/` and `.planning/todos/completed/` for the highest existing number, increment by 1, zero-pad to 3 digits) and slug is the first ~4 meaningful words of the note text
 7. Extract the note text from the source file (body after frontmatter)
@@ -110,7 +110,7 @@ If a scope has no directory or no entries, show: `(no notes)`
 title: "{note text}"
 status: pending
 priority: P2
-source: "promoted from /gsd:note"
+source: "promoted from {{COMMAND_PREFIX}}note"
 created: {YYYY-MM-DD}
 theme: general
 ---
@@ -135,9 +135,9 @@ Promoted from quick note captured on {original date}.
 </process>
 
 <edge_cases>
-1. **"list" as note text**: `/gsd:note list of things` saves note "list of things" (subcommand only when `list` is the entire arg)
+1. **"list" as note text**: `{{COMMAND_PREFIX}}note list of things` saves note "list of things" (subcommand only when `list` is the entire arg)
 2. **No `.planning/`**: Falls back to global `~/.claude/notes/` — works in any directory
-3. **Promote without project**: Warns that todos require `.planning/`, suggests `/gsd:new-project`
+3. **Promote without project**: Warns that todos require `.planning/`, suggests `{{COMMAND_PREFIX}}new-project`
 4. **Large files**: `list` shows last 10 when >20 active entries
 5. **Duplicate slugs**: Append `-2`, `-3` etc. to filename if slug already used on same date
 6. **`--global` position**: Stripped from anywhere — `--global my idea` and `my idea --global` both save "my idea" globally

--- a/gsd-ng/workflows/pause-work.md
+++ b/gsd-ng/workflows/pause-work.md
@@ -107,7 +107,7 @@ Current state:
 - Status: [in_progress/blocked]
 - Committed as WIP
 
-To resume: /gsd:resume-work
+To resume: {{COMMAND_PREFIX}}resume-work
 
 ```
 </step>

--- a/gsd-ng/workflows/plan-milestone-gaps.md
+++ b/gsd-ng/workflows/plan-milestone-gaps.md
@@ -1,5 +1,5 @@
 <purpose>
-Create all phases necessary to close gaps identified by `/gsd:audit-milestone`. Reads MILESTONE-AUDIT.md, groups gaps into logical phases, creates phase entries in ROADMAP.md, and offers to plan each phase. One command creates all fix phases — no manual `/gsd:add-phase` per gap.
+Create all phases necessary to close gaps identified by `{{COMMAND_PREFIX}}audit-milestone`. Reads MILESTONE-AUDIT.md, groups gaps into logical phases, creates phase entries in ROADMAP.md, and offers to plan each phase. One command creates all fix phases — no manual `{{COMMAND_PREFIX}}add-phase` per gap.
 </purpose>
 
 @~/.claude/gsd-ng/references/ask-user-question.md
@@ -24,7 +24,7 @@ Parse YAML frontmatter to extract structured gaps:
 
 If no audit file exists or has no gaps, error:
 ```
-No audit gaps found. Run `/gsd:audit-milestone` first.
+No audit gaps found. Run `{{COMMAND_PREFIX}}audit-milestone` first.
 ```
 
 ## 2. Prioritize Gaps
@@ -165,22 +165,22 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs(roadmap): add gap clo
 
 **Plan first gap closure phase**
 
-`/gsd:plan-phase {N}`
+`{{COMMAND_PREFIX}}plan-phase {N}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:execute-phase {N}` — if plans already exist
+- `{{COMMAND_PREFIX}}execute-phase {N}` — if plans already exist
 - `cat .planning/ROADMAP.md` — see updated roadmap
 
 ---
 
 **After all gap phases complete:**
 
-`/gsd:audit-milestone` — re-audit to verify gaps closed
-`/gsd:complete-milestone {version}` — archive when audit passes
+`{{COMMAND_PREFIX}}audit-milestone` — re-audit to verify gaps closed
+`{{COMMAND_PREFIX}}complete-milestone {version}` — archive when audit passes
 ```
 
 </process>
@@ -271,5 +271,5 @@ becomes:
 - [ ] Coverage count updated in REQUIREMENTS.md
 - [ ] Phase directories created
 - [ ] Changes committed (includes REQUIREMENTS.md)
-- [ ] User knows to run `/gsd:plan-phase` next
+- [ ] User knows to run `{{COMMAND_PREFIX}}plan-phase` next
 </success_criteria>

--- a/gsd-ng/workflows/plan-phase.md
+++ b/gsd-ng/workflows/plan-phase.md
@@ -31,7 +31,7 @@ Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_
 
 **File paths (for <files_to_read> blocks):** `state_path`, `roadmap_path`, `requirements_path`, `context_path`, `research_path`, `verification_path`, `uat_path`. These are null if files don't exist.
 
-**If `planning_exists` is false:** Error — run `/gsd:new-project` first.
+**If `planning_exists` is false:** Error — run `{{COMMAND_PREFIX}}new-project` first.
 
 ## 2. Parse and Normalize Arguments
 
@@ -178,7 +178,7 @@ Use AskUserQuestion:
   - "Run discuss-phase first" — Capture design decisions before planning
 
 If "Continue without context": Proceed to step 4.5.
-If "Run discuss-phase first": Display `/gsd:discuss-phase {X}` and exit workflow.
+If "Run discuss-phase first": Display `{{COMMAND_PREFIX}}discuss-phase {X}` and exit workflow.
 
 ## 4.5. Scan Related Todos (Fallback)
 
@@ -348,7 +348,7 @@ Answer: "What do I need to know to PLAN this phase well?"
 </objective>
 
 <files_to_read>
-- {context_path} (USER DECISIONS from /gsd:discuss-phase)
+- {context_path} (USER DECISIONS from {{COMMAND_PREFIX}}discuss-phase)
 - {requirements_path} (Project requirements)
 - {state_path} (Project decisions and history)
 </files_to_read>
@@ -444,7 +444,7 @@ Use AskUserQuestion:
 - header: "UI Design Contract"
 - question: "Phase {N} has frontend indicators but no UI-SPEC.md. Generate a design contract before planning?"
 - options:
-  - "Generate UI-SPEC first" → Display: "Run `/gsd:ui-phase {N}` then re-run `/gsd:plan-phase {N}`". Exit workflow.
+  - "Generate UI-SPEC first" → Display: "Run `{{COMMAND_PREFIX}}ui-phase {N}` then re-run `{{COMMAND_PREFIX}}plan-phase {N}`". Exit workflow.
   - "Continue without UI-SPEC" → Continue to step 6.
   - "Not a frontend phase" → Continue to step 6.
 
@@ -489,7 +489,7 @@ VALIDATION_EXISTS=$(ls "${PHASE_DIR}"/*-VALIDATION.md 2>/dev/null | head -1)
 ```
 
 If missing and Nyquist is still enabled/applicable — ask user:
-1. Re-run: `/gsd:plan-phase {PHASE} --research`
+1. Re-run: `{{COMMAND_PREFIX}}plan-phase {PHASE} --research`
 2. Disable Nyquist with the exact command:
    `node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-set workflow.nyquist_validation false`
 3. Continue anyway (plans fail Dimension 8)
@@ -518,7 +518,7 @@ Planner prompt:
 - {state_path} (Project State)
 - {roadmap_path} (Roadmap)
 - {requirements_path} (Requirements)
-- {context_path} (USER DECISIONS from /gsd:discuss-phase)
+- {context_path} (USER DECISIONS from {{COMMAND_PREFIX}}discuss-phase)
 - {research_path} (Technical Research)
 - {verification_path} (Verification Gaps - if --gaps)
 - {uat_path} (UAT Gaps - if --gaps)
@@ -533,7 +533,7 @@ Planner prompt:
 </planning_context>
 
 <downstream_consumer>
-Output consumed by /gsd:execute-phase. Plans need:
+Output consumed by {{COMMAND_PREFIX}}execute-phase. Plans need:
 - Frontmatter (wave, depends_on, files_modified, autonomous)
 - Tasks in XML format with read_first and acceptance_criteria fields (MANDATORY on every task)
 - Verification criteria
@@ -619,7 +619,7 @@ Checker prompt:
 - {PHASE_DIR}/*-PLAN.md (Plans to verify)
 - {roadmap_path} (Roadmap)
 - {requirements_path} (Requirements)
-- {context_path} (USER DECISIONS from /gsd:discuss-phase)
+- {context_path} (USER DECISIONS from {{COMMAND_PREFIX}}discuss-phase)
 - {research_path} (Technical Research — includes Validation Architecture)
 </files_to_read>
 
@@ -666,7 +666,7 @@ Revision prompt:
 
 <files_to_read>
 - {PHASE_DIR}/*-PLAN.md (Existing plans)
-- {context_path} (USER DECISIONS from /gsd:discuss-phase)
+- {context_path} (USER DECISIONS from {{COMMAND_PREFIX}}discuss-phase)
 </files_to_read>
 
 **Checker issues:** {structured_issues_from_checker}
@@ -742,14 +742,14 @@ The `--no-transition` flag tells execute-phase to return status after verificati
 
   Auto-advance pipeline finished.
 
-  Next: /gsd:discuss-phase ${NEXT_PHASE} --auto
+  Next: {{COMMAND_PREFIX}}discuss-phase ${NEXT_PHASE} --auto
   ```
 - **GAPS FOUND / VERIFICATION FAILED** → Display result, stop chain:
   ```
   Auto-advance stopped: Execution needs review.
 
   Review the output above and continue manually:
-  /gsd:execute-phase ${PHASE}
+  {{COMMAND_PREFIX}}execute-phase ${PHASE}
   ```
 
 **If neither `--auto` nor config enabled:**
@@ -780,7 +780,7 @@ Verification: {Passed | Passed with override | Skipped}
 
 **Execute Phase {X}** — run all {N} plans
 
-`/gsd:execute-phase {X}`
+`{{COMMAND_PREFIX}}execute-phase {X}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -788,7 +788,7 @@ Verification: {Passed | Passed with override | Skipped}
 
 **Also available:**
 - cat .planning/phases/{phase-dir}/*-PLAN.md — review plans
-- /gsd:plan-phase {X} --research — re-research first
+- {{COMMAND_PREFIX}}plan-phase {X} --research — re-research first
 
 ───────────────────────────────────────────────────────────────
 </offer_next>

--- a/gsd-ng/workflows/progress.md
+++ b/gsd-ng/workflows/progress.md
@@ -24,7 +24,7 @@ fi
 
 Extract from INIT JSON: `project_exists`, `roadmap_exists`, `state_exists`, `current_phase`, `next_phase`, `milestone_version`, `completed_count`, `phase_count`, `paused_at`, `state_path`, `roadmap_path`, `project_path`.
 
-If `project_exists` is false: "No planning structure found. Run /gsd:new-project to start." Exit.
+If `project_exists` is false: "No planning structure found. Run {{COMMAND_PREFIX}}new-project to start." Exit.
 If ROADMAP.md missing but PROJECT.md exists: Go to **Route F** (between milestones).
 
 ```bash
@@ -93,10 +93,10 @@ CONTEXT: [✓ if has_context | - if not]
 - [e.g. jq -r '.blockers[].text' from state-snapshot]
 
 ## Pending Todos
-- [count] pending — /gsd:check-todos to review
+- [count] pending — {{COMMAND_PREFIX}}check-todos to review
 
 ## Active Debug Sessions
-- [count] active — /gsd:debug to continue
+- [count] active — {{COMMAND_PREFIX}}debug to continue
 (Only show this section if count > 0)
 
 ## What's Next
@@ -155,7 +155,7 @@ Read its `<objective>` section.
 
 **{phase}-{plan}: [Plan Name]** — [objective summary from PLAN.md]
 
-`/gsd:execute-phase {phase}`
+`{{COMMAND_PREFIX}}execute-phase {phase}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -178,7 +178,7 @@ Check if `{phase_num}-CONTEXT.md` exists in phase directory.
 **Phase {N}: {Name}** — {Goal from ROADMAP.md}
 <sub>✓ Context gathered, ready to plan</sub>
 
-`/gsd:plan-phase {phase-number}`
+`{{COMMAND_PREFIX}}plan-phase {phase-number}`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -194,15 +194,15 @@ Check if `{phase_num}-CONTEXT.md` exists in phase directory.
 
 **Phase {N}: {Name}** — {Goal from ROADMAP.md}
 
-`/gsd:discuss-phase {phase}` — gather context and clarify approach
+`{{COMMAND_PREFIX}}discuss-phase {phase}` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:plan-phase {phase}` — skip discussion, plan directly
-- `/gsd:list-phase-assumptions {phase}` — see Claude's assumptions
+- `{{COMMAND_PREFIX}}plan-phase {phase}` — skip discussion, plan directly
+- `{{COMMAND_PREFIX}}list-phase-assumptions {phase}` — see Claude's assumptions
 
 ---
 ```
@@ -220,15 +220,15 @@ UAT.md exists with gaps (diagnosed issues). User needs to plan fixes.
 
 **{phase_num}-UAT.md** has {N} gaps requiring fixes.
 
-`/gsd:plan-phase {phase} --gaps`
+`{{COMMAND_PREFIX}}plan-phase {phase} --gaps`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:execute-phase {phase}` — execute phase plans
-- `/gsd:verify-work {phase}` — run more UAT testing
+- `{{COMMAND_PREFIX}}execute-phase {phase}` — execute phase plans
+- `{{COMMAND_PREFIX}}verify-work {phase}` — run more UAT testing
 
 ---
 ```
@@ -267,15 +267,15 @@ Read ROADMAP.md to get the next phase's name and goal.
 
 **Phase {Z+1}: {Name}** — {Goal from ROADMAP.md}
 
-`/gsd:discuss-phase {Z+1}` — gather context and clarify approach
+`{{COMMAND_PREFIX}}discuss-phase {Z+1}` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:plan-phase {Z+1}` — skip discussion, plan directly
-- `/gsd:verify-work {Z}` — user acceptance test before continuing
+- `{{COMMAND_PREFIX}}plan-phase {Z+1}` — skip discussion, plan directly
+- `{{COMMAND_PREFIX}}verify-work {Z}` — user acceptance test before continuing
 
 ---
 ```
@@ -295,14 +295,14 @@ All {N} phases finished!
 
 **Complete Milestone** — archive and prepare for next
 
-`/gsd:complete-milestone`
+`{{COMMAND_PREFIX}}complete-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:verify-work` — user acceptance test before completing milestone
+- `{{COMMAND_PREFIX}}verify-work` — user acceptance test before completing milestone
 
 ---
 ```
@@ -326,7 +326,7 @@ Ready to plan the next milestone.
 
 **Start Next Milestone** — questioning → research → requirements → roadmap
 
-`/gsd:new-milestone`
+`{{COMMAND_PREFIX}}new-milestone`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -338,10 +338,10 @@ Ready to plan the next milestone.
 <step name="edge_cases">
 **Handle edge cases:**
 
-- Phase complete but next phase not planned → offer `/gsd:plan-phase [next]`
+- Phase complete but next phase not planned → offer `{{COMMAND_PREFIX}}plan-phase [next]`
 - All work complete → offer milestone completion
 - Blockers present → highlight before offering to continue
-- Handoff file exists → mention it, offer `/gsd:resume-work`
+- Handoff file exists → mention it, offer `{{COMMAND_PREFIX}}resume-work`
   </step>
 
 </process>
@@ -351,7 +351,7 @@ Ready to plan the next milestone.
 - [ ] Rich context provided (recent work, decisions, issues)
 - [ ] Current position clear with visual progress
 - [ ] What's next clearly explained
-- [ ] Smart routing: /gsd:execute-phase if plans exist, /gsd:plan-phase if not
+- [ ] Smart routing: {{COMMAND_PREFIX}}execute-phase if plans exist, {{COMMAND_PREFIX}}plan-phase if not
 - [ ] User confirms before any action
 - [ ] Seamless handoff to appropriate gsd command
       </success_criteria>

--- a/gsd-ng/workflows/quick.md
+++ b/gsd-ng/workflows/quick.md
@@ -156,7 +156,7 @@ fi
 
 Parse JSON for: `planner_model`, `executor_model`, `checker_model`, `verifier_model`, `commit_docs`, `quick_id`, `slug`, `date`, `timestamp`, `quick_dir`, `task_dir`, `roadmap_exists`, `planning_exists`.
 
-**If `roadmap_exists` is false:** Error — Quick mode requires an active project with ROADMAP.md. Run `/gsd:new-project` first.
+**If `roadmap_exists` is false:** Error — Quick mode requires an active project with ROADMAP.md. Run `{{COMMAND_PREFIX}}new-project` first.
 
 Quick tasks can run mid-phase - validation only checks ROADMAP.md exists, not phase status.
 
@@ -737,7 +737,7 @@ Commit: ${commit_hash}
 
 ---
 
-Ready for next task: /gsd:quick
+Ready for next task: {{COMMAND_PREFIX}}quick
 ```
 
 **If NOT `$VERIFY_MODE`:**
@@ -754,7 +754,7 @@ Commit: ${commit_hash}
 
 ---
 
-Ready for next task: /gsd:quick
+Ready for next task: {{COMMAND_PREFIX}}quick
 ```
 
 ---

--- a/gsd-ng/workflows/remove-phase.md
+++ b/gsd-ng/workflows/remove-phase.md
@@ -11,15 +11,15 @@ Read all files referenced by the invoking prompt's execution_context before star
 <step name="parse_arguments">
 Parse the command arguments:
 - Argument is the phase number to remove (integer or decimal)
-- Example: `/gsd:remove-phase 17` → phase = 17
-- Example: `/gsd:remove-phase 16.1` → phase = 16.1
+- Example: `{{COMMAND_PREFIX}}remove-phase 17` → phase = 17
+- Example: `{{COMMAND_PREFIX}}remove-phase 16.1` → phase = 16.1
 
 If no argument provided:
 
 ```
 ERROR: Phase number required
-Usage: /gsd:remove-phase <phase-number>
-Example: /gsd:remove-phase 17
+Usage: {{COMMAND_PREFIX}}remove-phase <phase-number>
+Example: {{COMMAND_PREFIX}}remove-phase 17
 ```
 
 Exit.
@@ -59,7 +59,7 @@ Only future phases can be removed:
 - Current phase: {current}
 - Phase {target} is current or completed
 
-To abandon current work, use /gsd:pause-work instead.
+To abandon current work, use {{COMMAND_PREFIX}}pause-work instead.
 ```
 
 Exit.
@@ -132,7 +132,7 @@ Changes:
 ## What's Next
 
 Would you like to:
-- `/gsd:progress` — see updated roadmap status
+- `{{COMMAND_PREFIX}}progress` — see updated roadmap status
 - Continue with current phase
 - Review roadmap
 

--- a/gsd-ng/workflows/research-phase.md
+++ b/gsd-ng/workflows/research-phase.md
@@ -1,7 +1,7 @@
 <purpose>
 Research how to implement a phase. Spawns gsd-phase-researcher with phase context.
 
-Standalone research command. For most workflows, use `/gsd:plan-phase` which integrates research automatically.
+Standalone research command. For most workflows, use `{{COMMAND_PREFIX}}plan-phase` which integrates research automatically.
 </purpose>
 
 <process>
@@ -54,7 +54,7 @@ Research implementation approach for Phase {phase}: {name}
 </objective>
 
 <files_to_read>
-- {context_path} (USER DECISIONS from /gsd:discuss-phase)
+- {context_path} (USER DECISIONS from {{COMMAND_PREFIX}}discuss-phase)
 - {requirements_path} (Project requirements)
 - {state_path} (Project decisions and history)
 </files_to_read>

--- a/gsd-ng/workflows/resume-project.md
+++ b/gsd-ng/workflows/resume-project.md
@@ -34,7 +34,7 @@ Parse JSON for: `state_exists`, `roadmap_exists`, `project_exists`, `planning_ex
 
 **If `state_exists` is true:** Proceed to load_state
 **If `state_exists` is false but `roadmap_exists` or `project_exists` is true:** Offer to reconstruct STATE.md
-**If `planning_exists` is false:** This is a new project - route to /gsd:new-project
+**If `planning_exists` is false:** This is a new project - route to {{COMMAND_PREFIX}}new-project
 </step>
 
 <step name="load_state">
@@ -130,7 +130,7 @@ Present complete project status to user:
     Resume with: Task tool (resume parameter with agent ID)
 
 [If pending todos exist:]
-📋 [N] pending todos — /gsd:check-todos to review
+📋 [N] pending todos — {{COMMAND_PREFIX}}check-todos to review
 
 [If blockers exist:]
 ⚠️  Carried concerns:
@@ -186,11 +186,11 @@ What would you like to do?
 [Primary action based on state - e.g.:]
 1. Resume interrupted agent [if interrupted agent found]
    OR
-1. Execute phase (/gsd:execute-phase {phase})
+1. Execute phase ({{COMMAND_PREFIX}}execute-phase {phase})
    OR
-1. Discuss Phase 3 context (/gsd:discuss-phase 3) [if CONTEXT.md missing]
+1. Discuss Phase 3 context ({{COMMAND_PREFIX}}discuss-phase 3) [if CONTEXT.md missing]
    OR
-1. Plan Phase 3 (/gsd:plan-phase 3) [if CONTEXT.md exists or discuss option declined]
+1. Plan Phase 3 ({{COMMAND_PREFIX}}plan-phase 3) [if CONTEXT.md exists or discuss option declined]
 
 [Secondary options:]
 2. Review current phase status
@@ -221,7 +221,7 @@ Based on user selection, route to appropriate workflow:
 
   **{phase}-{plan}: [Plan Name]** — [objective from PLAN.md]
 
-  `/gsd:execute-phase {phase}`
+  `{{COMMAND_PREFIX}}execute-phase {phase}`
 
   <sub>`/clear` first → fresh context window</sub>
 
@@ -235,15 +235,15 @@ Based on user selection, route to appropriate workflow:
 
   **Phase [N]: [Name]** — [Goal from ROADMAP.md]
 
-  `/gsd:plan-phase [phase-number]`
+  `{{COMMAND_PREFIX}}plan-phase [phase-number]`
 
   <sub>`/clear` first → fresh context window</sub>
 
   ---
 
   **Also available:**
-  - `/gsd:discuss-phase [N]` — gather context first
-  - `/gsd:research-phase [N]` — investigate unknowns
+  - `{{COMMAND_PREFIX}}discuss-phase [N]` — gather context first
+  - `{{COMMAND_PREFIX}}research-phase [N]` — investigate unknowns
 
   ---
   ```

--- a/gsd-ng/workflows/settings.md
+++ b/gsd-ng/workflows/settings.md
@@ -39,7 +39,8 @@ Parse current values (default to `true` if not present):
 - `workflow.verifier` — spawn verifier during execute-phase
 - `workflow.nyquist_validation` — validation architecture research during plan-phase (default: true if absent)
 - `workflow.ui_phase` — generate UI-SPEC.md design contracts for frontend phases (default: true if absent)
-- `workflow.ui_safety_gate` — prompt to run /gsd:ui-phase before planning frontend phases (default: true if absent)
+- `workflow.ui_safety_gate` — prompt to run {{COMMAND_PREFIX}}ui-phase before planning frontend phases (default: true if absent)
+- `workflow.incremental_remap` — auto-update codebase docs after phase completion via gsd-incremental-mapper (default: true if absent)
 - `model_profile` — which model each agent uses (default: `balanced`)
 - `git.branching_strategy` — branching approach (default: `"none"`)
 - `git.target_branch` — default merge target for PRs (default: `"main"`)
@@ -127,12 +128,21 @@ AskUserQuestion([
     ]
   },
   {
-    question: "Enable UI Safety Gate? (prompts to run /gsd:ui-phase before planning frontend phases)",
+    question: "Enable UI Safety Gate? (prompts to run {{COMMAND_PREFIX}}ui-phase before planning frontend phases)",
     header: "UI Gate",
     multiSelect: false,
     options: [
-      { label: "Yes (Recommended)", description: "plan-phase asks to run /gsd:ui-phase first when frontend indicators detected." },
+      { label: "Yes (Recommended)", description: "plan-phase asks to run {{COMMAND_PREFIX}}ui-phase first when frontend indicators detected." },
       { label: "No", description: "No prompt — plan-phase proceeds without UI-SPEC check." }
+    ]
+  },
+  {
+    question: "Enable Incremental Remap? (auto-updates codebase docs after each phase)",
+    header: "Remap",
+    multiSelect: false,
+    options: [
+      { label: "Yes (Recommended)", description: "Run gsd-incremental-mapper agents after phase completion to keep codebase docs current." },
+      { label: "No", description: "Skip doc updates. Good when codebase docs are manual or phase work doesn't touch documented modules." }
     ]
   },
   {
@@ -160,7 +170,7 @@ AskUserQuestion([
     header: "Auto Push",
     multiSelect: false,
     options: [
-      { label: "No (Default)", description: "Push manually or via /gsd:create-pr" },
+      { label: "No (Default)", description: "Push manually or via {{COMMAND_PREFIX}}create-pr" },
       { label: "Yes", description: "Automatically push work branch to remote after each phase" }
     ]
   },
@@ -218,7 +228,7 @@ AskUserQuestion([
     multiSelect: false,
     options: [
       { label: "Yes (Default)", description: "Automatically close/comment external issues when GSD work completes" },
-      { label: "No", description: "Manual sync only via /gsd:sync-issues" }
+      { label: "No", description: "Manual sync only via {{COMMAND_PREFIX}}sync-issues" }
     ]
   },
   {
@@ -316,7 +326,8 @@ Merge new settings into existing config.json:
     "auto_advance": true/false,
     "nyquist_validation": true/false,
     "ui_phase": true/false,
-    "ui_safety_gate": true/false
+    "ui_safety_gate": true/false,
+    "incremental_remap": true/false
   },
   "git": {
     "branching_strategy": "none" | "phase" | "milestone",
@@ -404,6 +415,7 @@ Display:
 | Nyquist Validation   | {On/Off} |
 | UI Phase             | {On/Off} |
 | UI Safety Gate       | {On/Off} |
+| Incremental Remap    | {On/Off} |
 | Git Branching        | {None/Per Phase/Per Milestone} |
 | Target Branch        | {main/develop/custom} |
 | Auto Push            | {On/Off} |
@@ -417,13 +429,13 @@ Display:
 | Context Warnings     | {On/Off} |
 | Saved as Defaults    | {Yes/No} |
 
-These settings apply to future /gsd:plan-phase and /gsd:execute-phase runs.
+These settings apply to future {{COMMAND_PREFIX}}plan-phase and {{COMMAND_PREFIX}}execute-phase runs.
 
 Quick commands:
-- /gsd:set-profile <profile> — switch model profile
-- /gsd:plan-phase --research — force research
-- /gsd:plan-phase --skip-research — skip research
-- /gsd:plan-phase --skip-verify — skip plan check
+- {{COMMAND_PREFIX}}set-profile <profile> — switch model profile
+- {{COMMAND_PREFIX}}plan-phase --research — force research
+- {{COMMAND_PREFIX}}plan-phase --skip-research — skip research
+- {{COMMAND_PREFIX}}plan-phase --skip-verify — skip plan check
 ```
 </step>
 
@@ -431,7 +443,7 @@ Quick commands:
 
 <success_criteria>
 - [ ] Current config read
-- [ ] User presented with 18 settings (profile + 7 workflow toggles + git branching + target branch + auto push + PR draft + platform + 4 issue_tracker settings + context warnings), plus conditional platform follow-up and conditional verify_label
+- [ ] User presented with 19 settings (profile + 8 workflow toggles + git branching + target branch + auto push + PR draft + platform + 4 issue_tracker settings + context warnings), plus conditional platform follow-up and conditional verify_label
 - [ ] Config updated with model_profile, workflow, and git sections
 - [ ] User offered to save as global defaults (~/.gsd/defaults.json)
 - [ ] Changes confirmed to user

--- a/gsd-ng/workflows/stats.md
+++ b/gsd-ng/workflows/stats.md
@@ -47,7 +47,7 @@ X/Y plans complete (Z%)
 - **Project age:** N days
 ```
 
-If no `.planning/` directory exists, inform the user to run `/gsd:new-project` first.
+If no `.planning/` directory exists, inform the user to run `{{COMMAND_PREFIX}}new-project` first.
 </step>
 
 </process>

--- a/gsd-ng/workflows/sync-issues.md
+++ b/gsd-ng/workflows/sync-issues.md
@@ -28,7 +28,7 @@ Platform detected: {platform || 'none'}
 CLI installed: {cli_installed}
 {If cli_install_url: "Install: {cli_install_url}"}
 
-Configure platform via /gsd:settings or install the CLI tool.
+Configure platform via {{COMMAND_PREFIX}}settings or install the CLI tool.
 ```
 Exit.
 </step>
@@ -58,7 +58,7 @@ Add references using the `external_ref` field:
 - REQUIREMENTS.md traceability table: `| REQ-01 | Phase 1 | Complete | github:#42 |`
 - Todo frontmatter: `external_ref: github:#42`
 
-Import external issues: /gsd:import-issues
+Import external issues: {{COMMAND_PREFIX}}import-issues
 ```
 Exit.
 
@@ -115,7 +115,7 @@ For each conflict, use AskUserQuestion:
 <step name="security_awareness">
 After sync completes, check stderr output for `[security]` warnings.
 If present, inform the user:
-"Security scan detected suspicious content in synced issues. Details logged to .claude/logs/security-events.log. Run /gsd:health to review."
+"Security scan detected suspicious content in synced issues. Details logged to .claude/logs/security-events.log. Run {{COMMAND_PREFIX}}health to review."
 </step>
 
 <step name="summary">

--- a/gsd-ng/workflows/transition.md
+++ b/gsd-ng/workflows/transition.md
@@ -383,7 +383,7 @@ Next: Phase [X+1] — [Name]
 ⚡ Auto-continuing: Plan Phase [X+1] in detail
 ```
 
-Exit skill and invoke SlashCommand("/gsd:plan-phase [X+1] --auto")
+Exit skill and invoke SlashCommand("{{COMMAND_PREFIX}}plan-phase [X+1] --auto")
 
 **If CONTEXT.md does NOT exist:**
 
@@ -395,7 +395,7 @@ Next: Phase [X+1] — [Name]
 ⚡ Auto-continuing: Discuss Phase [X+1] first
 ```
 
-Exit skill and invoke SlashCommand("/gsd:discuss-phase [X+1] --auto")
+Exit skill and invoke SlashCommand("{{COMMAND_PREFIX}}discuss-phase [X+1] --auto")
 
 </if>
 
@@ -412,15 +412,15 @@ Exit skill and invoke SlashCommand("/gsd:discuss-phase [X+1] --auto")
 
 **Phase [X+1]: [Name]** — [Goal from ROADMAP.md]
 
-`/gsd:discuss-phase [X+1]` — gather context and clarify approach
+`{{COMMAND_PREFIX}}discuss-phase [X+1]` — gather context and clarify approach
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:plan-phase [X+1]` — skip discussion, plan directly
-- `/gsd:research-phase [X+1]` — investigate unknowns
+- `{{COMMAND_PREFIX}}plan-phase [X+1]` — skip discussion, plan directly
+- `{{COMMAND_PREFIX}}research-phase [X+1]` — investigate unknowns
 
 ---
 ```
@@ -437,15 +437,15 @@ Exit skill and invoke SlashCommand("/gsd:discuss-phase [X+1] --auto")
 **Phase [X+1]: [Name]** — [Goal from ROADMAP.md]
 <sub>✓ Context gathered, ready to plan</sub>
 
-`/gsd:plan-phase [X+1]`
+`{{COMMAND_PREFIX}}plan-phase [X+1]`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:discuss-phase [X+1]` — revisit context
-- `/gsd:research-phase [X+1]` — investigate unknowns
+- `{{COMMAND_PREFIX}}discuss-phase [X+1]` — revisit context
+- `{{COMMAND_PREFIX}}research-phase [X+1]` — investigate unknowns
 
 ---
 ```
@@ -471,7 +471,7 @@ Phase {X} marked complete.
 ⚡ Auto-continuing: Complete milestone and archive
 ```
 
-Exit skill and invoke SlashCommand("/gsd:complete-milestone {version}")
+Exit skill and invoke SlashCommand("{{COMMAND_PREFIX}}complete-milestone {version}")
 
 </if>
 
@@ -488,7 +488,7 @@ Exit skill and invoke SlashCommand("/gsd:complete-milestone {version}")
 
 **Complete Milestone {version}** — archive and prepare for next
 
-`/gsd:complete-milestone {version}`
+`{{COMMAND_PREFIX}}complete-milestone {version}`
 
 <sub>`/clear` first → fresh context window</sub>
 

--- a/gsd-ng/workflows/ui-phase.md
+++ b/gsd-ng/workflows/ui-phase.md
@@ -44,11 +44,11 @@ UI_ENABLED=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.u
 
 **If `UI_ENABLED` is `false`:**
 ```
-UI phase is disabled in config. Enable via /gsd:settings.
+UI phase is disabled in config. Enable via {{COMMAND_PREFIX}}settings.
 ```
 Exit workflow.
 
-**If `planning_exists` is false:** Error — run `/gsd:new-project` first.
+**If `planning_exists` is false:** Error — run `{{COMMAND_PREFIX}}new-project` first.
 
 ## 2. Parse and Validate Phase
 
@@ -65,7 +65,7 @@ PHASE_INFO=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" roadmap get-phase "${
 **If `has_context` is false:**
 ```
 No CONTEXT.md found for Phase {N}.
-Recommended: run /gsd:discuss-phase {N} first to capture design preferences.
+Recommended: run {{COMMAND_PREFIX}}discuss-phase {N} first to capture design preferences.
 Continuing without user decisions — UI researcher will ask all questions.
 ```
 Continue (non-blocking).
@@ -120,7 +120,7 @@ Answer: "What visual and interaction contracts does this phase need?"
 - {state_path} (Project State)
 - {roadmap_path} (Roadmap)
 - {requirements_path} (Requirements)
-- {context_path} (USER DECISIONS from /gsd:discuss-phase)
+- {context_path} (USER DECISIONS from {{COMMAND_PREFIX}}discuss-phase)
 - {research_path} (Technical Research — stack decisions)
 </files_to_read>
 
@@ -234,7 +234,7 @@ Max revision iterations reached. Remaining issues:
 
 Options:
 1. Force approve — proceed with current UI-SPEC (FLAGs become accepted)
-2. Edit manually — open UI-SPEC.md in editor, re-run /gsd:ui-phase
+2. Edit manually — open UI-SPEC.md in editor, re-run {{COMMAND_PREFIX}}ui-phase
 3. Abandon — exit without approving
 ```
 
@@ -259,7 +259,7 @@ Dimensions: 6/6 passed
 
 **Plan Phase {N}** — planner will use UI-SPEC.md as design context
 
-`/gsd:plan-phase {N}`
+`{{COMMAND_PREFIX}}plan-phase {N}`
 
 <sub>`/clear` first → fresh context window</sub>
 

--- a/gsd-ng/workflows/ui-review.md
+++ b/gsd-ng/workflows/ui-review.md
@@ -44,7 +44,7 @@ UI_SPEC_FILE=$(ls "${PHASE_DIR}"/*-UI-SPEC.md 2>/dev/null | head -1)
 UI_REVIEW_FILE=$(ls "${PHASE_DIR}"/*-UI-REVIEW.md 2>/dev/null | head -1)
 ```
 
-**If `SUMMARY_FILES` empty:** Exit — "Phase {N} not executed. Run /gsd:execute-phase {N} first."
+**If `SUMMARY_FILES` empty:** Exit — "Phase {N} not executed. Run {{COMMAND_PREFIX}}execute-phase {N} first."
 
 **If `UI_REVIEW_FILE` non-empty:** Use AskUserQuestion:
 - header: "Existing UI Review"
@@ -138,8 +138,8 @@ Full review: {path to UI-REVIEW.md}
 
 ## ▶ Next
 
-- `/gsd:verify-work {N}` — UAT testing
-- `/gsd:plan-phase {N+1}` — plan next phase
+- `{{COMMAND_PREFIX}}verify-work {N}` — UAT testing
+- `{{COMMAND_PREFIX}}plan-phase {N+1}` — plan next phase
 
 <sub>`/clear` first → fresh context window</sub>
 

--- a/gsd-ng/workflows/validate-phase.md
+++ b/gsd-ng/workflows/validate-phase.md
@@ -30,7 +30,7 @@ AUDITOR_MODEL=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" resolve-model gsd-
 NYQUIST_CFG=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" config-get workflow.nyquist_validation)
 ```
 
-If `NYQUIST_CFG` is `false`: exit with "Nyquist validation is disabled. Enable via /gsd:settings."
+If `NYQUIST_CFG` is `false`: exit with "Nyquist validation is disabled. Enable via {{COMMAND_PREFIX}}settings."
 
 Display banner: `GSD > VALIDATE PHASE {N}: {name}`
 
@@ -43,7 +43,7 @@ SUMMARY_FILES=$(ls "${PHASE_DIR}"/*-SUMMARY.md 2>/dev/null)
 
 - **State A** (`VALIDATION_FILE` non-empty): Audit existing
 - **State B** (`VALIDATION_FILE` empty, `SUMMARY_FILES` non-empty): Reconstruct from artifacts
-- **State C** (`SUMMARY_FILES` empty): Exit — "Phase {N} not executed. Run /gsd:execute-phase {N} first."
+- **State C** (`SUMMARY_FILES` empty): Exit — "Phase {N} not executed. Run {{COMMAND_PREFIX}}execute-phase {N} first."
 
 ## 2. Discovery
 
@@ -164,14 +164,14 @@ node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs(phase-${PHASE}): add/
 ```
 GSD > PHASE {N} IS NYQUIST-COMPLIANT
 All requirements have automated verification.
-▶ Next: /gsd:audit-milestone
+▶ Next: {{COMMAND_PREFIX}}audit-milestone
 ```
 
 **Partial:**
 ```
 GSD > PHASE {N} VALIDATED (PARTIAL)
 {M} automated, {K} manual-only.
-▶ Retry: /gsd:validate-phase {N}
+▶ Retry: {{COMMAND_PREFIX}}validate-phase {N}
 ```
 
 Display `/clear` reminder.

--- a/gsd-ng/workflows/verify-work.md
+++ b/gsd-ng/workflows/verify-work.md
@@ -1,5 +1,5 @@
 <purpose>
-Validate built features through conversational testing with persistent state. Creates UAT.md that tracks test progress, survives /clear, and feeds gaps into /gsd:plan-phase --gaps.
+Validate built features through conversational testing with persistent state. Creates UAT.md that tracks test progress, survives /clear, and feeds gaps into {{COMMAND_PREFIX}}plan-phase --gaps.
 
 User tests, Claude records. One test at a time. Plain text responses.
 </purpose>
@@ -78,7 +78,7 @@ If no, continue to `create_uat_file`.
 ```
 No active UAT sessions.
 
-Provide a phase number to start testing (e.g., /gsd:verify-work 4)
+Provide a phase number to start testing (e.g., {{COMMAND_PREFIX}}verify-work 4)
 ```
 
 **If no active sessions AND $ARGUMENTS provided:**
@@ -339,9 +339,9 @@ Present summary:
 ```
 All tests passed. Ready to continue.
 
-- `/gsd:plan-phase {next}` — Plan next phase
-- `/gsd:execute-phase {next}` — Execute next phase
-- `/gsd:ui-review {phase}` — visual quality audit (if frontend files were modified)
+- `{{COMMAND_PREFIX}}plan-phase {next}` — Plan next phase
+- `{{COMMAND_PREFIX}}execute-phase {next}` — Execute next phase
+- `{{COMMAND_PREFIX}}ui-review {phase}` — visual quality audit (if frontend files were modified)
 ```
 </step>
 
@@ -397,7 +397,7 @@ Task(
 </planning_context>
 
 <downstream_consumer>
-Output consumed by /gsd:execute-phase
+Output consumed by {{COMMAND_PREFIX}}execute-phase
 Plans must be executable prompts.
 </downstream_consumer>
 """,
@@ -506,7 +506,7 @@ Display: `Max iterations reached. {N} issues remain.`
 Offer options:
 1. Force proceed (execute despite issues)
 2. Provide guidance (user gives direction, retry)
-3. Abandon (exit, user runs /gsd:plan-phase manually)
+3. Abandon (exit, user runs {{COMMAND_PREFIX}}plan-phase manually)
 
 Wait for user response.
 </step>
@@ -534,7 +534,7 @@ Plans verified and ready for execution.
 
 **Execute fixes** — run fix plans
 
-`/gsd:execute-phase {phase} --gaps-only`
+`{{COMMAND_PREFIX}}execute-phase {phase} --gaps-only`
 
 <sub>`/clear` first → fresh context window</sub>
 
@@ -590,5 +590,5 @@ Default to **major** if unclear. User can correct if needed.
 - [ ] If issues: gsd-planner creates fix plans (gap_closure mode)
 - [ ] If issues: gsd-plan-checker verifies fix plans
 - [ ] If issues: revision loop until plans pass (max 3 iterations)
-- [ ] Ready for `/gsd:execute-phase --gaps-only` when complete
+- [ ] Ready for `{{COMMAND_PREFIX}}execute-phase --gaps-only` when complete
 </success_criteria>

--- a/tests/install-js.test.cjs
+++ b/tests/install-js.test.cjs
@@ -10,6 +10,8 @@ const crypto = require('crypto');
 
 const INSTALLER = path.resolve(__dirname, '..', 'bin', 'install.js');
 
+const { RUNTIMES } = require('../gsd-ng/bin/lib/template-processor.cjs');
+
 // Resolve a writable temp base — sandbox sets TMPDIR=/tmp/claude which may not exist on disk
 const { resolveTmpDir, cleanup } = require('./helpers.cjs');
 const BASE_TMPDIR = resolveTmpDir();
@@ -3173,5 +3175,67 @@ test('F-RULES-02: source new-project.md workflow uses {{PROJECT_RULES_FILE}} in 
     content.includes('{{PROJECT_RULES_FILE}}'),
     'new-project.md source must use {{PROJECT_RULES_FILE}} in Step 9 (F-RULES-02).\n' +
       'Fix: update new-project.md Step 9 to detect runtime and write dynamic content into {{PROJECT_RULES_FILE}}.',
+  );
+});
+
+// no runtime-specific PROJECT_RULES_FILE literals in template-mechanical source files
+test('RTAGNOSTIC-01: no PROJECT_RULES_FILE literals in template-mechanical sources', () => {
+  const REPO_ROOT = path.join(__dirname, '..');
+  const TEMPLATE_MECHANICAL_DIRS = [
+    path.join(REPO_ROOT, 'gsd-ng', 'workflows'),
+    path.join(REPO_ROOT, 'gsd-ng', 'references'),
+    path.join(REPO_ROOT, 'commands', 'gsd'),
+  ];
+
+  // Banned literals derived dynamically from RUNTIMES registry — no hardcoded list.
+  const BANNED_LITERALS = Object.values(RUNTIMES)
+    .map((r) => r.PROJECT_RULES_FILE)
+    .filter(Boolean);
+
+  function walkMd(dir) {
+    if (!fs.existsSync(dir)) return [];
+    const out = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) out.push(...walkMd(full));
+      else if (entry.isFile() && entry.name.endsWith('.md')) out.push(full);
+    }
+    return out;
+  }
+
+  const offenders = [];
+  for (const dir of TEMPLATE_MECHANICAL_DIRS) {
+    for (const file of walkMd(dir)) {
+      const content = fs.readFileSync(file, 'utf8');
+      for (const literal of BANNED_LITERALS) {
+        if (content.includes(literal)) {
+          offenders.push(`${path.relative(REPO_ROOT, file)} :: ${literal}`);
+          break;
+        }
+      }
+    }
+  }
+
+  assert.strictEqual(
+    offenders.length,
+    0,
+    `RTAGNOSTIC-01: runtime-specific PROJECT_RULES_FILE literals found in template-mechanical sources:\n  ${offenders.join('\n  ')}`,
+  );
+});
+
+// runtime-comparison prose must survive Copilot conversion intact
+test('COPILOT-RT: runtime-comparison prose survives Copilot conversion intact', () => {
+  const { convertClaudeToCopilotContent } = require('../bin/install.js');
+  const input =
+    'Updates both the project rules file (`CLAUDE.md` for Claude, ' +
+    '`.github/copilot-instructions.md` for Copilot).';
+  const output = convertClaudeToCopilotContent(input, false);
+  assert.ok(
+    output.includes('`CLAUDE.md` for Claude'),
+    `COPILOT-RT: expected '\`CLAUDE.md\` for Claude' to survive verbatim, got: ${output}`,
+  );
+  assert.ok(
+    output.includes('`.github/copilot-instructions.md` for Copilot'),
+    `COPILOT-RT: expected '\`.github/copilot-instructions.md\` for Copilot' to survive verbatim, got: ${output}`,
   );
 });


### PR DESCRIPTION
## Summary

Eliminate the runtime coupling that survives in deployed-template content. Two workstreams running in parallel:

1. **`/gsd:` → `{{COMMAND_PREFIX}}` sweep** — 295 hard-coded command prefix literals replaced across 54 source files (7 high-density workflows + 47 remaining workflows/references/commands)
2. **`CLAUDE.md` → `{{PROJECT_RULES_FILE}}` + `convertClaudeToCopilotContent` fix** — naive global regex substitutions removed from `bin/install.js`; `seed-memories.md` rewritten with template variables and `<!-- ONLY:runtime -->` blocks

Plus two follow-up quick tasks on the same branch:
- **`workflow.incremental_remap` toggle** — new config key gates the post-phase codebase doc update step in `execute-phase.md`, with a matching entry in `gsd:settings` so users can opt out interactively

## Changes

- **59-01**: TDD scaffold — `RTAGNOSTIC-01` (lint: zero banned literals in source) + `COPILOT-RT` (regression: `convertClaudeToCopilotContent` preserves runtime-comparison prose) added as failing tests
- **59-02**: 107 `/gsd:` → `{{COMMAND_PREFIX}}` substitutions in the 7 highest-density files
- **59-03**: 188 substitutions across the remaining 47 template-mechanical files
- **59-04**: `convertClaudeToCopilotContent` naive regexes removed; `seed-memories.md` uses `{{PROJECT_RULES_FILE}}` + `<!-- ONLY:* -->` blocks; both tests turn green
- **quick-t1z**: `workflow.incremental_remap` config key gates the incremental remap step in `execute-phase.md` (default `true`, silent skip when `false`); `planning-config.md` documents all `workflow.*` keys
- **quick-tq5**: `gsd:settings` menu gains an "Incremental Remap" question (question 19); `planning-config.md` updated to reflect it's now user-configurable

## Test Plan

- [x] `npm test` — 2187/2187 passing (up from 2185, +2 new tests)
- [x] `RTAGNOSTIC-01` green — zero banned literals in source dirs
- [x] `COPILOT-RT` green — `convertClaudeToCopilotContent` preserves runtime-comparison prose
- [x] `TEMPLATE-RESOLVE-01` green — `{{COMMAND_PREFIX}}` resolves correctly at install time
- [x] `COPILOT-10` green — Copilot install produces correct output
- [ ] Manual: run `gsd:settings` and verify "Incremental Remap" question appears

---
*Generated by [GSD-NG](https://github.com/chrisdevchroma/gsd-ng) from phase 59 execution*