### PR TITLE
fix: submodule PR platform/CLI detection

### DIFF
--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -1571,13 +1571,12 @@ function buildImportComment(style, context) {
   return 'Tracked for resolution.';
 }
 
-function cmdDetectPlatform(cwd, remote, silent) {
+function cmdDetectPlatform(cwd, remote, silent, platformOverride) {
   const { spawnSync } = require('child_process');
 
-  // 1. Check config override
+  // Explicit override wins, else config, else URL detection.
   const cfg = loadConfig(cwd);
-  // loadConfig returns a flat object; cfg.platform is the platform field (not cfg.git.platform)
-  const platformOverride = cfg.platform || null;
+  const cfgPlatformOverride = platformOverride || cfg.platform || null;
 
   let platform = null;
   let source = 'unknown';
@@ -1585,8 +1584,8 @@ function cmdDetectPlatform(cwd, remote, silent) {
   let cli = null;
   let cliInstalled = false;
 
-  if (platformOverride) {
-    platform = platformOverride;
+  if (cfgPlatformOverride) {
+    platform = cfgPlatformOverride;
     source = 'config';
   } else {
     // 2. Auto-detect from remote URL
@@ -1620,9 +1619,16 @@ function cmdDetectPlatform(cwd, remote, silent) {
   if (platform && PLATFORM_CLI[platform]) {
     cli = PLATFORM_CLI[platform];
 
-    // 4. Check CLI availability
-    const cliCheck = spawnSync(cli, ['--version'], { stdio: 'pipe' });
-    cliInstalled = cliCheck.status === 0;
+    // fj rejects --version; use its `version` subcommand. Missing binary => not installed.
+    const CLI_PROBE_ARGS = {
+      fj: ['version'], // fj uses subcommand, not --version
+      gh: ['--version'],
+      glab: ['--version'],
+      tea: ['--version'],
+    };
+    const probeArgs = CLI_PROBE_ARGS[cli] || ['--version'];
+    const cliCheck = spawnSync(cli, probeArgs, { stdio: 'pipe' });
+    cliInstalled = !cliCheck.error && cliCheck.status === 0;
   }
 
   const result = {

--- a/gsd-ng/bin/lib/workspace.cjs
+++ b/gsd-ng/bin/lib/workspace.cjs
@@ -470,7 +470,10 @@ function resolveGitContext(cwd) {
     (remoteUrl.startsWith('git@') || remoteUrl.startsWith('ssh://')),
   );
 
-  const platformInfo = cmdDetectPlatform(subCwd, remote, true) || {};
+  // Pass per-submodule platform override so loadConfig(subCwd) is bypassed (no .planning/ there).
+  const platformInfo =
+    cmdDetectPlatform(subCwd, remote, true, configSubmodule.platform || null) ||
+    {};
 
   return {
     is_submodule: true,

--- a/gsd-ng/references/planning-config.md
+++ b/gsd-ng/references/planning-config.md
@@ -341,19 +341,81 @@ Snapshot builds append `+{short_hash}` (e.g., `1.2.3+abc1234`) per SemVer 2.0.0 
 
 ### Submodule-Aware Git Operations
 
-When the workspace contains git submodules (`.gitmodules` exists), GSD automatically routes git push, PR creation, and branch operations to the correct repository:
+When the workspace contains git submodules (`.gitmodules` exists), GSD automatically routes git push, PR creation, and branch operations to the correct repository.
+
+#### Schema: `git.submodules.<name>`
+
+Per-submodule settings live under `git.submodules.<name>` where `<name>` is the **directory basename** of the submodule (e.g. for path `libs/anvil`, use `anvil`). Per-submodule keys are merged **over** the global `git.*` block — global values are the fallback, per-submodule values take precedence.
+
+> **Note (deprecated):** `git.submodule.*` (singular, no name key) was an earlier incorrect form that never worked. The only singular key the code recognizes is the deprecated `git.submodule.workspace_branch` (emit a warning). Always use the plural `git.submodules.<name>.*` form.
+
+#### Supported per-submodule keys
+
+All keys from the `git.*` global scope are also valid per-submodule. The validated allowlist is:
+
+| Key | Default (from global `git.*`) | Description |
+|-----|-------------------------------|-------------|
+| `target_branch` | `"main"` | Override the integration branch for submodule PRs |
+| `branching_strategy` | `"none"` | Branch strategy: `none`, `phase`, `milestone` |
+| `phase_branch_template` | `"gsd/phase-{phase}-{slug}"` | Template for phase branches |
+| `milestone_branch_template` | `"gsd/milestone-{milestone}-{slug}"` | Template for milestone branches |
+| `review_branch_template` | `null` (uses default) | Template for review/PR branches (e.g. `"{type}/{slug}"`) |
+| `remote` | `"origin"` | Git remote name for push/PR operations |
+| `auto_push` | `false` | Automatically push branch before PR creation |
+| `platform` | (auto-detected) | Force platform: `github`, `gitlab`, `forgejo`, `gitea` |
+| `pr_template` | `null` | Path to PR body template file |
+| `pr_draft` | `true` | Create PR as draft |
+| `commit_format` | `"conventional"` | Commit message format |
+| `commit_template` | `null` | Path to commit message template |
+| `versioning_scheme` | `"semver"` | Versioning scheme |
+| `type_aliases` | `null` | Conventional commit type aliases map |
+| `ssh_check` | `true` | Verify SSH key before push |
+
+#### Example configuration
+
+```json
+{
+  "git": {
+    "target_branch": "main",
+    "auto_push": false,
+    "submodules": {
+      "anvil": {
+        "target_branch": "develop",
+        "platform": "forgejo",
+        "review_branch_template": "{type}/{slug}",
+        "pr_draft": true
+      },
+      "gsd-ng": {
+        "platform": "github",
+        "target_branch": "develop",
+        "branching_strategy": "phase",
+        "review_branch_template": "{type}/{slug}"
+      }
+    }
+  }
+}
+```
+
+#### Resolution order
 
 1. **Auto-detection:** `git-context` inspects `git diff` to identify which submodule has changes
-2. **Remote resolution:** Uses the submodule's own `origin` remote, not the workspace remote
-3. **Target branch:** Reads from `git.submodule.target_branch` config, falls back to git tracking info, then `main`
-4. **Platform detection:** `git-context` includes `platform`, `cli`, `cli_installed` fields derived from the submodule's remote URL
+2. **Remote resolution:** Uses the submodule's own configured `remote` (default `origin`), not the workspace remote
+3. **Target branch:** Reads from `git.submodules.<name>.target_branch` (merged over global `git.target_branch`), falls back to git tracking info, then `main`
+4. **Platform detection:** Per-submodule `platform` key (when set) is passed directly to `detect-platform`, bypassing the inner `loadConfig` that would otherwise look inside the submodule directory (which has no `.planning/`). If `platform` is not set, URL-based auto-detection from the submodule's remote URL is used.
 
-| Config Key | Default | Description |
-|------------|---------|-------------|
-| `git.submodule.target_branch` | (auto-detect) | Override the target branch for submodule PRs |
-| `git.submodule.remote` | `"origin"` | Override the remote name used for submodule git operations |
+#### Platform and self-hosted hosts
 
-**When to configure:** Set `git.submodule.target_branch` when the submodule's integration branch differs from what git tracking reports. Common case: submodule tracks `develop` but git reports `main`.
+> **Self-hosted caveat:** `detect-platform` auto-detects platform only for known public hosts: `github.com`, `gitlab.com`, `codeberg.org`, `gitea.com`. Any self-hosted instance (e.g. `git.example.com`, `git.company.internal`) **will NOT be auto-detected** — its URL does not match the host map. You **must** set `platform` explicitly in the submodule config.
+
+Example for a self-hosted Forgejo instance:
+
+```json
+"submodules": {
+  "myproject": {
+    "platform": "forgejo"
+  }
+}
+```
 
 **Multi-submodule workspaces:** If multiple submodules have uncommitted changes, GSD surfaces the ambiguity and asks the user to resolve before continuing with push or PR creation.
 

--- a/gsd-ng/references/planning-config.md
+++ b/gsd-ng/references/planning-config.md
@@ -358,14 +358,14 @@ All keys from the `git.*` global scope are also valid per-submodule. The validat
 | `target_branch` | `"main"` | Override the integration branch for submodule PRs |
 | `branching_strategy` | `"none"` | Branch strategy: `none`, `phase`, `milestone` |
 | `phase_branch_template` | `"gsd/phase-{phase}-{slug}"` | Template for phase branches |
-| `milestone_branch_template` | `"gsd/milestone-{milestone}-{slug}"` | Template for milestone branches |
+| `milestone_branch_template` | `"gsd/{milestone}-{slug}"` | Template for milestone branches |
 | `review_branch_template` | `null` (uses default) | Template for review/PR branches (e.g. `"{type}/{slug}"`) |
 | `remote` | `"origin"` | Git remote name for push/PR operations |
 | `auto_push` | `false` | Automatically push branch before PR creation |
 | `platform` | (auto-detected) | Force platform: `github`, `gitlab`, `forgejo`, `gitea` |
 | `pr_template` | `null` | Path to PR body template file |
 | `pr_draft` | `true` | Create PR as draft |
-| `commit_format` | `"conventional"` | Commit message format |
+| `commit_format` | `"gsd"` | Commit message format |
 | `commit_template` | `null` | Path to commit message template |
 | `versioning_scheme` | `"semver"` | Versioning scheme |
 | `type_aliases` | `null` | Conventional commit type aliases map |

--- a/gsd-ng/references/planning-config.md
+++ b/gsd-ng/references/planning-config.md
@@ -359,7 +359,7 @@ All keys from the `git.*` global scope are also valid per-submodule. The validat
 | `branching_strategy` | `"none"` | Branch strategy: `none`, `phase`, `milestone` |
 | `phase_branch_template` | `"gsd/phase-{phase}-{slug}"` | Template for phase branches |
 | `milestone_branch_template` | `"gsd/{milestone}-{slug}"` | Template for milestone branches |
-| `review_branch_template` | `null` (uses default) | Template for review/PR branches (e.g. `"{type}/{slug}"`) |
+| `review_branch_template` | `null` | Template for review/PR branches (e.g. `"{type}/{slug}"`) — see note below |
 | `remote` | `"origin"` | Git remote name for push/PR operations |
 | `auto_push` | `false` | Automatically push branch before PR creation |
 | `platform` | (auto-detected) | Force platform: `github`, `gitlab`, `forgejo`, `gitea` |
@@ -370,6 +370,8 @@ All keys from the `git.*` global scope are also valid per-submodule. The validat
 | `versioning_scheme` | `"semver"` | Versioning scheme |
 | `type_aliases` | `null` | Conventional commit type aliases map |
 | `ssh_check` | `true` | Verify SSH key before push |
+
+> **Note:** `review_branch_template` and `type_aliases` are the two exceptions in the submodule path — when unset they resolve to `null` rather than the global `git.*` default (unlike `phase_branch_template`/`milestone_branch_template`, which do fall back to their built-in defaults). Set them explicitly per submodule if you need non-default review-branch naming or type aliases.
 
 #### Example configuration
 

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -538,10 +538,38 @@ Edit? (enter to accept, or type new title)
 Create the PR/MR using the platform-specific CLI. The body file (`$PR_BODY_FILE`) has been sanitized of `<untrusted-content>` wrapper tags by the `sanitize_outbound` step — external systems should never receive these internal GSD tags.
 
 ```bash
-# Determine draft flag
+# Determine draft flag / title prefix per platform:
+#
+#   github / gitlab: support --draft flag natively.
+#
+#   forgejo (fj pr create): has NO --draft flag. A PR is a draft when the title
+#   is prefixed with "WIP: " — fj recognizes this prefix and marks the PR as draft.
+#   Ref: https://codeberg.org/forgejo/cli (fj pr create docs).
+#
+#   gitea (tea pr create): tea v0.9+ supports `--type draft` to create a draft PR.
+#   If you are on an older tea that does not support --type, fall back to the WIP
+#   title prefix (same mechanism as forgejo) — the Gitea API accepts WIP-prefixed
+#   titles as draft indicators on older versions. The current implementation uses
+#   `--type draft` which requires tea >= 0.9.
+
 DRAFT_FLAG=""
 if [ "$PR_DRAFT" = "true" ]; then
   DRAFT_FLAG="--draft"
+fi
+
+# For forgejo and gitea, adjust the title to signal draft mode.
+EFFECTIVE_TITLE="$PR_TITLE"
+if [ "$PR_DRAFT" = "true" ]; then
+  case "$PLATFORM" in
+    forgejo)
+      # Forgejo draft = WIP: title prefix (no --draft flag in fj CLI)
+      EFFECTIVE_TITLE="WIP: $PR_TITLE"
+      ;;
+    gitea)
+      # Gitea draft via tea --type draft (tea >= 0.9). WIP prefix is the fallback
+      # for older tea versions; not prepended here since --type draft is passed below.
+      ;;
+  esac
 fi
 
 case "$PLATFORM" in
@@ -549,7 +577,7 @@ case "$PLATFORM" in
     PR_URL=$(gh pr create \
       --base "$PUSH_TARGET" \
       --head "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
+      --title "$EFFECTIVE_TITLE" \
       --body-file "$PR_BODY_FILE" \
       $DRAFT_FLAG 2>&1)
     PR_EXIT=$?
@@ -559,27 +587,38 @@ case "$PLATFORM" in
     PR_URL=$(glab mr create \
       --target-branch "$PUSH_TARGET" \
       --source-branch "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
+      --title "$EFFECTIVE_TITLE" \
       --description "$(cat "$PR_BODY_FILE")" \
       $DRAFT_FLAG 2>&1)
     PR_EXIT=$?
     ;;
 
   forgejo)
+    # Draft mode: title is prefixed with "WIP: " above (no --draft flag in fj).
     PR_URL=$(fj pr create \
       --base "$PUSH_TARGET" \
       --head "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
+      --title "$EFFECTIVE_TITLE" \
       --body "$(cat "$PR_BODY_FILE")" 2>&1)
     PR_EXIT=$?
     ;;
 
   gitea)
-    PR_URL=$(tea pr create \
-      --base "$PUSH_TARGET" \
-      --head "$HEAD_BRANCH" \
-      --title "$PR_TITLE" \
-      --description "$(cat "$PR_BODY_FILE")" 2>&1)
+    # Draft mode: tea >= 0.9 supports --type draft. Older tea: use WIP: prefix instead.
+    if [ "$PR_DRAFT" = "true" ]; then
+      PR_URL=$(tea pr create \
+        --base "$PUSH_TARGET" \
+        --head "$HEAD_BRANCH" \
+        --title "$EFFECTIVE_TITLE" \
+        --description "$(cat "$PR_BODY_FILE")" \
+        --type draft 2>&1)
+    else
+      PR_URL=$(tea pr create \
+        --base "$PUSH_TARGET" \
+        --head "$HEAD_BRANCH" \
+        --title "$EFFECTIVE_TITLE" \
+        --description "$(cat "$PR_BODY_FILE")" 2>&1)
+    fi
     PR_EXIT=$?
     ;;
 
@@ -642,6 +681,7 @@ fi
 - [ ] Review branch created and squashed from work branch (for phase/milestone strategies)
 - [ ] PR description built from template precedence chain (user config > repo template > GSD default)
 - [ ] PR created via platform CLI (gh pr create / glab mr create / fj pr create / tea pr create)
+- [ ] Draft mode applied correctly: github/gitlab use --draft flag; forgejo prepends "WIP: " to title (no --draft flag in fj); gitea uses tea --type draft (tea >= 0.9)
 - [ ] PR URL displayed to user
 - [ ] Work branch restored as current branch after PR creation
 - [ ] force-with-lease used for review branch re-push (squash rewrites history)

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -11759,3 +11759,185 @@ describe('commands.cjs branch defaults part 2 (60-11)', () => {
     assert.ok(ops.includes('close'));
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Bug 1+2: per-submodule platform override + Bug 3: fj CLI probe
+// Tests A-F: cmdDetectPlatform platformOverride param and robust CLI presence
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('cmdDetectPlatform: platformOverride parameter (Bugs 1+2)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // Test A: Override precedence — platformOverride 4th arg takes priority regardless of config/remote
+  test('Test A: platformOverride=forgejo sets platform=forgejo with source=config', () => {
+    // tmpDir has no .planning/config.json with platform, and no remote pointing at forgejo
+    // Call cmdDetectPlatform directly with the 4th platformOverride argument
+    const commandsPath = path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'commands.cjs');
+    const commands = require(commandsPath);
+    const result = commands.cmdDetectPlatform(tmpDir, null, true, 'forgejo');
+    assert.strictEqual(result.platform, 'forgejo', 'platform should be forgejo from override');
+    assert.strictEqual(result.source, 'config', 'source should be config when override provided');
+  });
+
+  // Test B: No override + github URL → URL-based auto-detection still works (backward compat)
+  test('Test B: no platformOverride with github URL returns platform=github via detection', () => {
+    const { execSync } = require('node:child_process');
+    execSync('git remote add origin https://github.com/example/test.git', {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
+    const r = runGsdTools(['detect-platform', '--json'], tmpDir);
+    assert.ok(r.success, `Command failed: ${r.error}`);
+    const parsed = JSON.parse(r.output);
+    assert.strictEqual(parsed.platform, 'github', 'should auto-detect github from URL');
+    assert.strictEqual(parsed.source, 'detected', 'source should be detected for URL-based');
+  });
+
+  // Test C: resolveGitContext integration — submodule with platform override in workspace config
+  test('Test C: submodule platform override flows through resolveGitContext to init', () => {
+    const { execSync: execSyncC } = require('node:child_process');
+    const { createSubmoduleWorkspace } = require('./helpers.cjs');
+
+    // Create workspace with a submodule pointing at a self-hosted (unknown) host
+    const { workspaceDir } = createSubmoduleWorkspace(
+      [{ name: 'mymod', path: 'mymod', remoteUrl: 'ssh://git@git.selfhosted.example:3022/org/repo.git' }],
+      { roadmap: true, state: true },
+    );
+
+    // Set per-submodule platform=forgejo in workspace-root config
+    const config = {
+      git: {
+        submodules: {
+          mymod: {
+            platform: 'forgejo',
+          },
+        },
+      },
+    };
+    fs.writeFileSync(
+      path.join(workspaceDir, '.planning', 'config.json'),
+      JSON.stringify(config, null, 2),
+    );
+
+    // Create a staged change inside the submodule so resolveGitContext identifies it
+    const subDir = path.join(workspaceDir, 'mymod');
+    fs.writeFileSync(path.join(subDir, 'newfile.txt'), 'change');
+    execSyncC('git add newfile.txt', { cwd: subDir, stdio: 'pipe' });
+
+    // Also update the workspace gitlink so git diff sees the submodule as modified
+    const newSha = execSyncC('git rev-parse HEAD', { cwd: subDir, encoding: 'utf-8', stdio: 'pipe' }).trim();
+    execSyncC(
+      `git update-index --cacheinfo 160000,${newSha},mymod`,
+      { cwd: workspaceDir, stdio: 'pipe' },
+    );
+
+    const r = runGsdTools(['init', 'execute-phase', '1', '--json'], workspaceDir);
+    // init may succeed or fail due to test infra; we care about platform in git context
+    // If it fails for non-platform reasons, parse output if available
+    const outputStr = r.output || r.stderr || '';
+    if (outputStr.includes('"platform"')) {
+      try {
+        const parsed = JSON.parse(outputStr);
+        const gitPlatform = parsed.git && parsed.git.platform;
+        if (gitPlatform !== null) {
+          assert.strictEqual(gitPlatform, 'forgejo', 'git.platform must be forgejo from submodule override');
+        }
+      } catch {
+        // If JSON parse fails the field is embedded — verify presence
+        assert.ok(outputStr.includes('"forgejo"') || outputStr.includes('forgejo'), 'forgejo platform must appear in init output');
+      }
+    }
+    // Cleanup
+    const { cleanup: cleanupHelper } = require('./helpers.cjs');
+    cleanupHelper(workspaceDir);
+  });
+});
+
+describe('CLI probe robustness: fj/forgejo and missing binary (Bug 3)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // Test D: fj probe uses `version` subcommand, not --version (which fj rejects)
+  test('Test D: forgejo platform probe for fj does not depend on --version flag', () => {
+    const config = { git: { platform: 'forgejo' } };
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify(config, null, 2),
+    );
+    const r = runGsdTools(['detect-platform', '--json'], tmpDir);
+    assert.ok(r.success, `detect-platform should not crash: ${r.error}`);
+    const parsed = JSON.parse(r.output);
+    assert.strictEqual(parsed.platform, 'forgejo', 'platform must be forgejo');
+    // cli_installed must be a boolean (true or false) — not an error/crash
+    assert.ok(
+      parsed.cli_installed === true || parsed.cli_installed === false,
+      `cli_installed must be boolean, got: ${JSON.stringify(parsed.cli_installed)}`,
+    );
+    // cli must be 'fj'
+    assert.strictEqual(parsed.cli, 'fj', 'cli must be fj for forgejo');
+  });
+
+  // Test E: absent binary → cli_installed=false, no crash (uses forgejo/fj which is absent in CI)
+  test('Test E: missing CLI binary reports cli_installed=false without crashing', () => {
+    const config = { git: { platform: 'forgejo' } };
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify(config, null, 2),
+    );
+    const r = runGsdTools(['detect-platform', '--json'], tmpDir);
+    assert.ok(r.success, `Command must not crash when CLI absent: ${r.error}`);
+    const parsed = JSON.parse(r.output);
+    // cli_installed must be a boolean regardless of whether fj is installed
+    assert.ok(
+      parsed.cli_installed === true || parsed.cli_installed === false,
+      `cli_installed must be boolean, got: ${JSON.stringify(parsed.cli_installed)}`,
+    );
+  });
+
+  // Test F: regression — gh/glab/tea still report installed correctly via their probes
+  test('Test F: gh/glab/tea CLI probe works (regression: --version still used for these)', () => {
+    for (const [platform, cli] of [['github', 'gh'], ['gitlab', 'glab'], ['gitea', 'tea']]) {
+      const subDir = fs.mkdtempSync(path.join(require('./helpers.cjs').resolveTmpDir(), 'gsd-cli-test-'));
+      try {
+        fs.mkdirSync(path.join(subDir, '.planning', 'phases'), { recursive: true });
+        const config = { git: { platform } };
+        fs.writeFileSync(
+          path.join(subDir, '.planning', 'config.json'),
+          JSON.stringify(config, null, 2),
+        );
+        // Init git so detect-platform can run
+        const { execSync: exec2 } = require('node:child_process');
+        exec2('git init', { cwd: subDir, stdio: 'pipe' });
+        exec2('git config user.email "t@t.com"', { cwd: subDir, stdio: 'pipe' });
+        exec2('git config user.name "T"', { cwd: subDir, stdio: 'pipe' });
+
+        const r = runGsdTools(['detect-platform', '--json'], subDir);
+        assert.ok(r.success, `detect-platform crashed for ${platform}: ${r.error}`);
+        const parsed = JSON.parse(r.output);
+        assert.strictEqual(parsed.platform, platform, `platform should be ${platform}`);
+        assert.strictEqual(parsed.cli, cli, `cli should be ${cli} for ${platform}`);
+        assert.ok(
+          parsed.cli_installed === true || parsed.cli_installed === false,
+          `cli_installed should be boolean for ${platform}, got: ${JSON.stringify(parsed.cli_installed)}`,
+        );
+      } finally {
+        cleanup(subDir);
+      }
+    }
+  });
+});

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -11801,8 +11801,8 @@ describe('cmdDetectPlatform: platformOverride parameter (Bugs 1+2)', () => {
     assert.strictEqual(parsed.source, 'detected', 'source should be detected for URL-based');
   });
 
-  // Test C: resolveGitContext integration — submodule with platform override in workspace config
-  test('Test C: submodule platform override flows through resolveGitContext to init', () => {
+  // Test C: submodule platform override resolves through resolveGitContext unconditionally
+  test('Test C: submodule platform override flows through resolveGitContext', () => {
     const { execSync: execSyncC } = require('node:child_process');
     const { createSubmoduleWorkspace } = require('./helpers.cjs');
 
@@ -11839,25 +11839,37 @@ describe('cmdDetectPlatform: platformOverride parameter (Bugs 1+2)', () => {
       { cwd: workspaceDir, stdio: 'pipe' },
     );
 
-    const r = runGsdTools(['init', 'execute-phase', '1', '--json'], workspaceDir);
-    // init may succeed or fail due to test infra; we care about platform in git context
-    // If it fails for non-platform reasons, parse output if available
-    const outputStr = r.output || r.stderr || '';
-    if (outputStr.includes('"platform"')) {
-      try {
-        const parsed = JSON.parse(outputStr);
-        const gitPlatform = parsed.git && parsed.git.platform;
-        if (gitPlatform !== null) {
-          assert.strictEqual(gitPlatform, 'forgejo', 'git.platform must be forgejo from submodule override');
-        }
-      } catch {
-        // If JSON parse fails the field is embedded — verify presence
-        assert.ok(outputStr.includes('"forgejo"') || outputStr.includes('forgejo'), 'forgejo platform must appear in init output');
-      }
-    }
-    // Cleanup
+    // Resolve git context directly and assert the override flows through — unconditionally.
+    const workspace = require(
+      path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'workspace.cjs'),
+    );
+    const ctx = workspace.resolveGitContext(workspaceDir);
+    assert.strictEqual(ctx.is_submodule, true, 'workspace must resolve as a submodule context');
+    assert.strictEqual(ctx.platform, 'forgejo', 'platform must be forgejo from submodule override');
+    assert.strictEqual(ctx.cli, 'fj', 'cli must be fj for forgejo');
+
     const { cleanup: cleanupHelper } = require('./helpers.cjs');
     cleanupHelper(workspaceDir);
+  });
+
+  // Test G: 4th-arg override outranks both config platform and a conflicting remote URL
+  test('Test G: platformOverride wins over config platform and remote URL', () => {
+    const { execSync } = require('node:child_process');
+    // config says gitea, remote URL says github, override says forgejo → forgejo must win
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ git: { platform: 'gitea' } }, null, 2),
+    );
+    execSync('git remote add origin https://github.com/example/test.git', {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
+    const commands = require(
+      path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'commands.cjs'),
+    );
+    const result = commands.cmdDetectPlatform(tmpDir, null, true, 'forgejo');
+    assert.strictEqual(result.platform, 'forgejo', 'override must beat config and URL');
+    assert.strictEqual(result.source, 'config', 'source should be config for an override');
   });
 });
 
@@ -11872,72 +11884,80 @@ describe('CLI probe robustness: fj/forgejo and missing binary (Bug 3)', () => {
     cleanup(tmpDir);
   });
 
-  // Test D: fj probe uses `version` subcommand, not --version (which fj rejects)
-  test('Test D: forgejo platform probe for fj does not depend on --version flag', () => {
-    const config = { git: { platform: 'forgejo' } };
-    fs.writeFileSync(
-      path.join(tmpDir, '.planning', 'config.json'),
-      JSON.stringify(config, null, 2),
+  // Test D: fj is probed with the `version` subcommand, not --version (which fj rejects)
+  test('Test D: fj probe uses `version` subcommand, not --version', () => {
+    const commands = require(
+      path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'commands.cjs'),
     );
-    const r = runGsdTools(['detect-platform', '--json'], tmpDir);
-    assert.ok(r.success, `detect-platform should not crash: ${r.error}`);
-    const parsed = JSON.parse(r.output);
-    assert.strictEqual(parsed.platform, 'forgejo', 'platform must be forgejo');
-    // cli_installed must be a boolean (true or false) — not an error/crash
-    assert.ok(
-      parsed.cli_installed === true || parsed.cli_installed === false,
-      `cli_installed must be boolean, got: ${JSON.stringify(parsed.cli_installed)}`,
-    );
-    // cli must be 'fj'
-    assert.strictEqual(parsed.cli, 'fj', 'cli must be fj for forgejo');
+    const cp = require('node:child_process');
+    const origSpawn = cp.spawnSync;
+    const calls = [];
+    cp.spawnSync = (cmd, cmdArgs) => {
+      calls.push({ cmd, args: cmdArgs });
+      return { status: 0, error: undefined };
+    };
+    try {
+      const result = commands.cmdDetectPlatform(tmpDir, null, true, 'forgejo');
+      assert.strictEqual(result.cli, 'fj', 'cli must be fj for forgejo');
+      const fjCall = calls.find((c) => c.cmd === 'fj');
+      assert.ok(fjCall, 'fj binary must be probed');
+      assert.deepStrictEqual(
+        fjCall.args,
+        ['version'],
+        'fj must be probed with `version`, not `--version`',
+      );
+      assert.strictEqual(result.cli_installed, true, 'exit status 0 => cli_installed');
+    } finally {
+      cp.spawnSync = origSpawn;
+    }
   });
 
-  // Test E: absent binary → cli_installed=false, no crash (uses forgejo/fj which is absent in CI)
-  test('Test E: missing CLI binary reports cli_installed=false without crashing', () => {
-    const config = { git: { platform: 'forgejo' } };
-    fs.writeFileSync(
-      path.join(tmpDir, '.planning', 'config.json'),
-      JSON.stringify(config, null, 2),
+  // Test E: a missing binary (spawn ENOENT) reports cli_installed=false without crashing
+  test('Test E: missing CLI binary reports cli_installed=false (ENOENT)', () => {
+    const commands = require(
+      path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'commands.cjs'),
     );
-    const r = runGsdTools(['detect-platform', '--json'], tmpDir);
-    assert.ok(r.success, `Command must not crash when CLI absent: ${r.error}`);
-    const parsed = JSON.parse(r.output);
-    // cli_installed must be a boolean regardless of whether fj is installed
-    assert.ok(
-      parsed.cli_installed === true || parsed.cli_installed === false,
-      `cli_installed must be boolean, got: ${JSON.stringify(parsed.cli_installed)}`,
-    );
+    const cp = require('node:child_process');
+    const origSpawn = cp.spawnSync;
+    cp.spawnSync = () => ({
+      error: Object.assign(new Error('spawn fj ENOENT'), { code: 'ENOENT' }),
+      status: null,
+    });
+    try {
+      const result = commands.cmdDetectPlatform(tmpDir, null, true, 'forgejo');
+      assert.strictEqual(result.cli, 'fj', 'cli must be fj for forgejo');
+      assert.strictEqual(result.cli_installed, false, 'ENOENT must report not installed');
+    } finally {
+      cp.spawnSync = origSpawn;
+    }
   });
 
-  // Test F: regression — gh/glab/tea still report installed correctly via their probes
-  test('Test F: gh/glab/tea CLI probe works (regression: --version still used for these)', () => {
-    for (const [platform, cli] of [['github', 'gh'], ['gitlab', 'glab'], ['gitea', 'tea']]) {
-      const subDir = fs.mkdtempSync(path.join(require('./helpers.cjs').resolveTmpDir(), 'gsd-cli-test-'));
-      try {
-        fs.mkdirSync(path.join(subDir, '.planning', 'phases'), { recursive: true });
-        const config = { git: { platform } };
-        fs.writeFileSync(
-          path.join(subDir, '.planning', 'config.json'),
-          JSON.stringify(config, null, 2),
+  // Test F: gh/glab/tea remain on --version (regression guard for the unchanged probe path)
+  test('Test F: gh/glab/tea probe with --version (unchanged)', () => {
+    const commands = require(
+      path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'commands.cjs'),
+    );
+    const cp = require('node:child_process');
+    const origSpawn = cp.spawnSync;
+    try {
+      for (const [platform, cli] of [['github', 'gh'], ['gitlab', 'glab'], ['gitea', 'tea']]) {
+        const calls = [];
+        cp.spawnSync = (cmd, cmdArgs) => {
+          calls.push({ cmd, args: cmdArgs });
+          return { status: 0, error: undefined };
+        };
+        const result = commands.cmdDetectPlatform(tmpDir, null, true, platform);
+        assert.strictEqual(result.cli, cli, `cli must be ${cli} for ${platform}`);
+        const call = calls.find((c) => c.cmd === cli);
+        assert.ok(call, `${cli} binary must be probed`);
+        assert.deepStrictEqual(
+          call.args,
+          ['--version'],
+          `${cli} must probe with --version`,
         );
-        // Init git so detect-platform can run
-        const { execSync: exec2 } = require('node:child_process');
-        exec2('git init', { cwd: subDir, stdio: 'pipe' });
-        exec2('git config user.email "t@t.com"', { cwd: subDir, stdio: 'pipe' });
-        exec2('git config user.name "T"', { cwd: subDir, stdio: 'pipe' });
-
-        const r = runGsdTools(['detect-platform', '--json'], subDir);
-        assert.ok(r.success, `detect-platform crashed for ${platform}: ${r.error}`);
-        const parsed = JSON.parse(r.output);
-        assert.strictEqual(parsed.platform, platform, `platform should be ${platform}`);
-        assert.strictEqual(parsed.cli, cli, `cli should be ${cli} for ${platform}`);
-        assert.ok(
-          parsed.cli_installed === true || parsed.cli_installed === false,
-          `cli_installed should be boolean for ${platform}, got: ${JSON.stringify(parsed.cli_installed)}`,
-        );
-      } finally {
-        cleanup(subDir);
       }
+    } finally {
+      cp.spawnSync = origSpawn;
     }
   });
 });


### PR DESCRIPTION
## Summary

Fixes platform and CLI detection for submodule workspaces, surfaced while running `/gsd:create-pr` against a self-hosted Forgejo submodule.

## Bugs fixed

1. **Per-submodule `platform` override was a dead key** — `cmdDetectPlatform` now accepts an optional 4th `platformOverride` arg (takes precedence, `source='config'`); `resolveGitContext` passes the resolved platform through. Existing 3-arg callers unchanged.
2. **Config was read relative to the submodule directory** (which carries no config of its own), so the resolved platform was lost — it now reaches `cmdDetectPlatform` through the new parameter instead.
3. **CLI probe used `--version`, which Forgejo's `fj` rejects** → false "not installed". Replaced with a per-CLI probe-arg map (`fj → version`, `gh`/`glab`/`tea → --version`) plus correct ENOENT handling.
4. **Draft PRs ignored for Forgejo/Gitea** — `create-pr.md` now produces drafts: Forgejo via `WIP:` title prefix, Gitea via `tea pr create --type draft`. `gh`/`glab` `--draft` unchanged.
5. **Docs documented a non-existent singular `git.submodule.*` key** — rewrote `references/planning-config.md` to the real plural `git.submodules.<name>.*` schema, with a self-hosted-host caveat using a generic placeholder.

## Tests

New tests A–G in `tests/commands.test.cjs`: override precedence (incl. override > config > URL), URL auto-detect fallback, and exact probe-argv assertions (`fj → version`, `gh`/`glab`/`tea → --version`) with explicit ENOENT handling, all via a stubbed `spawnSync`. 746/746 pass; prettier `format:check` and the coverage gate are clean.
