### PR TITLE
chore(ci): chain release + publish from prepare-release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -120,6 +120,17 @@ jobs:
           git push --atomic origin "$RELEASE_BRANCH" "v$VERSION"
           echo "RELEASE_BRANCH=$RELEASE_BRANCH" >> "$GITHUB_ENV"
 
+      - name: Trigger release and publish workflows
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Tags pushed by GITHUB_TOKEN do NOT trigger downstream workflows
+          # (anti-loop protection). Explicitly dispatch release.yml and
+          # publish.yml against the just-pushed tag.
+          gh workflow run release.yml --ref "v$VERSION" -f tag="v$VERSION"
+          gh workflow run publish.yml --ref "v$VERSION" -f tag="v$VERSION"
+
       - name: Open release PR with auto-merge
         env:
           VERSION: ${{ inputs.version }}
@@ -130,7 +141,7 @@ jobs:
 
           - \`package.json\` bumped to $VERSION
           - \`CHANGELOG.md\` stamped with the [$VERSION] section
-          - Tag \`v$VERSION\` already pushed; \`release.yml\` and \`publish.yml\` fired on the tag push and run independently of this PR
+          - Tag \`v$VERSION\` already pushed; \`release.yml\` and \`publish.yml\` triggered explicitly against the tag
           - This PR merges the version bump + changelog stamp into \`$BRANCH\`; auto-merge enabled (rebase) so it lands as soon as required checks pass"
           gh pr create \
             --base "$BRANCH" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish (e.g., v1.0.0-dev.4)'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -15,7 +21,26 @@ jobs:
     environment: release
 
     steps:
+      - name: Resolve ref
+        id: resolve
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            REF="$INPUT_TAG"
+          else
+            REF="${GITHUB_REF#refs/tags/}"
+          fi
+          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+            echo "::error::Resolved ref '$REF' is not a valid release tag"
+            exit 1
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.resolve.outputs.ref }}
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -24,7 +49,9 @@ jobs:
 
       - name: Validate release
         shell: bash
-        run: bash scripts/validate-release.sh "${GITHUB_REF#refs/tags/v}"
+        env:
+          TAG: ${{ steps.resolve.outputs.ref }}
+        run: bash scripts/validate-release.sh "${TAG#v}"
 
       - name: Install dev dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build/release (e.g., v1.0.0-dev.4)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,7 +22,26 @@ jobs:
     environment: release
 
     steps:
+      - name: Resolve ref
+        id: resolve
+        shell: bash
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          if [ -n "$INPUT_TAG" ]; then
+            REF="$INPUT_TAG"
+          else
+            REF="${GITHUB_REF#refs/tags/}"
+          fi
+          if [[ ! "$REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z]+\.[0-9]+)?$ ]]; then
+            echo "::error::Resolved ref '$REF' is not a valid release tag"
+            exit 1
+          fi
+          echo "ref=$REF" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ steps.resolve.outputs.ref }}
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -24,7 +49,9 @@ jobs:
 
       - name: Validate release
         shell: bash
-        run: bash scripts/validate-release.sh "${GITHUB_REF#refs/tags/v}"
+        env:
+          TAG: ${{ steps.resolve.outputs.ref }}
+        run: bash scripts/validate-release.sh "${TAG#v}"
 
       - name: Install dev dependencies
         run: npm ci
@@ -38,8 +65,9 @@ jobs:
       - name: Detect prerelease and build release body
         id: meta
         shell: bash
+        env:
+          TAG: ${{ steps.resolve.outputs.ref }}
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
           # Link to the changelog file at the tagged revision for release details
           BODY="See [CHANGELOG.md](https://github.com/$GITHUB_REPOSITORY/blob/${TAG}/CHANGELOG.md) for details."
           {
@@ -61,6 +89,7 @@ jobs:
       - name: Create GitHub Release as draft
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
+          tag_name: ${{ steps.resolve.outputs.ref }}
           files: dist/gsd-ng.tar.gz
           body: ${{ steps.meta.outputs.body }}
           generate_release_notes: true
@@ -70,9 +99,9 @@ jobs:
 
       - name: Publish release
         shell: bash
+        env:
+          TAG: ${{ steps.resolve.outputs.ref }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          TAG=${GITHUB_REF#refs/tags/}
           RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --jq ".[] | select(.tag_name==\"${TAG}\") | .id")
           gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}" --method PATCH -f draft=false
-        env:
-          GH_TOKEN: ${{ github.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Deduplicated AST safety rules into single template
 - Wired `defaults.cjs` into config, core, init, verify, workspace modules
 - Removed stale Windows references and guards
-- `prepare-release.yml` workflow now creates a release branch + tag and opens an auto-merging PR into the target branch, instead of pushing the release commit and tag directly. Direct push was blocked by the `pull_request` rule on `develop`/`main` rulesets on user-owned forks (where the `github-actions` integration can't be added as a bypass actor). Downstream `release.yml` and `publish.yml` still fire on the tag push, independent of the PR's merge state.
+- `prepare-release.yml` workflow now creates a release branch + tag and opens an auto-merging PR into the target branch, instead of pushing the release commit and tag directly. Direct push was blocked by the `pull_request` rule on `develop`/`main` rulesets on user-owned forks (where the `github-actions` integration can't be added as a bypass actor).
+- `release.yml` and `publish.yml` now support `workflow_dispatch` with a `tag` input alongside the existing tag-push trigger. `prepare-release.yml` chains them explicitly via `gh workflow run` after the tag push — tags pushed by `GITHUB_TOKEN` don't trigger downstream workflows (anti-loop protection), so an explicit dispatch is required to keep the end-to-end release pipeline automated.
 
 ### Removed
 - `install.js --config-dir` / `-c` CLI flag — custom config directories are still supported via the `CLAUDE_CONFIG_DIR` / `COPILOT_CONFIG_DIR` environment variables. Users with `--config-dir` in install scripts must switch to the env-var form.


### PR DESCRIPTION
## Summary

Close the automation gap in the release pipeline. Tags pushed by `GITHUB_TOKEN` don't trigger downstream workflows (GitHub's anti-loop protection), so the `v$VERSION` tag pushed by `prepare-release.yml` was getting created but `release.yml` and `publish.yml` weren't firing for it. End-to-end the pipeline was 50% automated.

After this PR, running `prepare-release` once does everything: version bump, tag, release branch, PR, GitHub Release draft → publish, npm publish.

## What changed

**`release.yml` + `publish.yml`** — add `workflow_dispatch` with a `tag: string` input alongside the existing tag-push trigger. Each workflow gains a resolve step that picks the tag from either the dispatch input or the push ref, validates its format, and exposes it as a step output. All downstream steps that previously parsed `GITHUB_REF` now read the resolved tag. The `checkout` step uses the resolved tag as its ref so manual dispatches operate on the tagged commit (not the branch tip). `release.yml`'s `softprops/action-gh-release` step gets an explicit `tag_name` parameter so it doesn't depend on `GITHUB_REF` either.

**`prepare-release.yml`** — adds an explicit chain step after the tag push:

```sh
gh workflow run release.yml --ref "v$VERSION" -f tag="v$VERSION"
gh workflow run publish.yml --ref "v$VERSION" -f tag="v$VERSION"
```

This fires both workflows against the tag we just created. The `--ref` flag uses the tag itself, which means each workflow runs from the version of the file present at the tag — desirable for release determinism.

## Why dispatch instead of fixing the token

A PAT with admin scope could be used for the tag push (`secrets.RELEASE_PAT`), bypassing the loop protection. But that adds a credential the user has to maintain. The explicit dispatch keeps everything within the default `GITHUB_TOKEN` permissions and is self-documenting.

## Test plan

- [x] `npm test` — green (3177/3177)
- [x] YAML syntax verified locally
- [ ] After merge: run `prepare-release` for an unused version and confirm the full chain fires (release branch push, tag push, release.yml run, publish.yml run, PR opened + auto-merge, GitHub Release published, npm package published)

## Notes

- The `release.yml` and `publish.yml` push triggers are kept intact for the manual / admin-local-push case
- v1.0.0-dev.4 was already tagged before this PR but its downstream workflows never fired. After this PR merges to main, the same `prepare-release` workflow can re-dispatch them for that tag, or v1.0.0-dev.5 will exercise the full chain naturally
