### PR TITLE
chore(ci): prepare-release uses PR + tag flow instead of direct push

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -17,6 +17,7 @@ on:
           - main
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   prepare:
@@ -97,7 +98,7 @@ jobs:
             sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$VERSION] - $DATE/" CHANGELOG.md
           fi
 
-      - name: Commit and tag
+      - name: Commit, tag, and push release branch
         shell: bash
         env:
           VERSION: ${{ inputs.version }}
@@ -105,7 +106,35 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          # New branch holds the release commit + tag. Pushing to a fresh
+          # branch and to a new tag are not blocked by the branch's
+          # pull_request ruleset (which only governs the existing branch).
+          RELEASE_BRANCH="release/v$VERSION"
+          git checkout -b "$RELEASE_BRANCH"
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v$VERSION"
           git tag -a "v$VERSION" -m "Release v$VERSION"
-          git push --atomic origin "$BRANCH" "v$VERSION"
+          # Atomic push: branch + tag together. Downstream release.yml /
+          # publish.yml fire on the tag push and don't depend on the PR
+          # merging to $BRANCH first.
+          git push --atomic origin "$RELEASE_BRANCH" "v$VERSION"
+          echo "RELEASE_BRANCH=$RELEASE_BRANCH" >> "$GITHUB_ENV"
+
+      - name: Open release PR with auto-merge
+        env:
+          VERSION: ${{ inputs.version }}
+          BRANCH: ${{ inputs.branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PR_BODY="Automated release commit for v$VERSION.
+
+          - \`package.json\` bumped to $VERSION
+          - \`CHANGELOG.md\` stamped with the [$VERSION] section
+          - Tag \`v$VERSION\` already pushed; \`release.yml\` and \`publish.yml\` fired on the tag push and run independently of this PR
+          - This PR merges the version bump + changelog stamp into \`$BRANCH\`; auto-merge enabled (rebase) so it lands as soon as required checks pass"
+          gh pr create \
+            --base "$BRANCH" \
+            --head "$RELEASE_BRANCH" \
+            --title "chore: release v$VERSION" \
+            --body "$PR_BODY"
+          gh pr merge --auto --rebase "$RELEASE_BRANCH"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Deduplicated AST safety rules into single template
 - Wired `defaults.cjs` into config, core, init, verify, workspace modules
 - Removed stale Windows references and guards
+- `prepare-release.yml` workflow now creates a release branch + tag and opens an auto-merging PR into the target branch, instead of pushing the release commit and tag directly. Direct push was blocked by the `pull_request` rule on `develop`/`main` rulesets on user-owned forks (where the `github-actions` integration can't be added as a bypass actor). Downstream `release.yml` and `publish.yml` still fire on the tag push, independent of the PR's merge state.
 
 ### Removed
 - `install.js --config-dir` / `-c` CLI flag — custom config directories are still supported via the `CLAUDE_CONFIG_DIR` / `COPILOT_CONFIG_DIR` environment variables. Users with `--config-dir` in install scripts must switch to the env-var form.


### PR DESCRIPTION
## Summary

Rewrite `prepare-release.yml` to use a PR + tag flow instead of pushing the release commit directly to develop / main.

## Why

The current workflow ends with:
```yaml
git push --atomic origin "$BRANCH" "v$VERSION"
```

This is blocked by the `pull_request` rule on both develop's and main's protection rulesets. On user-owned repos (this fork is one), the `github-actions` integration can't be added as a bypass actor because GitHub's API requires the integration to belong to the org that owns the repo — there's no org here.

Symptom: `prepare-release` runs failed at the final push step with `remote: error: GH013: Repository rule violations found ... Changes must be made through a pull request.`

## What changed

The "Commit and tag" step is replaced by two steps:

1. **Commit, tag, and push release branch** — version bump + CHANGELOG stamp are committed on a fresh `release/v$VERSION` branch (not the target branch). Atomic push of the new branch + the new `v$VERSION` tag together. Neither is blocked: new branches aren't governed by the existing branch's ruleset, and tag creation isn't blocked by the `Protect version tags` ruleset (which only prevents update / deletion / non-FF).

2. **Open release PR with auto-merge** — opens a PR from `release/v$VERSION` into the target branch with a body explaining what's in the PR, then enables auto-merge (`--rebase`) so it lands as soon as required checks pass.

Also adds `pull-requests: write` to the workflow's `permissions:` block (needed for `gh pr create` / `gh pr merge`).

## Downstream effect

`release.yml` and `publish.yml` trigger on `push: tags: 'v*.*.*'`. They fire on the tag push from step 1 and run independently of step 2's PR merge. So release artifacts (GitHub Release, npm publish) appear at the same point in the timeline as before — just with the version-bump commit landing on develop via a PR rather than direct push.

## Test plan

- [x] `npm test` — green (workflow file change doesn't affect runtime code)
- [ ] Reviewer: confirm the PR body / merge method matches your preference
- [ ] Smoke test: run `prepare-release` for `1.0.0-dev.4` after this merges. The workflow should produce a `v1.0.0-dev.4` tag, fire `release.yml` + `publish.yml`, and open a PR for the version bump.
