### PR TITLE
docs: add CONTRIBUTING.md at repo root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Branch protection rulesets for main and develop (squash-only, PR required), tag protection for `v*` and `gsd/*`
 - VERSIONING.md documenting release strategy
 
+#### Documentation
+- `CONTRIBUTING.md` at repo root — repo layout, test commands, hook-debug pointer, commit-message conventions, issue / security reporting
+
 ### Changed
 - `install.js` permission seeding now emits one log line per section (`Added N allow entries`, `Added N deny rules`, `Added N ask entries`) instead of a single combined `Seeded N permissions` line. The no-op path (`Permissions already up to date`) is unchanged. Any downstream tooling that screen-scrapes installer output will need to adapt.
 - Template `settings-sandbox.json` now ships canonical `Edit(*)/Write(*)/Read(*)` forms; `install.js` down-converts to bare `Edit/Write/Read` on Linux at install time via `getReadEditWriteAllowRules`. Existing user installs keep their previous forms until a future `--clean` migration.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to gsd-ng
+
+Thanks for contributing. gsd-ng is a Claude Code-focused fork of get-shit-done. See [README.md](README.md) for getting started and [SECURITY.md](SECURITY.md) for security reporting.
+
+## Repo layout
+
+- `gsd-ng/workflows/` — orchestrator workflow prompts (`/gsd:execute-phase`, `/gsd:plan-phase`, etc.)
+- `gsd-ng/references/` — workflow reference snippets loaded via `@`-includes
+- `agents/` — typed subagent prompts (planner, executor, verifier, etc.)
+- `commands/gsd/` — Claude Code command shims that point at workflows
+- `bin/` — `install.js` + `gsd-tools.cjs` entry points
+- `bin/lib/` — `gsd-tools.cjs` subcommand implementations
+- `hooks/` — PreToolUse / Stop hook scripts (`bash-safety-hook.cjs`, `context-monitor`, etc.)
+- `scripts/` — repo build / lint / coverage scripts
+- `tests/` — `node --test` suites
+- `docs/` — architecture and reference documentation
+
+## Running tests
+
+```bash
+npm test                # full suite
+npm run test:coverage   # with c8 coverage (per-file gate)
+node --test tests/bash-hook.test.cjs   # single file, fast feedback
+```
+
+The coverage suite enforces ≥95% line / ≥90% branch / ≥80% function coverage per `bin/lib/*.cjs` module (see `scripts/coverage-gate.cjs`). A baseline-cap check (`tests/c8-ignore-lint.test.cjs`) prevents new `c8-ignore` directives from silently widening the exemption — add a justified entry to `tests/c8-ignore-baseline.json` if you legitimately need one.
+
+## The bash-safety hook
+
+The repo ships a PreToolUse hook (`hooks/bash-safety-hook.cjs`) that gates `Bash` tool calls through an allowlist with subshell decomposition and wrapper-bypass detection. If a commit's tests pass locally but fail in CI on a hook denial, see [docs/bash-safety-hook.md](docs/bash-safety-hook.md) for the deny/allow algorithm and how to debug a specific command.
+
+## Commit message style
+
+Use [`gsd-tools.cjs commit "<msg>" --files <files...>`](bin/gsd-tools.cjs) — handles attribution and co-author lines.
+
+Prefix conventions follow [Conventional Commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `refactor:`, `docs:`, `test:`, `chore:`. Optional scope in parens describes the module touched, not internal task tracking — e.g. `feat(hook):`, `fix(install):`, `test(coverage):`.
+
+See [VERSIONING.md](VERSIONING.md) for the release / changelog flow.
+
+## Reporting issues
+
+- Bugs and feature requests: GitHub Issues.
+- Security: see [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary

Add a `CONTRIBUTING.md` at the repo root. No precedent file in the repo.

## Sections

- **Repo layout** — one-line description of each top-level directory contributors will touch (`gsd-ng/workflows/`, `gsd-ng/references/`, `agents/`, `commands/gsd/`, `bin/`, `bin/lib/`, `hooks/`, `scripts/`, `tests/`, `docs/`).
- **Running tests** — the three test commands (`npm test`, `npm run test:coverage`, single-file `node --test`) plus a one-line description of the per-file coverage gate and c8-ignore baseline-cap mechanism that PRs need to maintain.
- **The bash-safety hook** — short pointer to `docs/bash-safety-hook.md` (lands separately) for anyone debugging a hook denial in CI.
- **Commit message style** — Conventional Commits with optional module scope (`feat(hook):`, `fix(install):`, etc.), plus a pointer to `gsd-tools.cjs commit` and `VERSIONING.md`.
- **Reporting issues** — GitHub Issues for bugs / features, `SECURITY.md` for security.

## Test plan

- [x] `npm test` — passes; the comment-hygiene lint covers the new doc indirectly via the scan rules
- [x] Markdown rendering verified locally
- [ ] Reviewer: check that the hook-debug pointer is clear enough — `docs/bash-safety-hook.md` itself lands in a follow-up PR

## Note

This is one of two recovery PRs. A separate PR will add `docs/bash-safety-hook.md` that the CONTRIBUTING file forward-references.
