### PR TITLE
fix(commands): respect prerelease channels in /gsd:update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `/gsd:update` never prompted prerelease (`-dev.N`) users to upgrade, even when a newer prerelease was published. Three intertwined bugs in `commands.cjs`: `detectInstallLocation` stripped the prerelease suffix from the local `VERSION` file (so `1.0.0-dev.7+30c9587` became `1.0.0`), `cmdUpdate` queried `npm view gsd-ng version` which returns the `latest` dist-tag rather than the channel the user is on, and `compareSemVer` only compared the numeric core (so `1.0.0` and `1.0.0-dev.3` compared equal). `detectInstallLocation` now preserves the prerelease tag and drops only `+build` metadata, `cmdUpdate` picks the npm dist-tag matching the installed channel (with the previous query as a fallback) and filters GitHub Releases by channel on the fallback path, and `compareSemVer` is now semver §11 compliant — release versions beat prerelease versions, numeric identifiers compare numerically, and identifier counts break ties correctly.
+
 ## [1.0.0-dev.8] - 2026-05-15
 
 ### Fixed

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -543,7 +543,7 @@ Set `commit_docs: false` during `/gsd:new-project` or via `/gsd:settings`. Add `
 
 ### GSD Update Overwrote My Local Changes
 
-Since v1.17, the installer backs up locally modified files to `gsd-local-patches/`. Run `/gsd:reapply-patches` to merge your changes back.
+The installer backs up locally modified GSD files to `gsd-local-patches/` before overwriting them. Run `/gsd:reapply-patches` to merge your changes back into the freshly installed copies.
 
 ### Subagent Appears to Fail but Work Was Done
 

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -4472,13 +4472,47 @@ function cmdCleanup(cwd, options) {
  * Compare two semver strings.
  * @returns {number} 1 if a > b, -1 if a < b, 0 if equal
  */
+// Implements semver §11 precedence (release > prerelease, identifier-by-identifier compare).
 function compareSemVer(a, b) {
-  const pa = String(a).replace(/^v/, '').split('.').map(Number);
-  const pb = String(b).replace(/^v/, '').split('.').map(Number);
+  const stripBuild = (v) => String(v).replace(/^v/, '').split('+')[0];
+  const [coreA, preA] = stripBuild(a).split(/-(.+)/);
+  const [coreB, preB] = stripBuild(b).split(/-(.+)/);
+
+  const pa = coreA.split('.').map(Number);
+  const pb = coreB.split('.').map(Number);
   for (let i = 0; i < 3; i++) {
     if ((pa[i] || 0) > (pb[i] || 0)) return 1;
     if ((pa[i] || 0) < (pb[i] || 0)) return -1;
   }
+
+  if (!preA && !preB) return 0;
+  if (!preA) return 1;
+  if (!preB) return -1;
+
+  const idsA = preA.split('.');
+  const idsB = preB.split('.');
+  const n = Math.min(idsA.length, idsB.length);
+  for (let i = 0; i < n; i++) {
+    const aId = idsA[i];
+    const bId = idsB[i];
+    const aNum = /^\d+$/.test(aId);
+    const bNum = /^\d+$/.test(bId);
+    if (aNum && bNum) {
+      const dA = Number(aId);
+      const dB = Number(bId);
+      if (dA > dB) return 1;
+      if (dA < dB) return -1;
+    } else if (aNum && !bNum) {
+      return -1;
+    } else if (!aNum && bNum) {
+      return 1;
+    } else {
+      if (aId > bId) return 1;
+      if (aId < bId) return -1;
+    }
+  }
+  if (idsA.length < idsB.length) return -1;
+  if (idsA.length > idsB.length) return 1;
   return 0;
 }
 
@@ -4495,11 +4529,15 @@ function detectInstallLocation(cwd) {
   const localPath = path.join(cwd, '.claude', 'gsd-ng', 'VERSION');
   const globalPath = path.join(homeDir, '.claude', 'gsd-ng', 'VERSION');
 
+  // Strips build metadata (semver §10) so compareSemVer sees a clean version.
+  const VERSION_RE = /^(\d+\.\d+\.\d+(?:-[\w.]+)?)/;
+
   // Check local first
   if (fs.existsSync(localPath)) {
     try {
       const localVersion = fs.readFileSync(localPath, 'utf-8').trim();
-      if (/^\d+\.\d+\.\d+/.test(localVersion)) {
+      const m = localVersion.match(VERSION_RE);
+      if (m) {
         // Only treat as LOCAL if local path differs from global path
         // (prevents misdetection when cwd === homeDir)
         const localDir = path.dirname(localPath);
@@ -4508,7 +4546,7 @@ function detectInstallLocation(cwd) {
           return {
             isLocal: true,
             installPath: localDir,
-            installedVersion: localVersion.match(/^\d+\.\d+\.\d+/)[0],
+            installedVersion: m[1],
           };
         }
       }
@@ -4519,11 +4557,12 @@ function detectInstallLocation(cwd) {
   if (fs.existsSync(globalPath)) {
     try {
       const globalVersion = fs.readFileSync(globalPath, 'utf-8').trim();
-      if (/^\d+\.\d+\.\d+/.test(globalVersion)) {
+      const m = globalVersion.match(VERSION_RE);
+      if (m) {
         return {
           isLocal: false,
           installPath: path.dirname(globalPath),
-          installedVersion: globalVersion.match(/^\d+\.\d+\.\d+/)[0],
+          installedVersion: m[1],
         };
       }
     } catch {}
@@ -4645,33 +4684,86 @@ function cmdUpdate(cwd, options, _testOverrides) {
   const { isLocal, installedVersion } = installInfo;
   const installed = installedVersion;
 
+  const installedChannel = installed.includes('-')
+    ? installed.split('-')[1].split('.')[0] || null
+    : null;
+
   // 2. Check latest version
   let latestVersion = null;
   let updateSource = null;
 
-  if (_testOverrides) {
-    // Test injection: bypass network calls
-    latestVersion = _testOverrides.latestVersion || null;
-    updateSource = _testOverrides.updateSource || null;
+  if (overrides.latestVersion) {
+    latestVersion = overrides.latestVersion;
+    updateSource = overrides.updateSource || null;
+  } else if (_testOverrides && !overrides.execNpmView) {
+    // Test override present without an explicit execNpmView seam means "no
+    // live network" — don't fall through to real `npm view`.
+    latestVersion = null;
+    updateSource = null;
   } else {
-    /* c8 ignore start — network: `npm view` + GitHub Releases API. Exercised via _testOverrides.latestVersion injection seam in cmdUpdate dryRun/already_current/ahead tests. */
-    // Try npm first
-    try {
-      const npmResult = execSync('npm view gsd-ng version', {
-        timeout: 15000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        encoding: 'utf-8',
-      });
-      const npmVersion = npmResult.toString().trim();
-      if (npmVersion && /^\d+\.\d+\.\d+/.test(npmVersion)) {
-        latestVersion = npmVersion;
-        updateSource = 'npm';
-      }
-    } catch {}
+    /* c8 ignore start — network: `npm view` + GitHub Releases API. */
+    const execNpmView =
+      overrides.execNpmView ||
+      ((cmd) =>
+        execSync(cmd, {
+          timeout: 15000,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          encoding: 'utf-8',
+        }));
+    let npmVersion = null;
+    if (installedChannel) {
+      try {
+        const v = execNpmView(`npm view gsd-ng dist-tags.${installedChannel}`)
+          .toString()
+          .trim();
+        if (v && /^\d+\.\d+\.\d+/.test(v)) npmVersion = v;
+      } catch {}
+    }
+    if (!npmVersion) {
+      try {
+        const v = execNpmView('npm view gsd-ng version').toString().trim();
+        if (v && /^\d+\.\d+\.\d+/.test(v)) npmVersion = v;
+      } catch {}
+    }
+    if (npmVersion) {
+      latestVersion = npmVersion;
+      updateSource = 'npm';
+    }
 
-    // Fall back to GitHub Releases API
     if (!latestVersion) {
-      const githubScript = `
+      const githubScript = installedChannel
+        ? `
+        const https = require('https');
+        const opts = {
+          hostname: 'api.github.com',
+          path: '/repos/chrisdevchroma/gsd-ng/releases?per_page=100',
+          headers: { 'User-Agent': 'gsd-ng', 'Accept': 'application/vnd.github.v3+json' },
+          timeout: 10000,
+        };
+        const channel = ${JSON.stringify(installedChannel)};
+        const req = https.request(opts, function(res) {
+          if (res.statusCode !== 200) { process.exit(1); }
+          let d = '';
+          res.on('data', function(c) { d += c; });
+          res.on('end', function() {
+            try {
+              const r = JSON.parse(d);
+              if (!Array.isArray(r)) { process.exit(1); }
+              const tags = r
+                .map(function(x) { return (x.tag_name || '').replace(/^v/, ''); })
+                .filter(function(t) {
+                  return t && t.indexOf('-' + channel) !== -1 && /^\\d+\\.\\d+\\.\\d+/.test(t);
+                });
+              if (tags.length === 0) { process.exit(0); }
+              process.stdout.write(tags.join('\\n'));
+            } catch(e) { process.exit(1); }
+          });
+        });
+        req.on('error', function() { process.exit(1); });
+        req.on('timeout', function() { req.destroy(); });
+        req.end();
+      `
+        : `
         const https = require('https');
         const opts = {
           hostname: 'api.github.com',
@@ -4702,10 +4794,22 @@ function cmdUpdate(cwd, options, _testOverrides) {
         stdio: ['pipe', 'pipe', 'pipe'],
         encoding: 'utf-8',
       });
-      const githubTag = (githubResult.stdout || '').toString().trim();
-      if (githubTag && /^\d+\.\d+\.\d+/.test(githubTag)) {
-        latestVersion = githubTag;
-        updateSource = 'github';
+      const stdout = (githubResult.stdout || '').toString().trim();
+      if (stdout) {
+        if (installedChannel) {
+          const tags = stdout
+            .split('\n')
+            .map((t) => t.trim())
+            .filter((t) => /^\d+\.\d+\.\d+/.test(t));
+          if (tags.length > 0) {
+            tags.sort((a, b) => compareSemVer(b, a));
+            latestVersion = tags[0];
+            updateSource = 'github';
+          }
+        } else if (/^\d+\.\d+\.\d+/.test(stdout)) {
+          latestVersion = stdout;
+          updateSource = 'github';
+        }
       }
     }
     /* c8 ignore stop */

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -4067,6 +4067,380 @@ describe('update command', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// update command — prerelease channel handling
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('update command — prerelease channel handling', () => {
+  let tmpDir;
+  let fakeHome;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-update-pre-'));
+    fakeHome = fs.mkdtempSync(path.join(resolveTmpDir(), 'gsd-home-pre-'));
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+    cleanup(fakeHome);
+  });
+
+  // Mirrors the runUpdate helper from the sibling `update command` describe block.
+  // Kept local so the new tests can be reviewed/moved as a unit without touching
+  // the original block.
+  function runUpdate(
+    localGsdVersion,
+    globalGsdVersion,
+    overrides,
+    options = {},
+  ) {
+    if (localGsdVersion) {
+      const localGsdDir = path.join(tmpDir, '.claude', 'gsd-ng');
+      fs.mkdirSync(localGsdDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(localGsdDir, 'VERSION'),
+        localGsdVersion + '\n',
+      );
+    }
+    if (globalGsdVersion) {
+      const globalGsdDir = path.join(fakeHome, '.claude', 'gsd-ng');
+      fs.mkdirSync(globalGsdDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(globalGsdDir, 'VERSION'),
+        globalGsdVersion + '\n',
+      );
+    }
+
+    const args = ['update', '--dry-run'];
+    if (options.execute) {
+      args.splice(args.indexOf('--dry-run'), 1);
+    }
+
+    const env = {
+      GSD_TEST_HOME: fakeHome,
+      GSD_UPDATE_TEST_OVERRIDES: JSON.stringify(
+        overrides || { latestVersion: null, updateSource: null },
+      ),
+    };
+    if (options.dryExecute) {
+      env.GSD_TEST_DRY_EXECUTE = '1';
+    }
+
+    return runGsdTools(args, tmpDir, env);
+  }
+
+  // ── A) compareSemVer — semver §11 precedence ────────────────────────────────
+
+  test('A1: compareSemVer prerelease numeric ordering (-dev.7 < -dev.8)', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0-dev.7', '1.0.0-dev.8'), -1);
+  });
+
+  test('A2: compareSemVer prerelease numeric ordering symmetric (-dev.8 > -dev.7)', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0-dev.8', '1.0.0-dev.7'), 1);
+  });
+
+  test('A3: compareSemVer equal prerelease returns 0', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0-dev.7', '1.0.0-dev.7'), 0);
+  });
+
+  test('A4: compareSemVer release > prerelease (§11: 1.0.0 > 1.0.0-dev.3)', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0', '1.0.0-dev.3'), 1);
+  });
+
+  test('A5: compareSemVer prerelease < release symmetric', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0-dev.3', '1.0.0'), -1);
+  });
+
+  test('A6: compareSemVer fewer prerelease identifiers < more (alpha < alpha.1)', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0-alpha', '1.0.0-alpha.1'), -1);
+  });
+
+  test('A7: compareSemVer numeric identifier < alphanumeric (alpha.1 < alpha.beta)', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0-alpha.1', '1.0.0-alpha.beta'), -1);
+  });
+
+  test('A8: compareSemVer ignores +build metadata even on prerelease', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0-rc.1+abc', '1.0.0-rc.1'), 0);
+  });
+
+  test('A9: compareSemVer regression guards (plain semver still correct)', () => {
+    const { compareSemVer } = require('../gsd-ng/bin/lib/commands.cjs');
+    assert.strictEqual(compareSemVer('1.0.0', '0.9.9'), 1);
+    assert.strictEqual(compareSemVer('1.0.0', '1.0.1'), -1);
+    assert.strictEqual(compareSemVer('1.2.3', '1.2.3'), 0);
+    assert.strictEqual(compareSemVer('v1.0.0', '1.0.0'), 0);
+    assert.strictEqual(compareSemVer('1.0.0+abc1234', '1.0.0'), 0);
+  });
+
+  // ── B) detectInstallLocation — preserves prerelease suffix ──────────────────
+
+  test('B1: detectInstallLocation preserves -dev.N on local VERSION, drops +build', () => {
+    const { detectInstallLocation } = require('../gsd-ng/bin/lib/commands.cjs');
+    const dir = createTempProject();
+    const homeDir = createTempProject();
+    fs.mkdirSync(path.join(dir, '.claude', 'gsd-ng'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '.claude', 'gsd-ng', 'VERSION'),
+      '1.0.0-dev.7+30c9587\n',
+    );
+    process.env.GSD_TEST_HOME = homeDir;
+    try {
+      const r = detectInstallLocation(dir);
+      assert.ok(r);
+      assert.strictEqual(r.isLocal, true);
+      assert.strictEqual(r.installedVersion, '1.0.0-dev.7');
+    } finally {
+      delete process.env.GSD_TEST_HOME;
+      cleanup(dir);
+      cleanup(homeDir);
+    }
+  });
+
+  test('B2: detectInstallLocation preserves -dev.N on global VERSION', () => {
+    const { detectInstallLocation } = require('../gsd-ng/bin/lib/commands.cjs');
+    const dir = createTempProject();
+    const homeDir = createTempProject();
+    fs.mkdirSync(path.join(homeDir, '.claude', 'gsd-ng'), { recursive: true });
+    fs.writeFileSync(
+      path.join(homeDir, '.claude', 'gsd-ng', 'VERSION'),
+      '1.0.0-dev.7+30c9587\n',
+    );
+    process.env.GSD_TEST_HOME = homeDir;
+    try {
+      const r = detectInstallLocation(dir);
+      assert.ok(r);
+      assert.strictEqual(r.isLocal, false);
+      assert.strictEqual(r.installedVersion, '1.0.0-dev.7');
+    } finally {
+      delete process.env.GSD_TEST_HOME;
+      cleanup(dir);
+      cleanup(homeDir);
+    }
+  });
+
+  test('B3: detectInstallLocation regression — plain 1.2.3 / 2.0.0 inputs', () => {
+    const { detectInstallLocation } = require('../gsd-ng/bin/lib/commands.cjs');
+    const dir = createTempProject();
+    const homeDir = createTempProject();
+    fs.mkdirSync(path.join(dir, '.claude', 'gsd-ng'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.claude', 'gsd-ng', 'VERSION'), '1.2.3');
+    process.env.GSD_TEST_HOME = homeDir;
+    try {
+      const r = detectInstallLocation(dir);
+      assert.ok(r);
+      assert.strictEqual(r.installedVersion, '1.2.3');
+    } finally {
+      delete process.env.GSD_TEST_HOME;
+      cleanup(dir);
+      cleanup(homeDir);
+    }
+  });
+
+  // ── C) cmdUpdate end-to-end with prerelease versions ────────────────────────
+
+  test('C1: prerelease user with newer prerelease available → update_available (headline regression)', () => {
+    const result = runUpdate('1.0.0-dev.7+30c9587', null, {
+      latestVersion: '1.0.0-dev.8',
+      updateSource: 'npm',
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.status, 'update_available');
+    assert.strictEqual(parsed.installed, '1.0.0-dev.7');
+    assert.strictEqual(parsed.latest, '1.0.0-dev.8');
+    assert.strictEqual(parsed.install_type, 'local');
+    assert.strictEqual(parsed.update_available, true);
+  });
+
+  test('C2: prerelease user ahead of injected older prerelease → ahead', () => {
+    const result = runUpdate('1.0.0-dev.8', null, {
+      latestVersion: '1.0.0-dev.7',
+      updateSource: 'npm',
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.status, 'ahead');
+  });
+
+  test('C3: prerelease user with stable release available → update_available (dev → stable)', () => {
+    const result = runUpdate('1.0.0-dev.7', null, {
+      latestVersion: '1.0.0',
+      updateSource: 'npm',
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.status, 'update_available');
+  });
+
+  test('C4: stable release user MUST NOT be prompted to "upgrade" to a prerelease → ahead', () => {
+    const result = runUpdate('1.0.0', null, {
+      latestVersion: '1.0.0-dev.99',
+      updateSource: 'npm',
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.status, 'ahead');
+  });
+
+  test('C5: prerelease user truly current on prerelease channel → already_current (no over-correction)', () => {
+    const result = runUpdate('1.0.0-dev.7', '1.0.0-dev.7', {
+      latestVersion: '1.0.0-dev.7',
+      updateSource: 'npm',
+    });
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.status, 'already_current');
+  });
+
+  // ── D) Channel pinning seam — npm dist-tag selection on prerelease installs ──
+
+  // These tests stub `_testOverrides.execNpmView` (a new seam introduced in
+  // Task 2) so we can assert the actual `npm view` command string that the
+  // channel-pinning branch would have shelled out, then read the JSON
+  // payload that `output()` writes via `fs.writeSync(1, ...)`.
+
+  // captureCmdUpdate: stubs `fs.writeSync(1, …)` so we can read the JSON
+  // `output()` would have sent to stdout, while still letting non-stdout
+  // writeSync calls (test reporter, etc.) pass through.
+  function captureCmdUpdate(dir, overrides) {
+    const { cmdUpdate } = require('../gsd-ng/bin/lib/commands.cjs');
+    const origWriteSync = fs.writeSync;
+    let captured_stdout = '';
+    fs.writeSync = function (fd, buf, ...rest) {
+      if (fd === 1) {
+        captured_stdout += typeof buf === 'string' ? buf : buf.toString();
+        return Buffer.byteLength(buf);
+      }
+      return origWriteSync.call(fs, fd, buf, ...rest);
+    };
+    try {
+      cmdUpdate(dir, { dryRun: true }, overrides);
+    } finally {
+      fs.writeSync = origWriteSync;
+    }
+    return captured_stdout;
+  }
+
+  test('D1: prerelease install → npm path queries dist-tags.<channel>, not dist-tags.latest', () => {
+    const dir = createTempProject();
+    const homeDir = createTempProject();
+    fs.mkdirSync(path.join(dir, '.claude', 'gsd-ng'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '.claude', 'gsd-ng', 'VERSION'),
+      '1.0.0-dev.7+30c9587',
+    );
+    process.env.GSD_TEST_HOME = homeDir;
+    const captured = [];
+    const stubExec = (cmd) => {
+      captured.push(cmd);
+      if (/dist-tags\.dev$/.test(cmd)) return '1.0.0-dev.8\n';
+      return '';
+    };
+    let captured_stdout;
+    try {
+      captured_stdout = captureCmdUpdate(dir, { execNpmView: stubExec });
+    } finally {
+      delete process.env.GSD_TEST_HOME;
+      cleanup(dir);
+      cleanup(homeDir);
+    }
+    assert.ok(
+      captured.some((c) => /npm view gsd-ng dist-tags\.dev/.test(c)),
+      'expected channel-pinned dist-tags.dev query, got: ' +
+        JSON.stringify(captured),
+    );
+    const parsed = JSON.parse(captured_stdout);
+    assert.strictEqual(parsed.status, 'update_available');
+    assert.strictEqual(parsed.latest, '1.0.0-dev.8');
+  });
+
+  test('D2: release install → npm path keeps prior `npm view gsd-ng version` query (regression guard)', () => {
+    const dir = createTempProject();
+    const homeDir = createTempProject();
+    fs.mkdirSync(path.join(dir, '.claude', 'gsd-ng'), { recursive: true });
+    fs.writeFileSync(path.join(dir, '.claude', 'gsd-ng', 'VERSION'), '1.0.0');
+    process.env.GSD_TEST_HOME = homeDir;
+    const captured = [];
+    const stubExec = (cmd) => {
+      captured.push(cmd);
+      return '1.0.1\n';
+    };
+    let captured_stdout;
+    try {
+      captured_stdout = captureCmdUpdate(dir, { execNpmView: stubExec });
+    } finally {
+      delete process.env.GSD_TEST_HOME;
+      cleanup(dir);
+      cleanup(homeDir);
+    }
+    assert.ok(
+      captured.some((c) => /npm view gsd-ng version/.test(c)),
+      'expected plain "npm view gsd-ng version" query for release install, got: ' +
+        JSON.stringify(captured),
+    );
+    assert.ok(
+      !captured.some((c) => /dist-tags\./.test(c)),
+      'release install must not query dist-tags.*, got: ' +
+        JSON.stringify(captured),
+    );
+    const parsed = JSON.parse(captured_stdout);
+    assert.strictEqual(parsed.status, 'update_available');
+    assert.strictEqual(parsed.latest, '1.0.1');
+  });
+
+  test('D3: prerelease install + channel dist-tag throws → falls back to plain `npm view gsd-ng version`', () => {
+    const dir = createTempProject();
+    const homeDir = createTempProject();
+    fs.mkdirSync(path.join(dir, '.claude', 'gsd-ng'), { recursive: true });
+    fs.writeFileSync(
+      path.join(dir, '.claude', 'gsd-ng', 'VERSION'),
+      '1.0.0-dev.7',
+    );
+    process.env.GSD_TEST_HOME = homeDir;
+    const captured = [];
+    const stubExec = (cmd) => {
+      captured.push(cmd);
+      if (/dist-tags\.dev$/.test(cmd)) {
+        const e = new Error('npm ERR! dist-tag dev not found');
+        e.status = 1;
+        throw e;
+      }
+      if (/npm view gsd-ng version$/.test(cmd)) return '1.0.0\n';
+      return '';
+    };
+    let captured_stdout;
+    try {
+      captured_stdout = captureCmdUpdate(dir, { execNpmView: stubExec });
+    } finally {
+      delete process.env.GSD_TEST_HOME;
+      cleanup(dir);
+      cleanup(homeDir);
+    }
+    assert.ok(
+      captured.some((c) => /npm view gsd-ng dist-tags\.dev/.test(c)),
+      'expected dist-tags.dev query attempt, got: ' + JSON.stringify(captured),
+    );
+    assert.ok(
+      captured.some((c) => /npm view gsd-ng version/.test(c)),
+      'expected fallback "npm view gsd-ng version" query after dist-tag failure, got: ' +
+        JSON.stringify(captured),
+    );
+    // The fallback latest (`1.0.0`) is correctly seen as a §11 upgrade from
+    // a prerelease (`1.0.0-dev.7`).
+    const parsed = JSON.parse(captured_stdout);
+    assert.strictEqual(parsed.status, 'update_available');
+    assert.strictEqual(parsed.latest, '1.0.0');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // staleness-check --count flag
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -10206,9 +10580,7 @@ describe('commands.cjs branch coverage residuals (60-11)', () => {
         const code =
           'const r = require(' +
           JSON.stringify(
-            path.resolve(
-              __dirname, '../gsd-ng/bin/lib/commands.cjs',
-            ),
+            path.resolve(__dirname, '../gsd-ng/bin/lib/commands.cjs'),
           ) +
           ').cmdCommit(' +
           JSON.stringify(proj) +
@@ -10245,9 +10617,7 @@ describe('commands.cjs branch coverage residuals (60-11)', () => {
         const code =
           'require(' +
           JSON.stringify(
-            path.resolve(
-              __dirname, '../gsd-ng/bin/lib/commands.cjs',
-            ),
+            path.resolve(__dirname, '../gsd-ng/bin/lib/commands.cjs'),
           ) +
           ').cmdCommit(' +
           JSON.stringify(proj) +
@@ -10281,9 +10651,7 @@ describe('commands.cjs branch coverage residuals (60-11)', () => {
       const code =
         'require(' +
         JSON.stringify(
-          path.resolve(
-            __dirname, '../gsd-ng/bin/lib/commands.cjs',
-          ),
+          path.resolve(__dirname, '../gsd-ng/bin/lib/commands.cjs'),
         ) +
         ').cmdScaffold(' +
         JSON.stringify(tmpDir) +
@@ -10306,9 +10674,7 @@ describe('commands.cjs branch coverage residuals (60-11)', () => {
       const code =
         'const r = require(' +
         JSON.stringify(
-          path.resolve(
-            __dirname, '../gsd-ng/bin/lib/commands.cjs',
-          ),
+          path.resolve(__dirname, '../gsd-ng/bin/lib/commands.cjs'),
         ) +
         ').cmdScaffold(' +
         JSON.stringify(tmpDir) +


### PR DESCRIPTION
## Summary

Follow-up to #84. The step-5 substitution fix shipped in v1.0.0-dev.8 is correct in isolation but is **unreachable for prerelease users** because three intertwined bugs in `commands.cjs` upstream of step 5 cause `/gsd:update --dry-run` to falsely report `already_current`. This PR fixes all three together — fixing fewer than three leaves the flow broken.

### Bugs fixed

| # | Location | Symptom |
|---|----------|---------|
| 1 | `detectInstallLocation` (commands.cjs ~L4492-4533) | `localVersion.match(/^\d+\.\d+\.\d+/)[0]` strips the prerelease suffix — `1.0.0-dev.7+30c9587` becomes `1.0.0`. New `VERSION_RE = /^(\d+\.\d+\.\d+(?:-[\w.]+)?)/` keeps the prerelease, drops only `+build`. |
| 2 | `cmdUpdate` npm/GitHub lookup (commands.cjs ~L4659-4710) | `npm view gsd-ng version` returns the `latest` dist-tag (currently `1.0.0-dev.3`) — never advances for prerelease users. Now dispatches by installed channel: `dist-tags.dev` for `-dev.*` users, `dist-tags.latest` for stable. GitHub Releases fallback paginates `/releases?per_page=100` and channel-filters when the installed version is a prerelease. Plain `npm view` + `/releases/latest` retained as fallbacks. |
| 3 | `compareSemVer` (commands.cjs L4475-4483) | Compared only `[major, minor, patch]` numerics; `"1.0.0-dev.3".split('.').map(Number)` yields `[1, 0, NaN, 3]` and `NaN \|\| 0 = 0`, so `1.0.0` and `1.0.0-dev.3` compared equal. Replaced with a semver §11 compliant compare (~30 lines, no dependency): release > prerelease at equal core; identifier-by-identifier compare with numeric-vs-alphanumeric tie-breakers and identifier-count tie-break. |

### Headline regression test

`tests/commands.test.cjs` C1 exercises the exact scenario that motivated this PR — installed `1.0.0-dev.7+30c9587` against an injected `1.0.0-dev.8` — and asserts the dry-run returns:

```json
{ "status": "update_available", "installed": "1.0.0-dev.7", "latest": "1.0.0-dev.8", "install_type": "local", "update_available": true }
```

Without these fixes that test would currently get `{ status: "already_current", installed: "1.0.0", latest: "1.0.0-dev.3" }`.

### Coverage

- 20 new tests in the new `describe('update command — prerelease channel handling', ...)` block: A1-A9 (compareSemVer §11), B1-B3 (detectInstallLocation prerelease preservation), C1-C5 (cmdUpdate end-to-end with `_testOverrides` + `GSD_TEST_HOME` seams), D1-D3 (channel-pinned npm view via new `execNpmView` seam). D4 deliberately omitted per the plan's brittleness clause; the GitHub channel-filter dispatch is still present and inspected.
- Full submodule test suite: **3193/3193 pass**.

### Test plan

- [x] New describe block in `tests/commands.test.cjs` passes
- [x] No regressions in existing `commands.test.cjs` suites
- [x] `npm test` green (3193 pass, 0 fail, 0 skipped)
- [x] `prettier --check` clean
- [ ] Post-merge smoke test (run by user after v1.0.0-dev.9 is published):
  ```bash
  node gsd-ng/bin/install.js --local --runtime claude
  node .claude/gsd-ng/bin/gsd-tools.cjs update --dry-run
  # Expect: status=update_available with installed/latest reflecting real npm dev dist-tag
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
