### PR TITLE
ci: drop environment: release gate from release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: release
 
     steps:
       - name: Resolve ref


### PR DESCRIPTION
## Problem

The release pipeline had its approval gate on the wrong workflow:

| Workflow | Action | Gated? |
|---|---|---|
| `release.yml` | Creates the GitHub Release (editable/deletable in seconds) | ✅ `environment: release` (required reviewer) |
| `publish.yml` | `npm publish` (irreversible) | ❌ ungated since #72 |

The gate sat on the trivially-reversible action while the irreversible one ran free — and it produced an inconsistent release UX (npm auto-publishes, GitHub Release blocks on a manual approval click).

## Fix

Remove `environment: release` from `release.yml`. The pipeline's single intended human gate is the manual `prepare-release.yml` dispatch — everything downstream fires automatically from the tag push. #72 already moved `publish.yml` to this model; `release.yml`'s gate was leftover.

`release.yml` only runs on `v*.*.*` tag pushes, and `prepare-release.yml` already validates version format and branch, so dropping the `release` environment's branch-policy from this job is no real loss.

Not adding a gate to `publish.yml` instead: it publishes via OIDC trusted publishing (`--provenance`), whose npm-side config is bound to repo + workflow filename — adding an `environment` claim would break the token exchange. If a hard pre-publish approval is ever wanted, the right place is a required-reviewers environment on `prepare-release.yml` (the actual decision point).

🤖 Generated with [Claude Code](https://claude.com/claude-code)