### PR TITLE
fix: replace shared config.runtime field with per-engine runtime detection

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1176,43 +1176,6 @@ function stripGsdFromCopilotInstructions(content) {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
-/**
- * Write the runtime field to .planning/config.json so effort-gating
- * can determine whether effort: frontmatter should be injected.
- * Creates .planning/ and config.json if they don't exist.
- * Preserves existing config values — only sets/updates "runtime".
- */
-function writeRuntimeToConfig(rt) {
-  const configDir = path.join(process.cwd(), '.planning');
-  const configPath = path.join(configDir, 'config.json');
-
-  // Ensure .planning directory exists
-  try {
-    fs.mkdirSync(configDir, { recursive: true });
-  } catch {}
-
-  let config = {};
-  try {
-    if (fs.existsSync(configPath)) {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
-    }
-  } catch {
-    // If config.json is corrupt, start fresh
-    config = {};
-  }
-
-  config.runtime = rt;
-
-  try {
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
-  } catch {
-    // If .planning is gitignored or read-only, silently skip
-    // runtime will default to claude behavior in loadConfig
-  }
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
-
 function install(isGlobal) {
   const isClaudeCode = runtime === 'claude';
   const dirName = getDirName(runtime);
@@ -1708,8 +1671,12 @@ function install(isGlobal) {
       }
     }
 
-    // Persist runtime to .planning/config.json for effort-gating
-    writeRuntimeToConfig(runtime);
+    // Write the per-engine .runtime marker so the deployed engine detects its
+    // own runtime without consulting the shared .planning/config.json.
+    const runtimeMarkerDest = path.join(targetDir, 'gsd-ng', '.runtime');
+    fs.mkdirSync(path.dirname(runtimeMarkerDest), { recursive: true });
+    fs.writeFileSync(runtimeMarkerDest, runtime + '\n');
+    console.log(`  ${green}✓${reset} Wrote .runtime marker (${runtime})`);
 
     return { settingsPath, settings, statuslineCommand };
 
@@ -1846,8 +1813,12 @@ function install(isGlobal) {
     writeManifest(targetDir, INSTALLED_VERSION);
     console.log(`  ${green}✓${reset} Wrote file manifest (${MANIFEST_NAME})`);
 
-    // Persist runtime to .planning/config.json for effort-gating
-    writeRuntimeToConfig(runtime);
+    // Write the per-engine .runtime marker so the deployed engine detects its
+    // own runtime without consulting the shared .planning/config.json.
+    const runtimeMarkerDest = path.join(targetDir, 'gsd-ng', '.runtime');
+    fs.mkdirSync(path.dirname(runtimeMarkerDest), { recursive: true });
+    fs.writeFileSync(runtimeMarkerDest, runtime + '\n');
+    console.log(`  ${green}✓${reset} Wrote .runtime marker (${runtime})`);
 
     return { settingsPath: null, settings: null, statuslineCommand: null, runtime };
   }

--- a/bin/install.js
+++ b/bin/install.js
@@ -1176,6 +1176,13 @@ function stripGsdFromCopilotInstructions(content) {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+function writeRuntimeMarker(targetDir, runtime) {
+  const dest = path.join(targetDir, 'gsd-ng', '.runtime');
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.writeFileSync(dest, runtime + '\n');
+  console.log(`  ${green}✓${reset} Wrote .runtime marker (${runtime})`);
+}
+
 function install(isGlobal) {
   const isClaudeCode = runtime === 'claude';
   const dirName = getDirName(runtime);
@@ -1671,12 +1678,7 @@ function install(isGlobal) {
       }
     }
 
-    // Write the per-engine .runtime marker so the deployed engine detects its
-    // own runtime without consulting the shared .planning/config.json.
-    const runtimeMarkerDest = path.join(targetDir, 'gsd-ng', '.runtime');
-    fs.mkdirSync(path.dirname(runtimeMarkerDest), { recursive: true });
-    fs.writeFileSync(runtimeMarkerDest, runtime + '\n');
-    console.log(`  ${green}✓${reset} Wrote .runtime marker (${runtime})`);
+    writeRuntimeMarker(targetDir, runtime);
 
     return { settingsPath, settings, statuslineCommand };
 
@@ -1813,12 +1815,7 @@ function install(isGlobal) {
     writeManifest(targetDir, INSTALLED_VERSION);
     console.log(`  ${green}✓${reset} Wrote file manifest (${MANIFEST_NAME})`);
 
-    // Write the per-engine .runtime marker so the deployed engine detects its
-    // own runtime without consulting the shared .planning/config.json.
-    const runtimeMarkerDest = path.join(targetDir, 'gsd-ng', '.runtime');
-    fs.mkdirSync(path.dirname(runtimeMarkerDest), { recursive: true });
-    fs.writeFileSync(runtimeMarkerDest, runtime + '\n');
-    console.log(`  ${green}✓${reset} Wrote .runtime marker (${runtime})`);
+    writeRuntimeMarker(targetDir, runtime);
 
     return { settingsPath: null, settings: null, statuslineCommand: null, runtime };
   }

--- a/commands/gsd/seed-memories.md
+++ b/commands/gsd/seed-memories.md
@@ -33,7 +33,6 @@ This skill is re-runnable; runtime topology may have changed since install. All 
 <!-- ONLY:copilot -->
    - If `{{PROJECT_RULES_FILE}}` exists at workspace root → runtime is Copilot.
 <!-- /ONLY:copilot -->
-   - If both exist, prefer the runtime that owns the active session (consult `.planning/config.json` `runtime:` field).
 
    Per detected runtime, use the correct paths:
 

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -4,7 +4,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error, planningPaths, loadConfig, getEngineRuntime } = require('./core.cjs');
+const {
+  output,
+  error,
+  planningPaths,
+  loadConfig,
+  getEngineRuntime,
+} = require('./core.cjs');
 const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 const {
   VALID_PROFILES,

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error, planningPaths, loadConfig } = require('./core.cjs');
+const { output, error, planningPaths, loadConfig, getEngineRuntime } = require('./core.cjs');
 const { DEFAULTS, WORKFLOW_DEFAULTS } = require('./defaults.cjs');
 const {
   VALID_PROFILES,
@@ -311,12 +311,11 @@ function cmdConfigGet(cwd, keyPath, defaultValue) {
   }
 
   // Claude-only surface lock: profile/effort keys are Claude-only.
-  // When runtime === 'copilot', treat these keys as not-present so callers
+  // When running as copilot, treat these keys as not-present so callers
   // get the same not-found / defaultValue behaviour they would on a config
   // that simply doesn't define them.
   if (PROFILE_EFFORT_KEY_PATTERN.test(keyPath)) {
-    const cfg = loadConfig(cwd) || {};
-    const isClaudeCode = (cfg.runtime || 'claude') === 'claude';
+    const isClaudeCode = getEngineRuntime() === 'claude';
     if (isClaudeCode) {
       // fall through to the existing lookup below
     } else {

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -316,22 +316,17 @@ function cmdConfigGet(cwd, keyPath, defaultValue) {
     );
   }
 
-  // Claude-only surface lock: profile/effort keys are Claude-only.
-  // When running as copilot, treat these keys as not-present so callers
-  // get the same not-found / defaultValue behaviour they would on a config
-  // that simply doesn't define them.
-  if (PROFILE_EFFORT_KEY_PATTERN.test(keyPath)) {
-    const isClaudeCode = getEngineRuntime() === 'claude';
-    if (isClaudeCode) {
-      // fall through to the existing lookup below
-    } else {
-      if (defaultValue !== undefined) {
-        output(defaultValue, String(defaultValue));
-        return;
-      }
-      error(`Key not found: ${keyPath}`);
+  // Claude-only surface lock: profile/effort keys read as not-present on non-Claude runtimes.
+  if (
+    PROFILE_EFFORT_KEY_PATTERN.test(keyPath) &&
+    getEngineRuntime() !== 'claude'
+  ) {
+    if (defaultValue !== undefined) {
+      output(defaultValue, String(defaultValue));
       return;
     }
+    error(`Key not found: ${keyPath}`);
+    return;
   }
 
   let config = {};

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -300,10 +300,11 @@ function getEngineRuntime() {
   // Test seam: GSD_TEST_RUNTIME_MARKER_DIR points at a fixture dir holding a .runtime marker.
   // Mirrors the existing GSD_TEST_* env-hook pattern (install.js GSD_TEST_FORCE_PLATFORM).
   const markerDir =
-    process.env.GSD_TEST_RUNTIME_MARKER_DIR ||
-    path.join(__dirname, '..', '..');
+    process.env.GSD_TEST_RUNTIME_MARKER_DIR || path.join(__dirname, '..', '..');
   try {
-    const val = fs.readFileSync(path.join(markerDir, '.runtime'), 'utf-8').trim();
+    const val = fs
+      .readFileSync(path.join(markerDir, '.runtime'), 'utf-8')
+      .trim();
     return val === 'copilot' ? 'copilot' : 'claude';
   } catch {
     return 'claude'; // marker absent (old install, source repo, test fixture) → claude

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -290,10 +290,23 @@ function loadConfig(cwd) {
       parallelization,
       model_overrides: parsed.model_overrides || null,
       effort_overrides: parsed.effort_overrides || null,
-      runtime: parsed.runtime || null,
     };
   } catch {
     return defaults;
+  }
+}
+
+function getEngineRuntime() {
+  // Test seam: GSD_TEST_RUNTIME_MARKER_DIR points at a fixture dir holding a .runtime marker.
+  // Mirrors the existing GSD_TEST_* env-hook pattern (install.js GSD_TEST_FORCE_PLATFORM).
+  const markerDir =
+    process.env.GSD_TEST_RUNTIME_MARKER_DIR ||
+    path.join(__dirname, '..', '..');
+  try {
+    const val = fs.readFileSync(path.join(markerDir, '.runtime'), 'utf-8').trim();
+    return val === 'copilot' ? 'copilot' : 'claude';
+  } catch {
+    return 'claude'; // marker absent (old install, source repo, test fixture) → claude
   }
 }
 
@@ -626,8 +639,7 @@ function resolveEffortInternal(cwd, agentType) {
   const config = loadConfig(cwd);
 
   // Non-Claude runtimes do not support effort: frontmatter — skip silently.
-  // When runtime is null/undefined, default to claude behavior (backward compat).
-  if (config.runtime && config.runtime !== 'claude') {
+  if (getEngineRuntime() !== 'claude') {
     return null;
   }
 
@@ -861,6 +873,7 @@ module.exports = {
   reapStaleTempFiles,
   safeReadFile,
   loadConfig,
+  getEngineRuntime,
   isGitIgnored,
   execGit,
   escapeRegex,

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -297,8 +297,7 @@ function loadConfig(cwd) {
 }
 
 function getEngineRuntime() {
-  // Test seam: GSD_TEST_RUNTIME_MARKER_DIR points at a fixture dir holding a .runtime marker.
-  // Mirrors the existing GSD_TEST_* env-hook pattern (install.js GSD_TEST_FORCE_PLATFORM).
+  // GSD_TEST_RUNTIME_MARKER_DIR: test-only override of the marker location.
   const markerDir =
     process.env.GSD_TEST_RUNTIME_MARKER_DIR || path.join(__dirname, '..', '..');
   try {
@@ -307,7 +306,7 @@ function getEngineRuntime() {
       .trim();
     return val === 'copilot' ? 'copilot' : 'claude';
   } catch {
-    return 'claude'; // marker absent (old install, source repo, test fixture) → claude
+    return 'claude'; // marker absent → default to claude
   }
 }
 

--- a/gsd-ng/bin/lib/effort-sync.cjs
+++ b/gsd-ng/bin/lib/effort-sync.cjs
@@ -16,7 +16,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { loadConfig, resolveEffortInternal } = require('./core.cjs');
+const { resolveEffortInternal, getEngineRuntime } = require('./core.cjs');
 const { EFFORT_PROFILES } = require('./model-profiles.cjs');
 const { extractFrontmatter, spliceFrontmatter } = require('./frontmatter.cjs');
 
@@ -30,8 +30,7 @@ const RESTART_NOTICE = 'Restart Claude Code to apply effort changes.';
  * @returns {{ changes: Array<{agent: string, effort: string|null}>, skipped?: boolean }}
  */
 function syncAgentEffortFrontmatter(cwd, agentsDir) {
-  const config = loadConfig(cwd) || {};
-  if (config.runtime && config.runtime !== 'claude') {
+  if (getEngineRuntime() !== 'claude') {
     return { skipped: true, changes: [] };
   }
 

--- a/gsd-ng/references/claude-model-profiles.md
+++ b/gsd-ng/references/claude-model-profiles.md
@@ -135,7 +135,7 @@ Effort profiles control the `effort:` frontmatter injected into agent spawn call
 ### Effort Resolution Order
 
 ```
-1. If runtime != 'claude', return null (effort unsupported)
+1. If engine runtime != 'claude', return null (effort unsupported)
 2. Check effort_overrides[agent] in .planning/config.json
 3. If no override, look up agent in EFFORT_PROFILES[agent][profile]
 4. If value is 'inherit', return null (omit effort parameter)
@@ -147,7 +147,7 @@ Effort profiles control the `effort:` frontmatter injected into agent spawn call
 
 ### Runtime Gating
 
-Effort is only injected when `runtime` in `.planning/config.json` is `"claude"`. Copilot installs always receive null from `resolveEffortInternal` regardless of profile or overrides. The `runtime` field is written by `install.js` at install time.
+The engine reads a `.runtime` marker file at `<config-dir>/gsd-ng/.runtime` (sibling of `VERSION`) to detect which runtime it belongs to. `install.js` writes this file into the deployed engine tree at install time — Claude installs write `claude`, Copilot installs write `copilot`. The file is read via `path.join(__dirname, '..', '..', '.runtime')` from `core.cjs`, making it immune to custom global config dirs. When the marker is absent (old install, source repo, test fixture), the engine defaults to Claude behavior. Copilot installs always receive null from `resolveEffortInternal` regardless of profile or overrides.
 
 ### Per-Agent Effort Overrides
 

--- a/gsd-ng/references/claude-model-profiles.md
+++ b/gsd-ng/references/claude-model-profiles.md
@@ -147,7 +147,7 @@ Effort profiles control the `effort:` frontmatter injected into agent spawn call
 
 ### Runtime Gating
 
-The engine reads a `.runtime` marker file at `<config-dir>/gsd-ng/.runtime` (sibling of `VERSION`) to detect which runtime it belongs to. `install.js` writes this file into the deployed engine tree at install time — Claude installs write `claude`, Copilot installs write `copilot`. The file is read via `path.join(__dirname, '..', '..', '.runtime')` from `core.cjs`, making it immune to custom global config dirs. When the marker is absent (old install, source repo, test fixture), the engine defaults to Claude behavior. Copilot installs always receive null from `resolveEffortInternal` regardless of profile or overrides.
+Effort is Claude-only. The engine detects its runtime from a `.runtime` marker file that `install.js` writes into the deployed engine tree (`<config-dir>/gsd-ng/.runtime`, sibling of `VERSION`). When the marker is absent, the engine defaults to Claude. On Copilot installs, `resolveEffortInternal` always returns null regardless of profile or overrides.
 
 ### Per-Agent Effort Overrides
 

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -814,8 +814,21 @@ describe('set-profile effort display and effort_overrides config-set (EFF-04, EF
 
 describe('Phase 55 — effort sync wiring', () => {
   let tmpDir;
+  let copilotMarkerDir;
   const { createTempProjectWithAgents } = require('./helpers.cjs');
-  afterEach(() => { if (tmpDir) cleanup(tmpDir); });
+  afterEach(() => {
+    if (tmpDir) cleanup(tmpDir);
+    if (copilotMarkerDir) {
+      try { cleanup(copilotMarkerDir); } catch {}
+      copilotMarkerDir = undefined;
+    }
+  });
+
+  function makeCopilotMarkerDir() {
+    const dir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-copilot-marker-'));
+    fs.writeFileSync(path.join(dir, '.runtime'), 'copilot\n', 'utf-8');
+    return dir;
+  }
 
   test('EFFSYNC-CONFIG-01: config-set-model-profile quality syncs agents and prints restart notice on stderr', () => {
     tmpDir = createTempProjectWithAgents(['gsd-planner', 'gsd-executor'], {
@@ -861,12 +874,14 @@ describe('Phase 55 — effort sync wiring', () => {
   });
 
   test('EFFSYNC-CONFIG-04: config-get model_profile is gated to defaultValue on Copilot runtime', () => {
+    copilotMarkerDir = makeCopilotMarkerDir();
     tmpDir = createTempProjectWithAgents(['gsd-planner'], {
       // hand-edited copilot config that includes profile keys (the strip must hide them)
-      config: { runtime: 'copilot', model_profile: 'quality', effort_overrides: { 'gsd-executor': 'high' } },
+      config: { model_profile: 'quality', effort_overrides: { 'gsd-executor': 'high' } },
     });
+    const env = { GSD_TEST_RUNTIME_MARKER_DIR: copilotMarkerDir };
     // With --default flag, Copilot consumer gets the default (key treated as not-present)
-    const withDefault = runGsdTools(['config-get', 'model_profile', '--default', 'balanced'], tmpDir);
+    const withDefault = runGsdTools(['config-get', 'model_profile', '--default', 'balanced'], tmpDir, env);
     assert.ok(withDefault.success, `expected success with --default, got: ${withDefault.error}`);
     assert.match(
       withDefault.output.trim(),
@@ -874,7 +889,7 @@ describe('Phase 55 — effort sync wiring', () => {
       `expected default 'balanced', got: ${withDefault.output}`
     );
     // Without --default, Copilot consumer gets a Key not found error
-    const noDefault = runGsdTools(['config-get', 'model_profile'], tmpDir);
+    const noDefault = runGsdTools(['config-get', 'model_profile'], tmpDir, env);
     assert.ok(!noDefault.success, `expected failure without --default, but command succeeded`);
     assert.ok(
       (noDefault.stderr || noDefault.error || '').includes('Key not found'),
@@ -892,10 +907,11 @@ describe('Phase 55 — effort sync wiring', () => {
   });
 
   test('EFFSYNC-CONFIG-06: config-get effort_overrides.gsd-executor is gated on Copilot runtime', () => {
+    copilotMarkerDir = makeCopilotMarkerDir();
     tmpDir = createTempProjectWithAgents(['gsd-planner'], {
-      config: { runtime: 'copilot', effort_overrides: { 'gsd-executor': 'high' } },
+      config: { effort_overrides: { 'gsd-executor': 'high' } },
     });
-    const result = runGsdTools(['config-get', 'effort_overrides.gsd-executor'], tmpDir);
+    const result = runGsdTools(['config-get', 'effort_overrides.gsd-executor'], tmpDir, { GSD_TEST_RUNTIME_MARKER_DIR: copilotMarkerDir });
     assert.ok(!result.success, `expected failure on copilot, but command succeeded with output: ${result.output}`);
     assert.ok(
       (result.stderr || result.error || '').includes('Key not found'),
@@ -1324,30 +1340,38 @@ describe('cmdConfigGet defaultValue and traversal branches', () => {
 describe('cmdConfigGet copilot runtime profile/effort gating', () => {
   test('strips effort_overrides.* keys with --default on copilot runtime', () => {
     const tmpDir = createTempProject();
+    const markerDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-copilot-marker-'));
+    fs.writeFileSync(path.join(markerDir, '.runtime'), 'copilot\n', 'utf-8');
     writeConfig(tmpDir, {
-      runtime: 'copilot',
       effort_overrides: { 'gsd-executor': 'high' },
     });
     try {
       const result = runGsdTools(
         ['config-get', 'effort_overrides.gsd-executor', '--default', 'medium'],
         tmpDir,
+        { GSD_TEST_RUNTIME_MARKER_DIR: markerDir },
       );
       assert.ok(result.success, `Command failed: ${result.error}`);
       assert.strictEqual(result.output.trim(), 'medium');
     } finally {
       cleanup(tmpDir);
+      cleanup(markerDir);
     }
   });
 
   test('strips model_overrides.* keys (errors without default) on copilot runtime', () => {
     const tmpDir = createTempProject();
+    const markerDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-copilot-marker-'));
+    fs.writeFileSync(path.join(markerDir, '.runtime'), 'copilot\n', 'utf-8');
     writeConfig(tmpDir, {
-      runtime: 'copilot',
       model_overrides: { 'gsd-executor': 'opus' },
     });
     try {
-      const result = runGsdTools(['config-get', 'model_overrides.gsd-executor'], tmpDir);
+      const result = runGsdTools(
+        ['config-get', 'model_overrides.gsd-executor'],
+        tmpDir,
+        { GSD_TEST_RUNTIME_MARKER_DIR: markerDir },
+      );
       assert.strictEqual(result.success, false);
       assert.match(
         result.stderr,
@@ -1356,6 +1380,7 @@ describe('cmdConfigGet copilot runtime profile/effort gating', () => {
       );
     } finally {
       cleanup(tmpDir);
+      cleanup(markerDir);
     }
   });
 });

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -1247,6 +1247,7 @@ describe('resolveEffortInternal', () => {
   });
 
   afterEach(() => {
+    delete process.env.GSD_TEST_RUNTIME_MARKER_DIR;
     cleanup(tmpDir);
   });
 
@@ -1255,6 +1256,11 @@ describe('resolveEffortInternal', () => {
       path.join(tmpDir, '.planning', 'config.json'),
       JSON.stringify(obj, null, 2),
     );
+  }
+
+  function writeRuntimeMarker(dir, value) {
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.runtime'), value + '\n', 'utf-8');
   }
 
   test('Test 1: returns max for gsd-planner when model_profile=quality and no overrides', () => {
@@ -1293,19 +1299,28 @@ describe('resolveEffortInternal', () => {
     assert.strictEqual(result, null);
   });
 
-  test('Test 6: returns null when config.runtime is copilot (non-Claude runtime suppression)', () => {
-    writeConfig({ model_profile: 'quality', runtime: 'copilot' });
+  test('Test 6: returns null when .runtime marker is copilot (non-Claude runtime suppression)', () => {
+    const markerDir = path.join(tmpDir, 'marker-copilot');
+    writeRuntimeMarker(markerDir, 'copilot');
+    process.env.GSD_TEST_RUNTIME_MARKER_DIR = markerDir;
+    writeConfig({ model_profile: 'quality' });
     const result = resolveEffortInternal(tmpDir, 'gsd-planner');
     assert.strictEqual(result, null);
   });
 
-  test('Test 7: returns normal value when config.runtime is claude', () => {
-    writeConfig({ model_profile: 'quality', runtime: 'claude' });
+  test('Test 7: returns normal value when .runtime marker is claude', () => {
+    const markerDir = path.join(tmpDir, 'marker-claude');
+    writeRuntimeMarker(markerDir, 'claude');
+    process.env.GSD_TEST_RUNTIME_MARKER_DIR = markerDir;
+    writeConfig({ model_profile: 'quality' });
     const result = resolveEffortInternal(tmpDir, 'gsd-planner');
     assert.strictEqual(result, 'max');
   });
 
-  test('Test 8: returns normal value when config.runtime is undefined (backward compat)', () => {
+  test('Test 8: returns normal value when .runtime marker is absent (backward compat, defaults to claude)', () => {
+    const markerDir = path.join(tmpDir, 'marker-absent');
+    fs.mkdirSync(markerDir, { recursive: true });
+    process.env.GSD_TEST_RUNTIME_MARKER_DIR = markerDir;
     writeConfig({ model_profile: 'quality' });
     const result = resolveEffortInternal(tmpDir, 'gsd-planner');
     assert.strictEqual(result, 'max');

--- a/tests/effort-sync.test.cjs
+++ b/tests/effort-sync.test.cjs
@@ -6,7 +6,7 @@ const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert');
 const fs = require('fs');
 const path = require('path');
-const { createTempProjectWithAgents, cleanup } = require('./helpers.cjs');
+const { createTempProjectWithAgents, cleanup, resolveTmpDir } = require('./helpers.cjs');
 const { extractFrontmatter } = require('../gsd-ng/bin/lib/frontmatter.cjs');
 const { syncAgentEffortFrontmatter, formatRestartNotice } = require('../gsd-ng/bin/lib/effort-sync.cjs');
 
@@ -17,11 +17,14 @@ function readEffort(agentFile) {
 
 describe('syncAgentEffortFrontmatter', () => {
   let tmpDir;
-  afterEach(() => { if (tmpDir) cleanup(tmpDir); });
+  afterEach(() => {
+    delete process.env.GSD_TEST_RUNTIME_MARKER_DIR;
+    if (tmpDir) cleanup(tmpDir);
+  });
 
   test('writes effort: frontmatter from quality profile', () => {
     tmpDir = createTempProjectWithAgents(['gsd-planner', 'gsd-executor'], {
-      config: { runtime: 'claude', model_profile: 'quality' },
+      config: { model_profile: 'quality' },
     });
     const agentsDir = path.join(tmpDir, '.claude', 'agents');
     const result = syncAgentEffortFrontmatter(tmpDir, agentsDir);
@@ -33,7 +36,7 @@ describe('syncAgentEffortFrontmatter', () => {
 
   test('removes effort: field when resolver returns null (balanced → inherit)', () => {
     tmpDir = createTempProjectWithAgents(['gsd-planner'], {
-      config: { runtime: 'claude', model_profile: 'balanced' },
+      config: { model_profile: 'balanced' },
     });
     const agentsDir = path.join(tmpDir, '.claude', 'agents');
     // Seed an existing effort: field that must be removed
@@ -47,7 +50,7 @@ describe('syncAgentEffortFrontmatter', () => {
 
   test('is idempotent — second call reports no changes', () => {
     tmpDir = createTempProjectWithAgents(['gsd-planner', 'gsd-executor'], {
-      config: { runtime: 'claude', model_profile: 'quality' },
+      config: { model_profile: 'quality' },
     });
     const agentsDir = path.join(tmpDir, '.claude', 'agents');
     syncAgentEffortFrontmatter(tmpDir, agentsDir);
@@ -56,14 +59,18 @@ describe('syncAgentEffortFrontmatter', () => {
   });
 
   test('skips non-claude runtime and returns skipped: true', () => {
+    const markerDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-effort-sync-marker-'));
+    fs.writeFileSync(path.join(markerDir, '.runtime'), 'copilot\n', 'utf-8');
+    process.env.GSD_TEST_RUNTIME_MARKER_DIR = markerDir;
     tmpDir = createTempProjectWithAgents(['gsd-planner'], {
-      config: { runtime: 'copilot', model_profile: 'quality' },
+      config: { model_profile: 'quality' },
     });
     const agentsDir = path.join(tmpDir, '.claude', 'agents');
     const result = syncAgentEffortFrontmatter(tmpDir, agentsDir);
     assert.strictEqual(result.skipped, true);
     assert.strictEqual(result.changes.length, 0);
     assert.strictEqual(readEffort(path.join(agentsDir, 'gsd-planner.md')), null);
+    cleanup(markerDir);
   });
 });
 

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -11,6 +11,7 @@ const {
   createTempProject,
   cleanup,
   cleanupSubdir,
+  resolveTmpDir,
 } = require('./helpers.cjs');
 
 describe('init commands', () => {
@@ -372,26 +373,34 @@ describe('Effort fields in init commands', () => {
     assert.ok('verifier_effort' in output, 'verifier_effort should be present');
   });
 
-  test('Test 8: effort fields are null when config.json has runtime=copilot', () => {
+  test('Test 8: effort fields are null when .runtime marker is copilot', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
     fs.mkdirSync(phaseDir, { recursive: true });
     fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '# Plan');
-    writeCopilotConfig(tmpDir);
+    // Write config with quality profile; runtime detection comes from the .runtime marker
+    const configPath = path.join(tmpDir, '.planning', 'config.json');
+    fs.writeFileSync(configPath, JSON.stringify({ model_profile: 'quality' }, null, 2), 'utf-8');
 
-    const result = runGsdTools('init execute-phase 03 --json', tmpDir);
-    assert.ok(result.success, `Command failed: ${result.error}`);
+    const markerDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-copilot-marker-'));
+    fs.writeFileSync(path.join(markerDir, '.runtime'), 'copilot\n', 'utf-8');
+    try {
+      const result = runGsdTools('init execute-phase 03 --json', tmpDir, { GSD_TEST_RUNTIME_MARKER_DIR: markerDir });
+      assert.ok(result.success, `Command failed: ${result.error}`);
 
-    const output = JSON.parse(result.output);
-    assert.strictEqual(
-      output.executor_effort,
-      null,
-      'executor_effort should be null for copilot runtime',
-    );
-    assert.strictEqual(
-      output.verifier_effort,
-      null,
-      'verifier_effort should be null for copilot runtime',
-    );
+      const output = JSON.parse(result.output);
+      assert.strictEqual(
+        output.executor_effort,
+        null,
+        'executor_effort should be null for copilot runtime',
+      );
+      assert.strictEqual(
+        output.verifier_effort,
+        null,
+        'verifier_effort should be null for copilot runtime',
+      );
+    } finally {
+      cleanup(markerDir);
+    }
   });
 
   function writeClaudeHaikuExecutorConfig(dir) {

--- a/tests/install-js.test.cjs
+++ b/tests/install-js.test.cjs
@@ -1847,9 +1847,9 @@ test('SVN-03: --runtime claude --local writes manifest.version equal to VERSION 
   }
 });
 
-// ── install.js writes runtime field to .planning/config.json ─────
+// ── install.js writes .runtime marker into the deployed engine tree ──
 
-test('RUNTIME-01: install.js --runtime claude writes "runtime":"claude" to .planning/config.json', () => {
+test('RUNTIME-01: install.js --runtime claude writes .runtime marker containing "claude" into .claude/gsd-ng/', () => {
   const tmpDir = fs.mkdtempSync(
     path.join(BASE_TMPDIR, 'gsd-js-runtime-claude-'),
   );
@@ -1872,24 +1872,24 @@ test('RUNTIME-01: install.js --runtime claude writes "runtime":"claude" to .plan
         (result.stderr || ''),
     );
 
-    const configPath = path.join(tmpDir, '.planning', 'config.json');
+    const markerPath = path.join(tmpDir, '.claude', 'gsd-ng', '.runtime');
     assert.ok(
-      fs.existsSync(configPath),
-      '.planning/config.json must exist after install (RUNTIME-01)',
+      fs.existsSync(markerPath),
+      '.claude/gsd-ng/.runtime must exist after claude install (RUNTIME-01)',
     );
 
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const markerContent = fs.readFileSync(markerPath, 'utf8').trim();
     assert.strictEqual(
-      config.runtime,
+      markerContent,
       'claude',
-      'config.json must contain "runtime":"claude" after claude install (RUNTIME-01)',
+      '.runtime marker must contain "claude" after claude install (RUNTIME-01)',
     );
   } finally {
     cleanup(tmpDir);
   }
 });
 
-test('RUNTIME-02: install.js --runtime copilot writes "runtime":"copilot" to .planning/config.json', () => {
+test('RUNTIME-02: install.js --runtime copilot writes .runtime marker containing "copilot" into .github/gsd-ng/', () => {
   const tmpDir = fs.mkdtempSync(
     path.join(BASE_TMPDIR, 'gsd-js-runtime-copilot-'),
   );
@@ -1912,17 +1912,17 @@ test('RUNTIME-02: install.js --runtime copilot writes "runtime":"copilot" to .pl
         (result.stderr || ''),
     );
 
-    const configPath = path.join(tmpDir, '.planning', 'config.json');
+    const markerPath = path.join(tmpDir, '.github', 'gsd-ng', '.runtime');
     assert.ok(
-      fs.existsSync(configPath),
-      '.planning/config.json must exist after copilot install (RUNTIME-02)',
+      fs.existsSync(markerPath),
+      '.github/gsd-ng/.runtime must exist after copilot install (RUNTIME-02)',
     );
 
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    const markerContent = fs.readFileSync(markerPath, 'utf8').trim();
     assert.strictEqual(
-      config.runtime,
+      markerContent,
       'copilot',
-      'config.json must contain "runtime":"copilot" after copilot install (RUNTIME-02)',
+      '.runtime marker must contain "copilot" after copilot install (RUNTIME-02)',
     );
   } finally {
     cleanup(tmpDir);
@@ -2022,7 +2022,7 @@ test('ALLOW-20: install.js syncSection uses Set.has() — not Array.includes() �
   );
 });
 
-test('RUNTIME-03: install.js preserves existing config.json values when writing runtime field', () => {
+test('RUNTIME-03: install.js preserves existing config.json values and writes .runtime marker', () => {
   const tmpDir = fs.mkdtempSync(
     path.join(BASE_TMPDIR, 'gsd-js-runtime-preserve-'),
   );
@@ -2053,30 +2053,38 @@ test('RUNTIME-03: install.js preserves existing config.json values when writing 
         (result.stderr || ''),
     );
 
+    // Existing config.json values must be preserved (install does not touch them)
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, '.planning', 'config.json'), 'utf8'),
-    );
-    assert.strictEqual(
-      config.runtime,
-      'claude',
-      'runtime field must be added (RUNTIME-03)',
     );
     assert.strictEqual(
       config.model_profile,
       'quality',
       'existing model_profile must be preserved (RUNTIME-03)',
     );
+
+    // .runtime marker must be written into the engine tree
+    const markerPath = path.join(tmpDir, '.claude', 'gsd-ng', '.runtime');
+    assert.ok(
+      fs.existsSync(markerPath),
+      '.claude/gsd-ng/.runtime marker must exist (RUNTIME-03)',
+    );
+    assert.strictEqual(
+      fs.readFileSync(markerPath, 'utf8').trim(),
+      'claude',
+      '.runtime marker must contain "claude" (RUNTIME-03)',
+    );
   } finally {
     cleanup(tmpDir);
   }
 });
 
-test('RUNTIME-04: install.js updates existing runtime field in config.json', () => {
+test('RUNTIME-04: stale config.json runtime field is left inert; .runtime marker reflects actual install runtime', () => {
   const tmpDir = fs.mkdtempSync(
     path.join(BASE_TMPDIR, 'gsd-js-runtime-update-'),
   );
   try {
-    // Pre-create config.json with runtime: copilot
+    // Pre-create config.json with a stale runtime: copilot field
     fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'config.json'),
@@ -2084,7 +2092,7 @@ test('RUNTIME-04: install.js updates existing runtime field in config.json', () 
       'utf-8',
     );
 
-    // Install with claude runtime — should update to claude
+    // Install with claude runtime
     const result = spawnSync(
       process.execPath,
       [INSTALLER, '--runtime', 'claude', '--local'],
@@ -2102,17 +2110,149 @@ test('RUNTIME-04: install.js updates existing runtime field in config.json', () 
       'install.js must exit 0 (RUNTIME-04)\nstderr: ' + (result.stderr || ''),
     );
 
+    // The .runtime marker in the engine tree reflects the actual install runtime
+    const markerPath = path.join(tmpDir, '.claude', 'gsd-ng', '.runtime');
+    assert.ok(
+      fs.existsSync(markerPath),
+      '.claude/gsd-ng/.runtime marker must exist after claude install (RUNTIME-04)',
+    );
+    assert.strictEqual(
+      fs.readFileSync(markerPath, 'utf8').trim(),
+      'claude',
+      '.runtime marker must contain "claude" (RUNTIME-04)',
+    );
+
+    // The stale config.json runtime field is left untouched (no migration)
     const config = JSON.parse(
       fs.readFileSync(path.join(tmpDir, '.planning', 'config.json'), 'utf8'),
     );
     assert.strictEqual(
       config.runtime,
-      'claude',
-      'runtime must be updated from copilot to claude (RUNTIME-04)',
+      'copilot',
+      'stale config.json runtime field must be left inert — no migration (RUNTIME-04)',
     );
   } finally {
     cleanup(tmpDir);
   }
+});
+
+// ── dual-runtime install-order integration test ───────────────────
+
+function runDualRuntimeTest(firstRuntime, secondRuntime) {
+  const tmpDir = fs.mkdtempSync(
+    path.join(BASE_TMPDIR, `gsd-js-dual-${firstRuntime}-${secondRuntime}-`),
+  );
+  try {
+    const runInstall = (rt) =>
+      spawnSync(
+        process.execPath,
+        [INSTALLER, '--runtime', rt, '--local'],
+        {
+          encoding: 'utf8',
+          timeout: 15000,
+          cwd: tmpDir,
+          env: Object.assign({}, process.env, { HOME: os.homedir() }),
+        },
+      );
+
+    // Install both runtimes in order
+    const r1 = runInstall(firstRuntime);
+    assert.strictEqual(
+      r1.status,
+      0,
+      `first install (${firstRuntime}) must exit 0\nstderr: ${r1.stderr || ''}`,
+    );
+    const r2 = runInstall(secondRuntime);
+    assert.strictEqual(
+      r2.status,
+      0,
+      `second install (${secondRuntime}) must exit 0\nstderr: ${r2.stderr || ''}`,
+    );
+
+    // Both markers must exist with correct content
+    const claudeMarker = path.join(tmpDir, '.claude', 'gsd-ng', '.runtime');
+    const copilotMarker = path.join(tmpDir, '.github', 'gsd-ng', '.runtime');
+    assert.ok(fs.existsSync(claudeMarker), `.claude/gsd-ng/.runtime must exist (${firstRuntime}-then-${secondRuntime})`);
+    assert.ok(fs.existsSync(copilotMarker), `.github/gsd-ng/.runtime must exist (${firstRuntime}-then-${secondRuntime})`);
+    assert.strictEqual(fs.readFileSync(claudeMarker, 'utf8').trim(), 'claude', `.claude marker must be "claude" (${firstRuntime}-then-${secondRuntime})`);
+    assert.strictEqual(fs.readFileSync(copilotMarker, 'utf8').trim(), 'copilot', `.github marker must be "copilot" (${firstRuntime}-then-${secondRuntime})`);
+
+    // Set up a model_profile so effort sync produces a non-null result
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }, null, 2),
+      'utf-8',
+    );
+
+    // Create a gsd-planner.md agent in Claude's agents dir
+    const claudeAgentsDir = path.join(tmpDir, '.claude', 'agents');
+    fs.mkdirSync(claudeAgentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(claudeAgentsDir, 'gsd-planner.md'),
+      '---\nmodel: claude-opus-4-5\n---\n# GSD Planner\n',
+      'utf-8',
+    );
+
+    // Create a gsd-planner.md agent in Copilot's agents dir
+    const copilotAgentsDir = path.join(tmpDir, '.github', 'agents');
+    fs.mkdirSync(copilotAgentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(copilotAgentsDir, 'gsd-planner.md'),
+      '---\nmodel: claude-opus-4-5\n---\n# GSD Planner\n',
+      'utf-8',
+    );
+
+    // Invoke each deployed engine's sync-agents CLI
+    const claudeGsdTools = path.join(tmpDir, '.claude', 'gsd-ng', 'bin', 'gsd-tools.cjs');
+    const copilotGsdTools = path.join(tmpDir, '.github', 'gsd-ng', 'bin', 'gsd-tools.cjs');
+
+    const claudeSync = spawnSync(
+      process.execPath,
+      [claudeGsdTools, 'sync-agents', '--agents-dir', claudeAgentsDir],
+      { encoding: 'utf8', timeout: 10000, cwd: tmpDir },
+    );
+    const copilotSync = spawnSync(
+      process.execPath,
+      [copilotGsdTools, 'sync-agents', '--agents-dir', copilotAgentsDir],
+      { encoding: 'utf8', timeout: 10000, cwd: tmpDir },
+    );
+
+    assert.strictEqual(
+      claudeSync.status,
+      0,
+      `Claude sync-agents must exit 0 (${firstRuntime}-then-${secondRuntime})\nstderr: ${claudeSync.stderr || ''}`,
+    );
+    assert.strictEqual(
+      copilotSync.status,
+      0,
+      `Copilot sync-agents must exit 0 (${firstRuntime}-then-${secondRuntime})\nstderr: ${copilotSync.stderr || ''}`,
+    );
+
+    // Claude engine: gsd-planner.md must have effort: frontmatter (quality profile → max)
+    const claudeAgentContent = fs.readFileSync(path.join(claudeAgentsDir, 'gsd-planner.md'), 'utf-8');
+    assert.ok(
+      /^effort:\s*max$/m.test(claudeAgentContent),
+      `Claude agent must have effort: max after sync (${firstRuntime}-then-${secondRuntime})\nactual:\n${claudeAgentContent}`,
+    );
+
+    // Copilot engine: gsd-planner.md must NOT have effort: frontmatter
+    const copilotAgentContent = fs.readFileSync(path.join(copilotAgentsDir, 'gsd-planner.md'), 'utf-8');
+    assert.ok(
+      !/^effort:/m.test(copilotAgentContent),
+      `Copilot agent must NOT have effort: after sync (${firstRuntime}-then-${secondRuntime})\nactual:\n${copilotAgentContent}`,
+    );
+  } finally {
+    cleanup(tmpDir);
+  }
+}
+
+test('RUNTIME-DUAL-A: claude-then-copilot install — Claude agents get effort:, Copilot agents do not, regardless of install order', () => {
+  runDualRuntimeTest('claude', 'copilot');
+});
+
+test('RUNTIME-DUAL-B: copilot-then-claude install — Claude agents get effort:, Copilot agents do not, regardless of install order', () => {
+  runDualRuntimeTest('copilot', 'claude');
 });
 
 // ── double-install is idempotent — no phantom local modifications ──


### PR DESCRIPTION
## Problem

`.planning/config.json` stored a scalar `config.runtime`, written by `writeRuntimeToConfig()` in **both** the Claude and Copilot install branches of `install.js`. But `.planning/` is shared between runtimes — so in a project with both runtimes installed, **the last install wins and silently corrupts the other**.

Concrete failure: install Copilot after Claude → `runtime: "copilot"` → a later `/gsd:set-profile` from a *Claude* session reads `config.runtime !== 'claude'` and **skips effort-frontmatter sync** on `.claude/agents/`, degrading the Claude install.

A list (`["claude","copilot"]`) doesn't fix it — it records *what is installed*, but every consumer needs *which runtime is executing now*. The runtime has to be derived at the point of use, not cached in a shared file.

## Fix — per-engine `.runtime` marker

`install.js` already knows the runtime from its `--runtime` flag. It now writes a one-line marker into the **deployed engine tree** — `<configdir>/gsd-ng/.runtime` — for each runtime. Separate trees → separate markers → no shared-file contention.

The engine self-detects via a new `getEngineRuntime()` helper in `core.cjs` that reads the `__dirname`-relative marker (`gsd-ng/.runtime`). It's immune to the local/global install distinction and to custom config-dir env vars, because it anchors to the engine's own location rather than a path name. Marker absent → assume `claude` (same backward-compat default as before).

- **`writeRuntimeToConfig()` and `config.runtime` are removed.** All three runtime gates retargeted to `getEngineRuntime()`: `resolveEffortInternal` (`core.cjs`), `syncAgentEffortFrontmatter` (`effort-sync.cjs`), and `cmdConfigGet` (`config.cjs`).
- Stale `config.runtime` keys in existing `.planning/config.json` files are left inert — ignored on read, no migration code.
- Docs updated (`claude-model-profiles.md`); the obsolete "consult `config.json` runtime field" instruction dropped from `seed-memories.md`.

## Tests

- `RUNTIME-01..04` retargeted from the `config.json` field to the `.runtime` marker, via a new `GSD_TEST_RUNTIME_MARKER_DIR` test seam.
- `core.test.cjs` / `effort-sync.test.cjs` runtime-suppression tests retargeted.
- **`RUNTIME-DUAL-A` / `RUNTIME-DUAL-B`** added — install Claude-then-Copilot *and* Copilot-then-Claude into one scratch project, run each engine's `sync-agents`, and assert Claude agents get `effort:` frontmatter while Copilot agents don't — **regardless of install order**.

Full suite: **3173/3173** green (rebased onto current `develop`, which includes #80).

## Provenance

Built via `/gsd:quick` (discuss + research + verify) — quick task `260514-ps7`. Plan-checked, executed with atomic commits, and verified (6/6 must-haves). Independent of #80; rebased on top of it with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)