### PR TITLE
fix: thread --runtime flag through cmdUpdate self-update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `/gsd:update` self-update no longer fails with `Error: --runtime required` on installs of v1.0.0-dev.11 and later; the required `--runtime` flag is now passed to the installer across all update paths (npm and GitHub-release tarball).
+
 ## [1.0.0-dev.11] - 2026-05-23
 
 ### Added

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -25,6 +25,7 @@ const {
   error,
   findPhaseInternal,
   planningPaths,
+  getEngineRuntime,
 } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { MODEL_PROFILES, EFFORT_PROFILES } = require('./model-profiles.cjs');
@@ -4540,12 +4541,12 @@ function detectInstallLocation(cwd) {
  * the bundled install.js. Extracted from cmdUpdate as a separate function
  * so tests can inject a fake `execUpdate` via `_testOverrides.execUpdate`.
  *
- * @param {{ version: string, installFlag: string, url: string }} args
+ * @param {{ version: string, installFlag: string, runtime: string, url: string }} args
  * @returns {{ success: boolean, error?: string }}
  */
 /* c8 ignore start — network+filesystem ops: download tarball, extract via tar binary, exec install.js. Tested via execUpdate seam injection (cmdUpdate — execUpdate seam describe block). */
 function _downloadAndInstallTarball(args) {
-  const { installFlag, url: tarballUrl } = args;
+  const { installFlag, url: tarballUrl, runtime } = args;
   const tmpExtractDir = path.join(os.tmpdir(), 'gsd-update-' + Date.now());
   const tarballPath = path.join(tmpExtractDir, 'gsd-ng.tar.gz');
   const extractDir = path.join(tmpExtractDir, 'extracted');
@@ -4597,7 +4598,7 @@ function _downloadAndInstallTarball(args) {
     // Run install.js
     const installResult = spawnSync(
       'node',
-      [path.join(extractDir, 'bin', 'install.js'), installFlag],
+      [path.join(extractDir, 'bin', 'install.js'), installFlag, '--runtime', runtime],
       {
         stdio: 'inherit',
         timeout: 120000,
@@ -4813,13 +4814,14 @@ function cmdUpdate(cwd, options, _testOverrides) {
   // Honors both `_testOverrides.dryExecute` (preferred) and the legacy
   // GSD_TEST_DRY_EXECUTE env hook for back-compat with subprocess tests.
   const installTarget = `gsd-ng@${installedChannel || 'latest'}`;
+  const runtime = getEngineRuntime();
 
   if (overrides.dryExecute || process.env.GSD_TEST_DRY_EXECUTE) {
     let installCommand;
     if (updateSource === 'npm') {
-      installCommand = `npx -y ${installTarget} ${installFlag}`;
+      installCommand = `npx -y ${installTarget} ${installFlag} --runtime ${runtime}`;
     } else {
-      installCommand = `node install.js ${installFlag} (github tarball download)`;
+      installCommand = `node install.js ${installFlag} --runtime ${runtime} (github tarball download)`;
     }
     return output({
       status: 'updated',
@@ -4833,7 +4835,7 @@ function cmdUpdate(cwd, options, _testOverrides) {
   if (updateSource === 'npm') {
     /* c8 ignore start — network: `npx -y gsd-ng@<channel>` shells out to npm. Exercised via dryExecute/GSD_TEST_DRY_EXECUTE short-circuit above (cmdUpdate dry-execute returns updated with install_command (npm) test). */
     try {
-      execSync(`npx -y ${installTarget} ${installFlag}`, {
+      execSync(`npx -y ${installTarget} ${installFlag} --runtime ${runtime}`, {
         stdio: 'inherit',
         timeout: 120000,
       });
@@ -4851,6 +4853,7 @@ function cmdUpdate(cwd, options, _testOverrides) {
     const execResult = exec({
       version: latestVersion,
       installFlag,
+      runtime,
       url: `https://github.com/chrisdevchroma/gsd-ng/releases/download/${latestVersion}/gsd-ng.tar.gz`,
     });
     if (execResult && execResult.success === false) {

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -4598,7 +4598,12 @@ function _downloadAndInstallTarball(args) {
     // Run install.js
     const installResult = spawnSync(
       'node',
-      [path.join(extractDir, 'bin', 'install.js'), installFlag, '--runtime', runtime],
+      [
+        path.join(extractDir, 'bin', 'install.js'),
+        installFlag,
+        '--runtime',
+        runtime,
+      ],
       {
         stdio: 'inherit',
         timeout: 120000,

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -8301,6 +8301,30 @@ describe('sub-batch H: cmdUpdate execUpdate seam exercised', () => {
     const parsed = JSON.parse(r.output);
     assert.strictEqual(parsed.status, 'updated');
     assert.match(parsed.install_command, /npx -y gsd-ng@latest/);
+    assert.match(parsed.install_command, /--runtime claude/);
+  });
+
+  test('cmdUpdate dry-execute threads --runtime copilot for npm path', () => {
+    const markerDir = fs.mkdtempSync(
+      path.join(resolveTmpDir(), 'gsd-copilot-marker-'),
+    );
+    fs.writeFileSync(path.join(markerDir, '.runtime'), 'copilot\n', 'utf-8');
+    try {
+      const r = runGsdTools(['update', '--json'], tmpDir, {
+        GSD_UPDATE_TEST_OVERRIDES: JSON.stringify({
+          latestVersion: '99.0.0',
+          updateSource: 'npm',
+        }),
+        GSD_TEST_DRY_EXECUTE: '1',
+        GSD_TEST_RUNTIME_MARKER_DIR: markerDir,
+      });
+      assert.ok(r.success);
+      const parsed = JSON.parse(r.output);
+      assert.match(parsed.install_command, /--runtime copilot/);
+      assert.doesNotMatch(parsed.install_command, /--runtime claude/);
+    } finally {
+      cleanup(markerDir);
+    }
   });
 
   test('cmdUpdate dry-execute: prerelease install tracks its own channel (@dev, never @latest)', () => {
@@ -8333,6 +8357,29 @@ describe('sub-batch H: cmdUpdate execUpdate seam exercised', () => {
     assert.ok(r.success);
     const parsed = JSON.parse(r.output);
     assert.match(parsed.install_command, /github tarball download/);
+    assert.match(parsed.install_command, /--runtime claude/);
+  });
+
+  test('cmdUpdate dry-execute threads --runtime copilot for github path', () => {
+    const markerDir = fs.mkdtempSync(
+      path.join(resolveTmpDir(), 'gsd-copilot-marker-'),
+    );
+    fs.writeFileSync(path.join(markerDir, '.runtime'), 'copilot\n', 'utf-8');
+    try {
+      const r = runGsdTools(['update', '--json'], tmpDir, {
+        GSD_UPDATE_TEST_OVERRIDES: JSON.stringify({
+          latestVersion: '99.0.0',
+          updateSource: 'github',
+        }),
+        GSD_TEST_DRY_EXECUTE: '1',
+        GSD_TEST_RUNTIME_MARKER_DIR: markerDir,
+      });
+      assert.ok(r.success);
+      const parsed = JSON.parse(r.output);
+      assert.match(parsed.install_command, /--runtime copilot/);
+    } finally {
+      cleanup(markerDir);
+    }
   });
 
   test('cmdUpdate execUpdate failure returns error status (in-process smoke)', () => {


### PR DESCRIPTION
## Summary

`/gsd:update` self-update now passes the required `--runtime` flag to the installer, so it no longer fails with `Error: --runtime required` on installs of v1.0.0-dev.11 and later. The flag is threaded through every installer path in `cmdUpdate`.

## Changes

`bin/lib/commands.cjs`:
- Resolve the active runtime once via `getEngineRuntime()` and append `--runtime ${runtime}` to all installer invocations:
  - the live npm `execSync(npx -y gsd-ng@<channel> ${installFlag})` call
  - the npm and GitHub dry-run command previews
  - the GitHub-release tarball `install.js` spawn (threaded through `_downloadAndInstallTarball`)

`tests/commands.test.cjs`:
- Assert `--runtime claude` (default) on the two dry-execute tests (npm + github)
- Two new tests asserting `--runtime copilot` via the `GSD_TEST_RUNTIME_MARKER_DIR` pattern

## Testing

Full suite green: **3297 tests, 0 failures**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
