### PR TITLE
chore: remove dead workspace_branch deprecation; record CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Submodule-aware PR creation now detects the platform and CLI correctly. `detect-platform` accepts a per-submodule `platform` override (previously a dead config key, because config was resolved relative to the submodule directory, which has no `.planning/`); the Forgejo `fj` CLI is now probed with its `version` subcommand instead of `--version` (which `fj` rejects, producing a false "not installed"); and `/gsd:create-pr` creates draft PRs on Forgejo (`WIP:` title prefix) and Gitea (`tea pr create --type draft`). The `git.submodules.<name>.*` per-submodule config schema is documented in `references/planning-config.md`.
+
+### Removed
+- Dropped the dead `git.submodule.workspace_branch` deprecation handling. The singular `git.submodule.*` form never worked and the key controlled no behavior, so `config-set`/`config-get` no longer special-case it or print a deprecation warning — it is now treated as an ordinary unknown key.
+
 ## [1.0.0-dev.14] - 2026-05-30
 
 ### Changed

--- a/gsd-ng/bin/lib/config.cjs
+++ b/gsd-ng/bin/lib/config.cjs
@@ -243,12 +243,6 @@ function cmdConfigSet(cwd, keyPath, value) {
 
   validateKnownConfigKeyPath(keyPath);
 
-  if (keyPath === 'git.submodule.workspace_branch') {
-    error(
-      'git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.',
-    );
-  }
-
   // model_profile is a domain-level setting, not a flat key/value.
   // Route users to the dedicated command so they get profile validation,
   // agent effort sync, and the restart notice.
@@ -310,12 +304,6 @@ function cmdConfigGet(cwd, keyPath, defaultValue) {
     error('Usage: config-get <key.path>');
   }
 
-  if (keyPath === 'git.submodule.workspace_branch') {
-    process.stderr.write(
-      'Warning: git.submodule.workspace_branch is deprecated — the workspace stays on git.target_branch when branching_strategy is none.\n',
-    );
-  }
-
   // Claude-only surface lock: profile/effort keys read as not-present on non-Claude runtimes.
   if (
     PROFILE_EFFORT_KEY_PATTERN.test(keyPath) &&
@@ -329,10 +317,7 @@ function cmdConfigGet(cwd, keyPath, defaultValue) {
     return;
   }
 
-  // Deprecated keys (warned about above) bypass the allowlist so callers
-  // can still read their value during migration.
   if (
-    keyPath !== 'git.submodule.workspace_branch' &&
     !VALID_CONFIG_KEYS.has(keyPath) &&
     !SUBMODULE_KEY_PATTERN.test(keyPath) &&
     !EFFORT_OVERRIDE_KEY_PATTERN.test(keyPath)

--- a/gsd-ng/references/planning-config.md
+++ b/gsd-ng/references/planning-config.md
@@ -345,9 +345,7 @@ When the workspace contains git submodules (`.gitmodules` exists), GSD automatic
 
 #### Schema: `git.submodules.<name>`
 
-Per-submodule settings live under `git.submodules.<name>` where `<name>` is the **directory basename** of the submodule (e.g. for path `libs/anvil`, use `anvil`). Per-submodule keys are merged **over** the global `git.*` block — global values are the fallback, per-submodule values take precedence.
-
-> **Note (deprecated):** `git.submodule.*` (singular, no name key) was an earlier incorrect form that never worked. The only singular key the code recognizes is the deprecated `git.submodule.workspace_branch` (emit a warning). Always use the plural `git.submodules.<name>.*` form.
+Per-submodule settings live under `git.submodules.<name>` (plural) where `<name>` is the **directory basename** of the submodule (e.g. for path `libs/anvil`, use `anvil`). Per-submodule keys are merged **over** the global `git.*` block — global values are the fallback, per-submodule values take precedence.
 
 #### Supported per-submodule keys
 

--- a/gsd-ng/workflows/create-pr.md
+++ b/gsd-ng/workflows/create-pr.md
@@ -188,7 +188,7 @@ if ! git -C "$GIT_CWD" ls-remote --heads "$PUSH_REMOTE" "$PUSH_TARGET" | grep -q
   echo "Available branches:"
   git -C "$GIT_CWD" ls-remote --heads "$PUSH_REMOTE" | head -10
   if [ "$IS_SUBMODULE" = "true" ]; then
-    echo "Set target branch: node gsd-tools.cjs config-set git.submodule.target_branch {branch}"
+    echo "Set target branch: node gsd-tools.cjs config-set git.submodules.<name>.target_branch {branch}"
   else
     echo "Set target branch: node gsd-tools.cjs config-set git.target_branch {branch}"
   fi

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -744,33 +744,6 @@ describe('Per-submodule config keys (SUBMOD-01)', () => {
     );
   });
 
-  test('SUBMOD-01c: config-set git.submodule.workspace_branch is rejected with deprecation message', () => {
-    const result = runGsdTools(
-      'config-set git.submodule.workspace_branch develop',
-      tmpDir,
-    );
-    assert.strictEqual(result.success, false, 'Should reject deprecated key');
-    assert.match(result.error || result.stderr || '', /deprecated/i);
-  });
-
-  test('SUBMOD-01d: config-get git.submodule.workspace_branch emits deprecation warning on stderr', () => {
-    // Write the value directly so config-get has something to read
-    const configPath = path.join(tmpDir, '.planning', 'config.json');
-    const existing = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
-    existing.git = existing.git || {};
-    existing.git.submodule = { workspace_branch: 'develop' };
-    fs.writeFileSync(configPath, JSON.stringify(existing, null, 2));
-
-    const result = runGsdTools(
-      'config-get git.submodule.workspace_branch',
-      tmpDir,
-    );
-    // Should succeed (returns value for migration) but stderr has warning
-    assert.match(
-      result.stderr || result.output || result.error || '',
-      /deprecated/i,
-    );
-  });
 });
 
 // ─── EFFORT_PROFILES ──────────────────────────────────────────────────────────
@@ -1641,23 +1614,31 @@ describe('cmdConfigGet defaultValue and traversal branches', () => {
     }
   });
 
-  test('emits deprecation warning on stderr for git.submodule.workspace_branch (with value present)', () => {
+  test('returns defaultValue when a valid key path traverses through a missing parent', () => {
     const tmpDir = createTempProject();
-    writeConfig(tmpDir, {
-      git: { submodule: { workspace_branch: 'develop' } },
-    });
+    writeConfig(tmpDir, {}); // no `workflow` object → path goes undefined mid-traversal
     try {
       const result = runGsdTools(
-        ['config-get', 'git.submodule.workspace_branch'],
+        ['config-get', 'workflow.research', '--default', 'fallback'],
         tmpDir,
       );
       assert.ok(result.success, `Command failed: ${result.error}`);
-      assert.match(
-        result.stderr,
-        /git\.submodule\.workspace_branch is deprecated/,
-        `Expected deprecation warning on stderr, got: ${result.stderr}`,
+      assert.strictEqual(result.output.trim(), 'fallback');
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('returns defaultValue when a valid key is unset under an existing parent', () => {
+    const tmpDir = createTempProject();
+    writeConfig(tmpDir, { workflow: {} }); // parent exists, leaf key undefined
+    try {
+      const result = runGsdTools(
+        ['config-get', 'workflow.research', '--default', 'fallback'],
+        tmpDir,
       );
-      assert.strictEqual(result.output.trim(), 'develop');
+      assert.ok(result.success, `Command failed: ${result.error}`);
+      assert.strictEqual(result.output.trim(), 'fallback');
     } finally {
       cleanup(tmpDir);
     }


### PR DESCRIPTION
Post-merge cleanup follow-up to #94.

## Removed
- The `git.submodule.workspace_branch` deprecation handling in `config.cjs` (`config-set` rejection, `config-get` stderr warning, and the allowlist-bypass special-case). The singular `git.submodule.*` form never worked and the key controlled no behavior, so it is now an ordinary unknown key.

## Fixed
- `create-pr.md` told submodule users to run `config-set git.submodule.target_branch` (singular, invalid) — corrected to the plural `git.submodules.<name>.target_branch`.

## Docs
- Dropped the deprecation blockquote from `references/planning-config.md`.
- **CHANGELOG**: recorded the submodule platform/CLI detection fix (#94, which merged without a changelog entry) and this removal under `[Unreleased]`.

## Tests
- Removed the 3 deprecation-warning tests.
- Added 2 `config-get` default-fallback tests so `config.cjs` branch coverage stays ≥ 90% after the removal (gate: 22/22 green, 92/92 in config.test.cjs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)