### PR TITLE
fix(ci): publish.yml uses Node 24 (npm 11+) for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Validate release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `publish.yml` uses Node 24 (npm 11) instead of Node 22 (npm 10). npm 10's CLI sends an unresolved `${NODE_AUTH_TOKEN}` placeholder as the bearer token to the npm registry and never falls back to OIDC trusted publishing, producing a misleading `404 Not Found` error.
+
 ## [1.0.0-dev.6] - 2026-05-12
 
 ### Changed


### PR DESCRIPTION
## Summary
Bumps `publish.yml` `node-version` from `22` to `24`. Node 24 ships with npm 11, which handles OIDC trusted publishing correctly. Node 22's npm 10.9.7 substitutes an unresolved `\${NODE_AUTH_TOKEN}` placeholder as the registry bearer token and never falls back to OIDC, producing a misleading `404 Not Found`.

## Diagnosis trail
- dev.4 and dev.6 first attempts failed with `npm error 404 Not Found - PUT https://registry.npmjs.org/gsd-ng`.
- npm hides auth errors as 404; underlying cause was npm sending a literal `XXXXX-XXXXX-XXXXX-XXXXX` string as the bearer token.
- setup-node's `registry-url` writes `~/.npmrc` containing `//registry.npmjs.org/:_authToken=\${NODE_AUTH_TOKEN}`. With `NODE_AUTH_TOKEN` set to GitHub's mask placeholder, npm 10 substituted that garbage and sent it.
- npm 11 (bundled in Node 24) handles this case correctly — OIDC trusted publishing engages.
- dev.3 worked because that workflow included `npm install -g npm@latest`, which upgraded to npm 11. That step was removed in PR #25.

## Test plan
- [x] **Verified end-to-end**: `gsd-ng@1.0.0-dev.6` published to npm via this fix (run 25760532675 on `debug/npm-oidc-claims`).
- [x] `dist-tags.dev` now points to `1.0.0-dev.6`.
- [ ] After merge, next release (dev.7) via `prepare-release.yml` should complete end-to-end without manual re-dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)