### PR TITLE
chore: ignore stray self-install artifacts in submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ coverage/
 
 # Vendored local binaries (platform-specific, not committed)
 .bin/
+
+# GSD artifacts
+/.claude/
+/.planning/


### PR DESCRIPTION
## Summary

Add `/.claude/` and `/.planning/` to `.gitignore` so stray self-installed GSD instances inside the submodule's working tree don't show up as permanent untracked content in submodule status.

## Why

When `node bin/install.js` runs with the submodule directory as the project root (during testing or accidental misuse), it deploys the GSD runtime into `gsd-ng/.claude/` and creates a `gsd-ng/.planning/` tree. Since these paths weren't gitignored, the parent workspace would forever see `modified: gsd-ng (untracked content)` in `git status`.

Found a stray instance from 2026-05-02 (workspace install version `1.0.0-dev.3+c97d460`) plus a `260411-hu7` quick-task dir from April 11 — so this clutter has been accreting for weeks.

## Verification

- `git ls-tree -r origin/develop` confirms no `.claude/` or `.planning/` files are currently tracked on origin.
- Branch scan across all `refs/remotes/origin/*` confirms no remote branch has these dirs in its tracked tree.
- History shows past `chore: remove project-specific planning files` / `chore: remove old planning files` commits — the repo was cleaned up before, this gate prevents recurrence.

## Test Plan

- [x] No tracked `.claude/` or `.planning/` content currently on origin
- [ ] After merge, accidental local install at submodule root no longer shows as untracked

---
*Generated by GSD-NG hygiene cleanup*
