### PR TITLE
fix: ship CHANGELOG.md in the npm package

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,10 +36,6 @@ jobs:
               exit 1
             fi
           done
-          if ! echo "$FILES" | grep -qw "CHANGELOG.md"; then
-            echo "::error::package.json files MUST include CHANGELOG.md (npm does not auto-pack it into the tarball)"
-            exit 1
-          fi
           echo "package.json files OK: $FILES"
 
   changelog-check:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Validate package.json files allowlist
         shell: bash
         run: |
-          ALLOWED='bin commands gsd-ng agents hooks'
+          ALLOWED='bin commands gsd-ng agents hooks CHANGELOG.md'
           FILES=$(node -p "require('./package.json').files.join(' ')")
           for entry in $FILES; do
             if ! echo "$ALLOWED" | grep -qw "$entry"; then
@@ -36,6 +36,10 @@ jobs:
               exit 1
             fi
           done
+          if ! echo "$FILES" | grep -qw "CHANGELOG.md"; then
+            echo "::error::package.json files MUST include CHANGELOG.md (npm does not auto-pack it into the tarball)"
+            exit 1
+          fi
           echo "package.json files OK: $FILES"
 
   changelog-check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- npm installs and updates now include `CHANGELOG.md`. Because `CHANGELOG.md` was missing from the package `files` list, the published tarball shipped no changelog, so installing or updating gsd-ng silently omitted it (and could wipe a previously installed copy). It is now packaged and installed with the rest of the project.
+
 ## [1.0.0-dev.12] - 2026-05-24
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "commands",
     "gsd-ng",
     "agents",
-    "hooks"
+    "hooks",
+    "CHANGELOG.md"
   ],
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary

The published npm tarball was missing `CHANGELOG.md`, so npm-based installs deployed no changelog and `/gsd:update` wiped any previously-deployed copy. `CHANGELOG.md` is now shipped, matching what `install.js` and the test suite already assume.

## Changes

- **`package.json`** — add `"CHANGELOG.md"` to `files` (npm doesn't auto-include CHANGELOG, so the `files` whitelist must list it).
- **`.github/workflows/test.yml`** (`package-files-check`) — add `CHANGELOG.md` to the `ALLOWED` allowlist, and add a **positive assertion** that `CHANGELOG.md` is present in `files` so it can't silently drop out again.
- **`CHANGELOG.md`** — `[Unreleased]` → Fixed entry.

## Testing

- `npm pack --dry-run --json`: `CHANGELOG.md` now in the tarball (196 files, was 195 without it).
- `npm test`: 3297 tests, 0 failures.

## Context

Follow-up to #90 — the gap surfaced while verifying that fix's deployed copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
