### PR TITLE
fix(commands): defer /gsd:update execution to Bash tool with substituted flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `/gsd:update` step 5 shelled out `update --{install_type}` as a literal slash-command bash block, so the placeholder was passed verbatim and `gsd-tools.cjs update` rejected the unknown flag. The same load-time semantics would also have bypassed the step-4 confirmation prompt if the flag had been valid. Step 5 now invokes the Bash tool after confirmation, substituting `install_type` from the dry-run JSON into `--local` or `--global` before the call.
+
 ## [1.0.0-dev.7] - 2026-05-14
 
 ### Fixed

--- a/commands/gsd/update.md
+++ b/commands/gsd/update.md
@@ -22,7 +22,10 @@ Run the update command in dry-run mode first, then ask for confirmation before e
 
 4. Use {{USER_QUESTION_TOOL}} to ask "Proceed with update?" with options "Yes, update now" and "Cancel".
 
-5. If confirmed, execute with the install_type from dry-run result:
-!`node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" update --{install_type}`
+5. If confirmed, execute the update by invoking the Bash tool (NOT the `!`backtick form, which runs literally without substitution). Use the `install_type` value from the dry-run JSON in step 1 to pick the flag: `--local` if `install_type` is `"local"`, `--global` if `"global"`. Run:
+
+   `node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" update <flag>`
+
+   where `<flag>` is the resolved `--local` or `--global` (substitute it yourself before calling Bash — do not pass the literal placeholder).
 
 6. Show the result and remind user to restart Claude Code.


### PR DESCRIPTION
## Summary

- Step 5 of the `/gsd:update` slash command shelled out `!`...update --{install_type}`` with a literal placeholder. Slash-command bash blocks fire at command-load time with no Claude-side templating, so the line ran verbatim and `gsd-tools.cjs update` rejected the unknown flag.
- The same load-time semantics also meant step 5 would have run unconditionally (bypassing the step-4 confirmation) had the flag been valid.
- Step 5 now instructs Claude to invoke the **Bash tool** after the user confirms, substituting `install_type` from the dry-run JSON into `--local` or `--global` before the call.

## Reported error

```
Error: Unknown flag '--{install_type}' for 'update'. Did you mean '--dry-run'?
Known flags: --dry-run, --local, --global
```

## Notes for the release

- This is a content-only edit to the slash-command markdown. Users on a broken install can't `/gsd:update` their way out — they need `npx gsd-ng@latest --local` (or `--global`) once to refresh the slash command.

## Test plan

- [ ] Reinstall locally; `/gsd:update` on a current install reports `already_current` with no error.
- [ ] On an older install, dry-run reports `update_available`; AskUserQuestion fires; "Cancel" performs no `update --local`/`--global` invocation.
- [ ] On "Yes", Claude invokes Bash with the substituted flag; literal `{install_type}` never appears in any executed command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)