### PR TITLE
docs(changelog): populate [Unreleased] for 1.0.0-dev.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- Expanded prompt-injection detection for untrusted Markdown. The scanner now flags, as high-confidence blocks, links that use the `javascript:` scheme, links with non-safelisted `data:` URIs (only raster image types — png, jpeg, gif, webp, avif — are allowed; SVG and others are rejected), links with embedded `user:pass@` credentials, and links carrying secret-bearing query parameters (tokens, API keys, passwords, and similar). It also raises a medium-confidence advisory when a link or file reference points at a credential path such as `~/.ssh`, `~/.aws/credentials`, a `.pem`, or a `.env` file. Every detection rule now carries a stable identifier and a human-readable description, and scan results are reported as self-documenting `identifier: description` strings instead of raw regex dumps.
+
+### Fixed
+- The background update check no longer runs on every sub-agent spawn. It now only checks for a newer version during a genuine primary-session startup (with a time-based throttle as a backstop), eliminating the repeated npm-registry access prompts seen during multi-agent workflows.
+
 ## [1.0.0-dev.10] - 2026-05-23
 
 ### Security


### PR DESCRIPTION
## Summary

Populates the empty `## [Unreleased]` section of `CHANGELOG.md` so `prepare-release` can stamp the next dev release (`1.0.0-dev.11`). The release workflow validation requires non-empty release notes under `[Unreleased]`; PR #88 landed the work but did not add changelog entries.

## Changes

Adds `[Unreleased]` notes covering what merged in #88:
- **Added** — the five new tiered injection rules (`MD-LINK-JS-SCHEME`, `MD-LINK-DATA-SCHEME`, `MD-LINK-USERINFO`, `MD-LINK-TOKEN-IN-QUERY`, `AT-FILE-CREDENTIAL-PATH`), the stable `id`/`description` retrofit, and the `RULE-ID: description` emit format.
- **Fixed** — the `gsd-check-update` SessionStart hook now gates update checks to primary sessions (no `npm view` on subagent spawns).

Docs-only; no code changes.

## Test Plan

- [x] Docs-only — no behavior change
