### PR TITLE
docs(changelog): seed [Unreleased] for v1.0.0-dev.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Release pipeline end-to-end automation — `1.0.0-dev.4` was tagged + drafted as a GitHub Release but never landed on npm because the `publish.yml` workflow didn't fire (tags pushed by `GITHUB_TOKEN` don't trigger downstream workflows, and the workflow at that tag predated the explicit `workflow_dispatch` chain). This release is the first that exercises the full chain — `prepare-release` → tag push → release branch PR auto-merge → explicit dispatch of `release.yml` + `publish.yml` → GitHub Release published + npm package published — without manual intervention.
+
 ## [1.0.0-dev.4] - 2026-05-10
 
 ### Added


### PR DESCRIPTION
Adds a single [Unreleased] entry noting the v1.0.0-dev.4 → v1.0.0-dev.5 distinction (dev.4 was tagged but never published to npm; dev.5 is the first full-chain release). Required by `prepare-release.yml`'s validate step which fails on empty [Unreleased].