### PR TITLE
fix: STATE.md YAML/body sync + harden gsd-executor todo-closure boundary

### DIFF
--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -164,7 +164,7 @@ Track auto-fix attempts per task. After 3 auto-fix attempts on a single task:
 - Do NOT restart the build to find more issues
 
 **TODO OPERATIONS BOUNDARY:**
-NEVER call `todo complete`, `todo update`, or any todo-related gsd-tools commands during plan execution. Todo lifecycle management (creation, completion, status changes) is exclusively an orchestrator responsibility. The orchestrator closes todos only after verification passes. If you see todo context in your prompt (e.g., origin todo file paths, todo titles), treat it as read-only context — do NOT act on it.
+NEVER call `todo complete`, `todo update`, or any todo-related gsd-tools commands during plan execution. Todo lifecycle management (creation, completion, status changes) is exclusively an orchestrator responsibility. The orchestrator closes todos only after verification passes. If you see todo context in your prompt (e.g., origin todo file paths, todo titles), treat it as read-only context — do NOT act on it. Additionally, NEVER move, copy, or delete files under `.planning/todos/` by hand or via `git mv`/`cp`/`mv`/`rm`. The CLI's `todo complete` (`cmdTodoComplete` in `gsd-ng/bin/lib/commands.cjs`) handles untracked files via `fs.writeFileSync` + `fs.unlinkSync` — `git mv` failure is **not** a reason to fall back to manual file ops. Closure is always the orchestrator's job; if you find yourself needing to close a todo, that is a deviation requiring user approval. The correct destination is `.planning/todos/completed/`, never `.planning/todos/done/`.
 </deviation_rules>
 
 <analysis_paralysis_guard>

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -676,6 +676,15 @@ function cmdTodoComplete(cwd, filename) {
 
   const { todosPending: pendingDir, todosCompleted: completedDir } =
     planningPaths(cwd);
+
+  const strayDoneDir = path.join(pendingDir, '..', 'done');
+  if (fs.existsSync(strayDoneDir)) {
+    process.stderr.write(
+      `[warning] Stray .planning/todos/done/ directory detected — likely created by an off-piste agent. ` +
+      `Move its contents into .planning/todos/completed/ and remove the empty done/ directory.\n`
+    );
+  }
+
   const sourcePath = path.join(pendingDir, filename);
 
   if (!fs.existsSync(sourcePath)) {

--- a/gsd-ng/bin/lib/state.cjs
+++ b/gsd-ng/bin/lib/state.cjs
@@ -1059,9 +1059,10 @@ function writeStateMd(statePath, content, cwd) {
       `[security] Advisory: potential injection in STATE.md: ${findings.join('; ')}\n`,
     );
   }
-  // Transparent write — no implicit frontmatter sync.
-  // Use `state rebuild-frontmatter` to explicitly regenerate frontmatter from body.
-  fs.writeFileSync(statePath, content, 'utf-8');
+  // Sync YAML frontmatter from body on every write so top YAML and body bold stay in lockstep.
+  // syncStateFrontmatter is idempotent and read-only on the body — only constructs FM from it.
+  const synced = syncStateFrontmatter(content, cwd);
+  fs.writeFileSync(statePath, synced, 'utf-8');
 }
 
 function cmdStateRebuildFrontmatter(cwd) {

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -629,6 +629,71 @@ describe('todo complete command', () => {
     assert.ok(!result.success, 'should fail');
     assert.ok(result.error.includes('not found'), 'error mentions not found');
   });
+
+  test('warns when stray .planning/todos/done/ directory exists (non-recurring path)', () => {
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    const strayDoneDir = path.join(tmpDir, '.planning', 'todos', 'done');
+    fs.mkdirSync(pendingDir, { recursive: true });
+    fs.mkdirSync(strayDoneDir, { recursive: true });
+    fs.writeFileSync(path.join(pendingDir, 'sample.md'), 'title: Sample\n');
+
+    const result = runGsdTools('todo complete sample.md --json', tmpDir);
+    assert.ok(result.success, `Command should succeed despite stray dir: ${result.error}`);
+    assert.match(
+      result.stderr || '',
+      /Stray \.planning\/todos\/done\//,
+      'should warn about stray done/ directory'
+    );
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, '.planning', 'todos', 'completed', 'sample.md')),
+      'non-recurring todo should be moved to completed/'
+    );
+  });
+
+  test('warns when stray .planning/todos/done/ directory exists (recurring path)', () => {
+    // Recurring todos take an early-return branch. The warning must fire BEFORE that branch.
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    const strayDoneDir = path.join(tmpDir, '.planning', 'todos', 'done');
+    fs.mkdirSync(pendingDir, { recursive: true });
+    fs.mkdirSync(strayDoneDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(pendingDir, 'recurring.md'),
+      '---\nrecurring: true\ninterval: weekly\n---\n\n# Weekly check\n'
+    );
+
+    const result = runGsdTools('todo complete recurring.md --json', tmpDir);
+    assert.ok(result.success, `Recurring complete should succeed: ${result.error}`);
+    assert.match(
+      result.stderr || '',
+      /Stray \.planning\/todos\/done\//,
+      'should warn about stray done/ directory on recurring path too'
+    );
+    // Recurring file STAYS in pending/ — verify it did not move to completed/
+    assert.ok(
+      fs.existsSync(path.join(pendingDir, 'recurring.md')),
+      'recurring todo should stay in pending/'
+    );
+    assert.ok(
+      !fs.existsSync(path.join(tmpDir, '.planning', 'todos', 'completed', 'recurring.md')),
+      'recurring todo should NOT be in completed/'
+    );
+    // last_completed should be added
+    const updated = fs.readFileSync(path.join(pendingDir, 'recurring.md'), 'utf-8');
+    assert.match(updated, /last_completed:\s*\d{4}-\d{2}-\d{2}T/, 'last_completed timestamp should be added');
+  });
+
+  test('does NOT warn when no stray done/ directory exists', () => {
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    fs.mkdirSync(pendingDir, { recursive: true });
+    fs.writeFileSync(path.join(pendingDir, 'sample.md'), 'title: Sample\n');
+
+    const result = runGsdTools('todo complete sample.md --json', tmpDir);
+    assert.ok(result.success);
+    assert.ok(
+      !/Stray \.planning\/todos\/done\//.test(result.stderr || ''),
+      'should NOT warn when no stray done/ exists'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -1509,6 +1509,59 @@ describe('phase complete command', () => {
     assert.strictEqual(cells[1], 'v1.0', 'Milestone column should be preserved');
     assert.ok(cells[3].includes('Complete'), 'Status column should be Complete');
   });
+
+  test('phase complete keeps top YAML and body bold in sync (Bug 260502-wid)', () => {
+    // Seed: body has current phase 01 body bold fields; no YAML frontmatter yet.
+    // Simulates a STATE.md that has only ever had body bold (pre-fix drift state).
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] Phase 1: Foundation
+- [ ] Phase 2: API
+
+### Phase 1: Foundation
+**Goal:** Setup
+**Plans:** 1 plans
+
+### Phase 2: API
+**Goal:** Build API
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 01\n**Current Phase Name:** Foundation\n**Status:** In progress\n**Current Plan:** 01-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 1\n`
+    );
+
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '02-api'), { recursive: true });
+
+    const result = runGsdTools('phase complete 1 --json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const { extractFrontmatter } = require('../gsd-ng/bin/lib/frontmatter.cjs');
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const fm = extractFrontmatter(content);
+
+    assert.ok(fm && Object.keys(fm).length > 0, 'STATE.md should have YAML frontmatter after phase complete');
+
+    // Extract body bold values for comparison
+    const bodyPhase = (content.match(/\*\*Current Phase:\*\*\s*(\S+)/) || [])[1];
+    const bodyStatus = (content.match(/\*\*Status:\*\*\s*(.+)/) || [])[1];
+
+    assert.ok(bodyPhase, 'body should have **Current Phase:** field');
+    assert.ok(bodyStatus, 'body should have **Status:** field');
+
+    // Top YAML current_phase should match body bold **Current Phase:**
+    assert.strictEqual(
+      String(fm.current_phase),
+      bodyPhase.trim(),
+      `YAML current_phase (${fm.current_phase}) should match body bold (${bodyPhase.trim()})`
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -425,8 +425,8 @@ stopped_at: Plan 2 of Phase 3
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// STATE.md frontmatter sync (Bug 1 fix: writeStateMd is now a transparent write)
-// Frontmatter is only added/updated via explicit `state rebuild-frontmatter`.
+// STATE.md frontmatter sync (Bug 260502-wid fix: writeStateMd now auto-syncs YAML frontmatter)
+// Every write keeps top YAML and body bold in lockstep via syncStateFrontmatter.
 // ─────────────────────────────────────────────────────────────────────────────
 
 describe('STATE.md frontmatter sync', () => {
@@ -440,9 +440,9 @@ describe('STATE.md frontmatter sync', () => {
     cleanup(tmpDir);
   });
 
-  test('state update updates body field but does NOT auto-add frontmatter (Bug 1 fix)', () => {
-    // Bug 1 fix: writeStateMd is now a transparent write — no implicit syncStateFrontmatter.
-    // state update only updates the body field; frontmatter is NOT auto-generated.
+  test('state update updates body field AND auto-adds frontmatter', () => {
+    // Bug 260502-wid fix: writeStateMd now calls syncStateFrontmatter on every write.
+    // state update updates the body field AND auto-generates YAML frontmatter.
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
       `# Project State
@@ -459,8 +459,8 @@ describe('STATE.md frontmatter sync', () => {
     // Body field should be updated
     assert.ok(content.includes('**Current Phase:** 02'), 'body field should be preserved');
     assert.ok(content.includes('**Status:** Executing Plan 1'), 'updated field in body');
-    // Frontmatter should NOT be auto-added (no longer coupled to writeStateMd)
-    assert.ok(!content.startsWith('---\n'), 'frontmatter should NOT be auto-added on state update');
+    // Frontmatter SHOULD be auto-added (now coupled to writeStateMd)
+    assert.ok(content.startsWith('---\n'), 'frontmatter should be auto-added on state update');
   });
 
   test('state rebuild-frontmatter explicitly adds frontmatter to STATE.md', () => {
@@ -484,7 +484,7 @@ describe('STATE.md frontmatter sync', () => {
     assert.ok(content.includes('**Current Phase:** 02'), 'body field should be preserved');
   });
 
-  test('state patch updates body field but does NOT auto-add frontmatter (Bug 1 fix)', () => {
+  test('state patch updates body field AND auto-adds frontmatter', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
       `# Project State
@@ -501,13 +501,13 @@ describe('STATE.md frontmatter sync', () => {
     const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
     // Body should be updated
     assert.ok(content.includes('**Current Plan:** 04-02'), 'body field should be updated by patch');
-    // Frontmatter should NOT be auto-added
-    assert.ok(!content.startsWith('---\n'), 'frontmatter should NOT be auto-added on state patch');
+    // Frontmatter SHOULD be auto-added
+    assert.ok(content.startsWith('---\n'), 'frontmatter should be auto-added on state patch');
   });
 
-  test('multiple state updates do not accumulate frontmatter (Bug 1 fix)', () => {
-    // Previously: each write would call syncStateFrontmatter, potentially duplicating delimiters.
-    // Now: transparent writes; no frontmatter accumulation.
+  test('multiple state updates do not accumulate frontmatter (Bug 260502-wid fix)', () => {
+    // Each write calls syncStateFrontmatter which is idempotent — multiple writes
+    // produce exactly one frontmatter block, never duplicated delimiters.
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
       `# Project State
@@ -521,13 +521,19 @@ describe('STATE.md frontmatter sync', () => {
     runGsdTools('state update Status "Paused"', tmpDir);
 
     const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
-    // Should have zero frontmatter blocks (none auto-added)
+    // Should have exactly one frontmatter block (2 delimiters: opening and closing ---)
     const delimiterCount = (content.match(/^---$/gm) || []).length;
-    assert.strictEqual(delimiterCount, 0, 'no frontmatter should be auto-added on multiple writes');
+    assert.strictEqual(delimiterCount, 2, 'exactly one frontmatter block (2 delimiters) should exist after multiple writes');
   });
 
-  test('preserves existing frontmatter unchanged when updating body (Bug 1 fix)', () => {
-    // writeStateMd is transparent — existing frontmatter in content is preserved as-is.
+  test('preserves existing frontmatter values when body has no overriding bold field', () => {
+    // Seed body has **Current Phase:** and **Current Plan:** but NO **Status:** line.
+    // syncStateFrontmatter trace on this seed:
+    //   stateExtractField(body, 'Status') → null
+    //   buildStateFrontmatter sees null → preservation branch fires → status: 'executing' is kept from existing FM
+    //   milestone is non-canonical → dropped (only canonical keys survive a rebuild)
+    // After `state update "Current Plan" "03-03"` the body's bold is updated, then writeStateMd
+    // re-runs syncStateFrontmatter so YAML's current_plan now reads "03-03".
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
       `---
@@ -542,18 +548,20 @@ milestone: v1.0
 `
     );
 
-    // state update now only changes the body field; frontmatter is not touched
     runGsdTools('state update "Current Plan" "03-03"', tmpDir);
 
     const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
-    // The existing frontmatter should be preserved (transparent write)
-    assert.ok(content.includes('status: executing'), 'existing frontmatter should be preserved by transparent write');
+    // Status preserved via preservation branch (body has no **Status:** field)
+    assert.ok(content.includes('status: executing'), 'status preserved because body has no **Status:** field for buildStateFrontmatter to derive from');
     assert.ok(content.includes('**Current Plan:** 03-03'), 'body field should be updated');
+    // YAML current_plan should sync from the updated body bold
+    assert.match(content, /current_plan:\s*03-03/, 'YAML current_plan should sync from body bold');
   });
 
   test('round-trip: write then read via state json', () => {
-    // state json reads from frontmatter if present, otherwise builds from body.
-    // After an update, the frontmatter may be stale — state json falls back to body parsing.
+    // state json reads from the YAML frontmatter (now always present + current after Bug 260502-wid fix).
+    // Before the fix, FM could be stale and state json would fall back to body parsing; that fallback
+    // path still exists for legacy STATE.md files but is no longer the common case.
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),
       `# Project State
@@ -573,7 +581,7 @@ milestone: v1.0
     assert.ok(result.success, `state json failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
-    // state json builds frontmatter on-the-fly from body when no frontmatter exists
+    // state json reads from the now-current YAML frontmatter (built by syncStateFrontmatter on write)
     assert.strictEqual(output.current_phase, '07', 'round-trip: phase preserved');
     assert.strictEqual(output.current_phase_name, 'Production', 'round-trip: phase name preserved');
     assert.strictEqual(output.status, 'executing', 'round-trip: status normalized');
@@ -2095,9 +2103,9 @@ describe('stateReplaceField frontmatter safety (Bug 6)', () => {
   });
 });
 
-// ─── Bug 1: writeStateMd decoupling ──────────────────────────────────────────
+// ─── Bug 1 fix v2: writeStateMd coupling ─────────────────────────────────────
 
-describe('writeStateMd decoupling (Bug 1)', () => {
+describe('writeStateMd coupling (Bug 1 fix v2)', () => {
   let tmpDir;
 
   beforeEach(() => {
@@ -2108,22 +2116,24 @@ describe('writeStateMd decoupling (Bug 1)', () => {
     cleanup(tmpDir);
   });
 
-  test('writeStateMd writes content as-is without calling syncStateFrontmatter', () => {
-    // Write a STATE.md with known body content — if syncStateFrontmatter were called
-    // it would regenerate the frontmatter from the body, potentially changing it.
-    // We pass content with a deliberately unusual frontmatter to detect any transformation.
+  test('writeStateMd auto-syncs frontmatter from body', () => {
+    // writeStateMd now calls syncStateFrontmatter before writing.
+    // A non-canonical key in the original FM (unique marker) is dropped and the FM
+    // is rebuilt from body bold. The canonical keys (current_phase, last_updated) must be present.
     const statePath = path.join(tmpDir, '.planning', 'STATE.md');
-    const uniqueMarker = 'UNIQUE_MARKER_SHOULD_NOT_BE_REMOVED_12345';
-    const content = `---\n${uniqueMarker}: yes\n---\n\n**Status:** executing\n`;
+    const uniqueMarker = 'UNIQUE_MARKER_SHOULD_BE_REMOVED_12345';
+    const content = `---\n${uniqueMarker}: yes\n---\n\n**Current Phase:** 7\n**Status:** executing\n`;
     const { writeStateMd } = require('../gsd-ng/bin/lib/state.cjs');
 
     writeStateMd(statePath, content, tmpDir);
 
     const written = fs.readFileSync(statePath, 'utf-8');
     assert.ok(
-      written.includes(uniqueMarker),
-      `writeStateMd should write content as-is; unique frontmatter key should be preserved. Got:\n${written}`
+      !written.includes(uniqueMarker),
+      `syncStateFrontmatter should rebuild FM from body, dropping the non-canonical unique marker. Got:\n${written}`
     );
+    assert.ok(written.includes('current_phase:'), 'FM should contain canonical current_phase key');
+    assert.ok(written.includes('last_updated:'), 'FM should contain canonical last_updated key');
   });
 
   test('writeStateMd still performs scanForInjection advisory check (exits 0 on injection)', () => {


### PR DESCRIPTION
## Summary

Two bugs surfaced during the 260502-vdg session, fixed together because they're both about state-management hygiene:

1. **STATE.md dual-format drift.** `writeStateMd` deliberately skipped frontmatter sync ("transparent write"), so every `phase complete N` updated body markdown bold (`**Current Phase:** N`) but left top YAML (`current_phase: N`) stale. Readers fell through to body, so behavior was correct, but humans reading the top of STATE.md saw the wrong phase number — which was the original tripwire that sent us down the 260502-vdg rabbit hole.

2. **gsd-executor todo-closure footgun.** During 260502-vdg the executor moved a closed todo to `.planning/todos/done/` instead of `.planning/todos/completed/` — invented `done/` from intuition, by-passing the CLI's `cmdTodoComplete` (which would have used the right destination via `fs.writeFileSync`+`fs.unlinkSync`). The agent's reasoning ("file untracked → can't `git mv` → fall back to `cp`+`rm`") was based on a wrong premise (CLI never used `git mv`).

## Fix Bug 1 — `writeStateMd` auto-syncs

`gsd-ng/bin/lib/state.cjs:1054-1066` — `writeStateMd` now calls `syncStateFrontmatter(content, cwd)` before `fs.writeFileSync`. `syncStateFrontmatter` (already battle-tested at line 1027) is idempotent and read-only on the body, so unioning it into every write is safe.

This was Option A from the research (smaller, surgical) over Option B (drop body bold, YAML-canonical, 14-site migration). The deciding factor: every existing writer goes through `writeStateMd`, so a one-line change covers all 14 sites automatically.

## Fix Bug 2 — gsd-executor TODO OPERATIONS BOUNDARY

`gsd-ng/agents/gsd-executor.md` — extended the existing TODO OPERATIONS BOUNDARY block to explicitly forbid `cp`/`mv`/`git mv` under `.planning/todos/`. Closure MUST invoke `node gsd-tools.cjs todo complete <filename>`. Includes a one-liner clarifying the CLI handles untracked files (so the executor can't fall back to manual moves on that pretext again).

Belt-and-braces: `cmdTodoComplete` (`commands.cjs:680-686`) warns to stderr if `.planning/todos/done/` exists at runtime. Placed before the recurring-todo early-return so both completion paths emit the warning. If a future executor goes off-piste again, operators see it immediately instead of finding stray dirs weeks later.

## Test Inversions (the surprising part)

`gsd-ng/tests/state.test.cjs:432-540` had **6 tests deliberately asserting the decoupling**, labelled "(Bug 1 fix)" — written when someone previously fixed an opposite bug by removing implicit frontmatter sync. The plan-checker initially flagged this and I had to convince myself it was safe to invert.

**Why this is the right direction now (not a regression of the prior fix):** the prior bug was almost certainly "frontmatter accreting / corrupting on writes" — `syncStateFrontmatter` was buggy at the time, so removing it was the safe call. But `syncStateFrontmatter` has since been hardened (idempotent, status-preservation branch at lines 1037-1043), so it's now safe to wire it back in. The new tests assert: "after writeStateMd, top YAML reflects body" — the inverse of the old "after writeStateMd, frontmatter is untouched". 5 inverted, 1 kept (`state rebuild-frontmatter` is still explicit), 1 audited (the round-trip test still passes because FM is now current; only its descriptive comment changed).

Plan checker iteration log:
- Round 1: 2 blockers (6th test missed in enumeration; stray-done warning fires on recurring path too)
- Round 2: PASS after surgical revisions

## Eat our own dog food

Both source todos closed via `node gsd-tools.cjs todo complete` (NOT manual cp/rm). This is the EXACT failure pattern this PR fixes.

## Test Plan

- [x] 449/449 tests pass (was 446 before; +3 stray-done tests, plus invariant test, plus inverted/audited state tests)
- [x] Source/deployed parity clean for `gsd-executor.md`
- [x] Both source todos in `.planning/todos/completed/`, none in `pending/`
- [ ] Manual verification: next `phase complete N` should leave STATE.md top YAML and body bold in agreement

---
*Generated by GSD-NG from quick task 260502-wid (research + plan-checker + verifier)*
