### PR TITLE
docs(readme): point upstream link to open-gsd/get-shit-done-redux

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **gsd-ng is a next-generation hard fork of GSD, optimized for Claude Code and GitHub Copilot CLI.**
 
-Forked from [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done).
+Forked from [open-gsd/get-shit-done-redux](https://github.com/open-gsd/get-shit-done-redux).
 
 **A light-weight and powerful meta-prompting, context engineering and spec-driven development system.**
 


### PR DESCRIPTION
## What

Updates the "Forked from" link in `README.md` to point at the new upstream home, [`open-gsd/get-shit-done-redux`](https://github.com/open-gsd/get-shit-done-redux).

## Why

The original upstream `gsd-build/get-shit-done` is deprecated and now redirects to the community-maintained `open-gsd/get-shit-done-redux` fork.

## Change

```diff
-Forked from [gsd-build/get-shit-done](https://github.com/gsd-build/get-shit-done).
+Forked from [open-gsd/get-shit-done-redux](https://github.com/open-gsd/get-shit-done-redux).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)