### PR TITLE
fix: update-check cache is local-first (no false /gsd:update banner)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- The update-check cache is now local-first: a project with a local GSD install (`.claude/gsd-ng/VERSION` present) reads and writes its own cache under `<project>/.claude/cache/gsd-update-check.json` instead of the global `~/.claude/cache/`. When both a local and a global install exist, the local cache always wins so two projects on different versions can never poison each other's banner. A global-only install continues to use the global cache path. `CLAUDE_CONFIG_DIR` with `gsd-ng/VERSION` takes top precedence as before. Both the writer (`gsd-check-update.js`) and the reader (`gsd-statusline.js`) derive the cache path from a single shared helper (`bin/lib/cache-path.cjs`) so they can never drift.
+- The statusline now suppresses the `⬆ /gsd:update` banner when `cache.installed` does not match the live local `VERSION` file. This guards the within-session gap after running `/gsd:update` before the next TTL refresh writes a new cache — the stale "update available" entry no longer shows the banner for an already-updated install.
+- **Migration:** A stale global cache (`~/.claude/cache/gsd-update-check.json`) left by older versions is automatically ignored for local installs because the reader now resolves the local cache path and never reads the global one.
+
 ## [1.0.0-dev.15] - 2026-05-31
 
 ### Fixed

--- a/gsd-ng/bin/lib/cache-path.cjs
+++ b/gsd-ng/bin/lib/cache-path.cjs
@@ -1,6 +1,5 @@
+// Shared between hooks/gsd-check-update.js (writer) and hooks/gsd-statusline.js (reader). DO NOT duplicate — require this module so the two cache paths can never drift.
 'use strict';
-// Shared between hooks/gsd-check-update.js (writer) and hooks/gsd-statusline.js (reader)
-// — DO NOT inline; both require this so cache paths can never drift.
 
 const fs = require('fs');
 const path = require('path');
@@ -8,101 +7,65 @@ const path = require('path');
 const CACHE_FILENAME = 'gsd-update-check.json';
 
 /**
- * Detect the GSD config directory for a given base directory.
- * Returns the variant dir (e.g. <base>/.claude) when an install is present,
- * or null when no install is found under this base.
- *
- * Variant order (same as gsd-check-update.js detectConfigDir):
- *   1. env.CLAUDE_CONFIG_DIR with gsd-ng/VERSION present
- *   2. <base>/.claude/gsd-ng/VERSION
- *   3. <base>/.github/gsd-ng/VERSION
- *   4. <base>/.copilot/gsd-ng/VERSION
- *
- * Unlike the hook's private copy, this version returns null on miss
- * so callers can distinguish "install present" from "fallback path".
- *
- * @param {string} baseDir - Directory to probe
- * @param {object} [env] - Environment object (defaults to process.env)
+ * Detect the GSD config dir under baseDir (CLAUDE_CONFIG_DIR, then .claude/.github/.copilot).
+ * Returns null when no install is present — unlike the hooks' private copy, which falls
+ * back to a default path. The null lets callers distinguish "install present" from "absent".
+ * @param {string} baseDir
+ * @param {object} [env]
  * @returns {string|null}
  */
 function detectConfigDir(baseDir, env) {
   const e = env || process.env;
-  // Env override takes absolute top precedence (only when VERSION is present there too)
   const envDir = e.CLAUDE_CONFIG_DIR;
   if (envDir && fs.existsSync(path.join(envDir, 'gsd-ng', 'VERSION'))) {
     return envDir;
   }
-  // Claude Code local: .claude/gsd-ng/VERSION
-  if (fs.existsSync(path.join(baseDir, '.claude', 'gsd-ng', 'VERSION'))) {
-    return path.join(baseDir, '.claude');
-  }
-  // Copilot local: .github/gsd-ng/VERSION
-  if (fs.existsSync(path.join(baseDir, '.github', 'gsd-ng', 'VERSION'))) {
-    return path.join(baseDir, '.github');
-  }
-  // Copilot global: .copilot/gsd-ng/VERSION
-  if (fs.existsSync(path.join(baseDir, '.copilot', 'gsd-ng', 'VERSION'))) {
-    return path.join(baseDir, '.copilot');
+  for (const variant of ['.claude', '.github', '.copilot']) {
+    if (fs.existsSync(path.join(baseDir, variant, 'gsd-ng', 'VERSION'))) {
+      return path.join(baseDir, variant);
+    }
   }
   return null;
 }
 
 /**
- * Resolve the cache DIRECTORY for gsd-update-check.json using
- * local-before-global precedence:
- *
- *   1. env.CLAUDE_CONFIG_DIR with gsd-ng/VERSION → join(envDir, 'cache')
- *   2. Local install under cwd → join(localConfigDir, 'cache')   [local wins]
- *   3. Global install under homeDir → join(globalConfigDir, 'cache')
- *   4. Fallback → join(env.CLAUDE_CONFIG_DIR || join(homeDir, '.claude'), 'cache')
- *
+ * Resolve the cache directory with local-before-global precedence:
+ * CLAUDE_CONFIG_DIR > local install under cwd > global install under homeDir > default.
  * @param {object} opts
- * @param {string} opts.cwd     - Current working / project directory
- * @param {string} opts.homeDir - User home directory
- * @param {object} [opts.env]   - Environment object (defaults to process.env)
- * @returns {string} Absolute path to the cache directory
+ * @param {string} opts.cwd
+ * @param {string} opts.homeDir
+ * @param {object} [opts.env]
+ * @returns {string}
  */
 function resolveUpdateCacheDir({ cwd, homeDir, env }) {
   const e = env || process.env;
 
-  // 1. Env override with VERSION present
   const envDir = e.CLAUDE_CONFIG_DIR;
   if (envDir && fs.existsSync(path.join(envDir, 'gsd-ng', 'VERSION'))) {
     return path.join(envDir, 'cache');
   }
 
-  // 2. Local install (project dir)
   const localConfig = detectConfigDir(cwd, e);
   if (localConfig) {
     return path.join(localConfig, 'cache');
   }
 
-  // 3. Global install (home dir) — only check base variants, NOT env (already handled)
-  // We need to probe homeDir variants directly (no env re-check to avoid double-counting).
-  if (fs.existsSync(path.join(homeDir, '.claude', 'gsd-ng', 'VERSION'))) {
-    return path.join(homeDir, '.claude', 'cache');
-  }
-  if (fs.existsSync(path.join(homeDir, '.github', 'gsd-ng', 'VERSION'))) {
-    return path.join(homeDir, '.github', 'cache');
-  }
-  if (fs.existsSync(path.join(homeDir, '.copilot', 'gsd-ng', 'VERSION'))) {
-    return path.join(homeDir, '.copilot', 'cache');
+  // Probe homeDir variants directly — passing e to detectConfigDir would re-check the env dir.
+  for (const variant of ['.claude', '.github', '.copilot']) {
+    if (fs.existsSync(path.join(homeDir, variant, 'gsd-ng', 'VERSION'))) {
+      return path.join(homeDir, variant, 'cache');
+    }
   }
 
-  // 4. Fallback (no install found anywhere)
-  const fallbackBase = envDir || path.join(homeDir, '.claude');
-  return path.join(fallbackBase, 'cache');
+  return path.join(envDir || path.join(homeDir, '.claude'), 'cache');
 }
 
 /**
- * Resolve the absolute path to gsd-update-check.json using local-before-global
- * precedence. Both the writer (gsd-check-update.js) and the reader
- * (gsd-statusline.js) must call this so their cache paths cannot drift.
- *
+ * Absolute path to gsd-update-check.json. See resolveUpdateCacheDir for precedence.
  * @param {object} opts
- * @param {string} opts.cwd     - Current working / project directory
- * @param {string} opts.homeDir - User home directory
- * @param {object} [opts.env]   - Environment object (defaults to process.env)
+ * @param {string} opts.cwd
+ * @param {string} opts.homeDir
+ * @param {object} [opts.env]
  * @returns {string}
  */
 function resolveUpdateCacheFile(opts) {

--- a/gsd-ng/bin/lib/cache-path.cjs
+++ b/gsd-ng/bin/lib/cache-path.cjs
@@ -1,0 +1,116 @@
+'use strict';
+// Shared between hooks/gsd-check-update.js (writer) and hooks/gsd-statusline.js (reader)
+// — DO NOT inline; both require this so cache paths can never drift.
+
+const fs = require('fs');
+const path = require('path');
+
+const CACHE_FILENAME = 'gsd-update-check.json';
+
+/**
+ * Detect the GSD config directory for a given base directory.
+ * Returns the variant dir (e.g. <base>/.claude) when an install is present,
+ * or null when no install is found under this base.
+ *
+ * Variant order (same as gsd-check-update.js detectConfigDir):
+ *   1. env.CLAUDE_CONFIG_DIR with gsd-ng/VERSION present
+ *   2. <base>/.claude/gsd-ng/VERSION
+ *   3. <base>/.github/gsd-ng/VERSION
+ *   4. <base>/.copilot/gsd-ng/VERSION
+ *
+ * Unlike the hook's private copy, this version returns null on miss
+ * so callers can distinguish "install present" from "fallback path".
+ *
+ * @param {string} baseDir - Directory to probe
+ * @param {object} [env] - Environment object (defaults to process.env)
+ * @returns {string|null}
+ */
+function detectConfigDir(baseDir, env) {
+  const e = env || process.env;
+  // Env override takes absolute top precedence (only when VERSION is present there too)
+  const envDir = e.CLAUDE_CONFIG_DIR;
+  if (envDir && fs.existsSync(path.join(envDir, 'gsd-ng', 'VERSION'))) {
+    return envDir;
+  }
+  // Claude Code local: .claude/gsd-ng/VERSION
+  if (fs.existsSync(path.join(baseDir, '.claude', 'gsd-ng', 'VERSION'))) {
+    return path.join(baseDir, '.claude');
+  }
+  // Copilot local: .github/gsd-ng/VERSION
+  if (fs.existsSync(path.join(baseDir, '.github', 'gsd-ng', 'VERSION'))) {
+    return path.join(baseDir, '.github');
+  }
+  // Copilot global: .copilot/gsd-ng/VERSION
+  if (fs.existsSync(path.join(baseDir, '.copilot', 'gsd-ng', 'VERSION'))) {
+    return path.join(baseDir, '.copilot');
+  }
+  return null;
+}
+
+/**
+ * Resolve the cache DIRECTORY for gsd-update-check.json using
+ * local-before-global precedence:
+ *
+ *   1. env.CLAUDE_CONFIG_DIR with gsd-ng/VERSION → join(envDir, 'cache')
+ *   2. Local install under cwd → join(localConfigDir, 'cache')   [local wins]
+ *   3. Global install under homeDir → join(globalConfigDir, 'cache')
+ *   4. Fallback → join(env.CLAUDE_CONFIG_DIR || join(homeDir, '.claude'), 'cache')
+ *
+ * @param {object} opts
+ * @param {string} opts.cwd     - Current working / project directory
+ * @param {string} opts.homeDir - User home directory
+ * @param {object} [opts.env]   - Environment object (defaults to process.env)
+ * @returns {string} Absolute path to the cache directory
+ */
+function resolveUpdateCacheDir({ cwd, homeDir, env }) {
+  const e = env || process.env;
+
+  // 1. Env override with VERSION present
+  const envDir = e.CLAUDE_CONFIG_DIR;
+  if (envDir && fs.existsSync(path.join(envDir, 'gsd-ng', 'VERSION'))) {
+    return path.join(envDir, 'cache');
+  }
+
+  // 2. Local install (project dir)
+  const localConfig = detectConfigDir(cwd, e);
+  if (localConfig) {
+    return path.join(localConfig, 'cache');
+  }
+
+  // 3. Global install (home dir) — only check base variants, NOT env (already handled)
+  // We need to probe homeDir variants directly (no env re-check to avoid double-counting).
+  if (fs.existsSync(path.join(homeDir, '.claude', 'gsd-ng', 'VERSION'))) {
+    return path.join(homeDir, '.claude', 'cache');
+  }
+  if (fs.existsSync(path.join(homeDir, '.github', 'gsd-ng', 'VERSION'))) {
+    return path.join(homeDir, '.github', 'cache');
+  }
+  if (fs.existsSync(path.join(homeDir, '.copilot', 'gsd-ng', 'VERSION'))) {
+    return path.join(homeDir, '.copilot', 'cache');
+  }
+
+  // 4. Fallback (no install found anywhere)
+  const fallbackBase = envDir || path.join(homeDir, '.claude');
+  return path.join(fallbackBase, 'cache');
+}
+
+/**
+ * Resolve the absolute path to gsd-update-check.json using local-before-global
+ * precedence. Both the writer (gsd-check-update.js) and the reader
+ * (gsd-statusline.js) must call this so their cache paths cannot drift.
+ *
+ * @param {object} opts
+ * @param {string} opts.cwd     - Current working / project directory
+ * @param {string} opts.homeDir - User home directory
+ * @param {object} [opts.env]   - Environment object (defaults to process.env)
+ * @returns {string}
+ */
+function resolveUpdateCacheFile(opts) {
+  return path.join(resolveUpdateCacheDir(opts), CACHE_FILENAME);
+}
+
+module.exports = {
+  detectConfigDir,
+  resolveUpdateCacheDir,
+  resolveUpdateCacheFile,
+};

--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -61,8 +61,7 @@ function detectConfigDir(baseDir) {
 const globalConfigDir = detectConfigDir(homeDir);
 const projectConfigDir = detectConfigDir(cwd);
 
-// Derive cache path from the shared helper (local-before-global precedence).
-// resolveUpdateCacheFile/Dir are null only in GSD_TEST_MODE with no helper — guarded above.
+// null only in GSD_TEST_MODE with no helper — guarded above.
 const cacheDir = resolveUpdateCacheDir
   ? resolveUpdateCacheDir({ cwd, homeDir, env: process.env })
   : null;

--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -10,8 +10,33 @@ const { spawn } = require('child_process');
 const homeDir = os.homedir();
 const cwd = process.cwd();
 
-// Detect GSD config directory — supports Claude Code (.claude), Copilot local (.github), Copilot global (.copilot)
-// Respects CLAUDE_CONFIG_DIR for custom config directory setups
+// ── Locate shared cache-path module ───────────────────────────────────────────
+// Same dual-candidate pattern as semver-utils: supports deployed and source layouts.
+const cachePathModulePath = (function () {
+  const candidates = [
+    // Deployed layout: hooks/ lives beside bin/lib/
+    path.join(__dirname, '..', 'bin', 'lib', 'cache-path.cjs'),
+    // Source layout: hooks/ lives at gsd-ng/hooks/, lib at gsd-ng/gsd-ng/bin/lib/
+    path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'cache-path.cjs'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) return p;
+  }
+  return null;
+})();
+
+// Defensive guard: if cache-path is unreachable skip the update check silently
+// (mirrors the semver-utils guard below — both are required for a correct check).
+if (!cachePathModulePath && !process.env.GSD_TEST_MODE) {
+  process.exit(0);
+}
+
+const { resolveUpdateCacheDir, resolveUpdateCacheFile } = cachePathModulePath
+  ? require(cachePathModulePath)
+  : { resolveUpdateCacheDir: null, resolveUpdateCacheFile: null };
+
+// Detect GSD config directory — used for VERSION file location (project-first).
+// Respects CLAUDE_CONFIG_DIR for custom config directory setups.
 function detectConfigDir(baseDir) {
   // Check env override first (supports multi-account setups)
   const envDir = process.env.CLAUDE_CONFIG_DIR;
@@ -35,8 +60,15 @@ function detectConfigDir(baseDir) {
 
 const globalConfigDir = detectConfigDir(homeDir);
 const projectConfigDir = detectConfigDir(cwd);
-const cacheDir = path.join(globalConfigDir, 'cache');
-const cacheFile = path.join(cacheDir, 'gsd-update-check.json');
+
+// Derive cache path from the shared helper (local-before-global precedence).
+// resolveUpdateCacheFile/Dir are null only in GSD_TEST_MODE with no helper — guarded above.
+const cacheDir = resolveUpdateCacheDir
+  ? resolveUpdateCacheDir({ cwd, homeDir, env: process.env })
+  : null;
+const cacheFile = resolveUpdateCacheFile
+  ? resolveUpdateCacheFile({ cwd, homeDir, env: process.env })
+  : null;
 
 // VERSION file locations (check project first, then global)
 const projectVersionFile = path.join(projectConfigDir, 'gsd-ng', 'VERSION');
@@ -88,13 +120,20 @@ const { compareSemVer, normalizeTag, isSnapshot, parseChannel } =
  * @param {object} [opts.env] - Environment object (defaults to {} if omitted)
  * @returns {boolean}
  */
-function shouldRunUpdateCheck({ source, lastCheckedEpoch, nowEpoch, ttlSeconds, env }) {
+function shouldRunUpdateCheck({
+  source,
+  lastCheckedEpoch,
+  nowEpoch,
+  ttlSeconds,
+  env,
+}) {
   const e = env || {};
-  if (e.GSD_OFFLINE) return false;                   // offline always wins
-  if (source !== 'startup') return false;             // only genuine top-level sessions
-  if (lastCheckedEpoch == null) return true;          // never checked → stale
-  if (typeof lastCheckedEpoch !== 'number' || Number.isNaN(lastCheckedEpoch)) return true;
-  return (nowEpoch - lastCheckedEpoch) >= ttlSeconds; // wall-clock cooldown throttle
+  if (e.GSD_OFFLINE) return false; // offline always wins
+  if (source !== 'startup') return false; // only genuine top-level sessions
+  if (lastCheckedEpoch == null) return true; // never checked → stale
+  if (typeof lastCheckedEpoch !== 'number' || Number.isNaN(lastCheckedEpoch))
+    return true;
+  return nowEpoch - lastCheckedEpoch >= ttlSeconds; // wall-clock cooldown throttle
 }
 
 // Wall-clock cooldown constant for the primary npm/check path
@@ -385,7 +424,7 @@ if (!process.env.GSD_SIMULATE_SANDBOX) {
 let input = '';
 const stdinTimeout = setTimeout(() => process.exit(0), 3000);
 process.stdin.setEncoding('utf8');
-process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('data', (chunk) => (input += chunk));
 process.stdin.on('end', () => {
   clearTimeout(stdinTimeout);
   try {
@@ -394,12 +433,23 @@ process.stdin.on('end', () => {
 
     // Read cache's last-checked epoch defensively (null if cache absent/corrupt)
     let lastCheckedEpoch = null;
-    try { lastCheckedEpoch = JSON.parse(fs.readFileSync(cacheFile, 'utf8')).checked ?? null; } catch (e) {}
+    try {
+      lastCheckedEpoch =
+        JSON.parse(fs.readFileSync(cacheFile, 'utf8')).checked ?? null;
+    } catch (e) {}
 
     const nowEpoch = Math.floor(Date.now() / 1000);
 
     // Gate: only run the update check for genuine primary sessions with a stale cache
-    if (!shouldRunUpdateCheck({ source, lastCheckedEpoch, nowEpoch, ttlSeconds: PRIMARY_CHECK_TTL, env: process.env })) {
+    if (
+      !shouldRunUpdateCheck({
+        source,
+        lastCheckedEpoch,
+        nowEpoch,
+        ttlSeconds: PRIMARY_CHECK_TTL,
+        env: process.env,
+      })
+    ) {
       process.exit(0);
     }
 

--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -31,31 +31,31 @@ if (!cachePathModulePath && !process.env.GSD_TEST_MODE) {
   process.exit(0);
 }
 
-const { resolveUpdateCacheDir, resolveUpdateCacheFile } = cachePathModulePath
+const { resolveUpdateCacheDir, resolveUpdateCacheFile, detectConfigDir: _sharedDetectConfigDir } = cachePathModulePath
   ? require(cachePathModulePath)
-  : { resolveUpdateCacheDir: null, resolveUpdateCacheFile: null };
+  : { resolveUpdateCacheDir: null, resolveUpdateCacheFile: null, detectConfigDir: null };
+// Mutable reference so GSD_TEST_MODE tests can simulate the no-module path.
+let sharedDetectConfigDir = _sharedDetectConfigDir;
 
 // Detect GSD config directory — used for VERSION file location (project-first).
 // Respects CLAUDE_CONFIG_DIR for custom config directory setups.
+// Delegates the .claude → .github → .copilot variant order to the shared
+// cache-path.cjs detectConfigDir (single source of truth — zero duplication here).
 function detectConfigDir(baseDir) {
-  // Check env override first (supports multi-account setups)
-  const envDir = process.env.CLAUDE_CONFIG_DIR;
-  if (envDir && fs.existsSync(path.join(envDir, 'gsd-ng', 'VERSION'))) {
-    return envDir;
+  if (sharedDetectConfigDir) {
+    // Primary path: shared module handles env override + variant probing + null on no-match.
+    // Wrap its null-on-no-match with the hook's own fallback contract.
+    return (
+      sharedDetectConfigDir(baseDir, process.env) ||
+      process.env.CLAUDE_CONFIG_DIR ||
+      path.join(baseDir, '.claude')
+    );
   }
-  // Check Claude Code local (.claude/gsd-ng/VERSION)
-  if (fs.existsSync(path.join(baseDir, '.claude', 'gsd-ng', 'VERSION'))) {
-    return path.join(baseDir, '.claude');
-  }
-  // Check Copilot local (.github/gsd-ng/VERSION)
-  if (fs.existsSync(path.join(baseDir, '.github', 'gsd-ng', 'VERSION'))) {
-    return path.join(baseDir, '.github');
-  }
-  // Check Copilot global (~/.copilot/gsd-ng/VERSION)
-  if (fs.existsSync(path.join(baseDir, '.copilot', 'gsd-ng', 'VERSION'))) {
-    return path.join(baseDir, '.copilot');
-  }
-  return envDir || path.join(baseDir, '.claude');
+  // Shared module unavailable — only reachable in GSD_TEST_MODE; production exits at the
+  // require guard above before detectConfigDir is ever called. Degrade WITHOUT probing
+  // variants so the .claude → .github → .copilot order is single-sourced in
+  // cache-path.cjs with ZERO duplication here.
+  return process.env.CLAUDE_CONFIG_DIR || path.join(baseDir, '.claude');
 }
 
 const globalConfigDir = detectConfigDir(homeDir);
@@ -396,6 +396,9 @@ if (process.env.GSD_TEST_MODE) {
     parseChannel,
     buildChildSource,
     shouldRunUpdateCheck,
+    detectConfigDir,
+    // Test-only seam: allows tests to simulate the shared-module-unavailable path.
+    _setSharedDetectConfigDir(fn) { sharedDetectConfigDir = fn; },
   };
   return;
 }

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -7,9 +7,7 @@ const path = require('path');
 const os = require('os');
 
 // ── Locate shared cache-path module ──────────────────────────────────────────
-// Dual-candidate pattern: supports deployed layout (.claude/gsd-ng/hooks/ →
-// .claude/gsd-ng/bin/lib/) and source layout (gsd-ng/hooks/ → gsd-ng/gsd-ng/bin/lib/).
-// Wrapped in try/catch — statusline must never throw on any import failure.
+// Dual-candidate pattern (deployed vs source layout), same as gsd-check-update.js.
 let _cachePathLib = null;
 try {
   const candidates = [
@@ -138,27 +136,15 @@ function renderCrossModelWarning(data, config) {
 // ─── GSD update banner ───────────────────────────────────────────────────────
 
 /**
- * Render the GSD update-available banner segment.
+ * Render the GSD update-available banner segment, or '' to suppress it.
  *
- * Uses the shared cache-path.cjs helper to derive the cache file path with
- * local-before-global precedence, so both writer (gsd-check-update.js) and
- * reader always use the same cache location and can never drift.
+ * Resolves the cache path through the shared cache-path.cjs helper (local-before-global),
+ * so it reads the same cache the writer wrote and a stale global cache is never read for a
+ * local install. Suppresses the banner when cache.installed differs from the live local
+ * VERSION — guards the within-session gap after /gsd:update before the next TTL refresh.
  *
- * Staleness guard: re-reads the live local VERSION (cheap file read, no network).
- * If cache.installed !== liveVersion the banner is suppressed — this guards the
- * within-session post-update gap where the cache still shows the pre-update state.
- *
- * Migration note: because the reader now resolves the LOCAL cache path, the old
- * global cache (~/.claude/cache/gsd-update-check.json) is simply never read for
- * a local install. Any stale "update_available: true" in the global cache is
- * therefore automatically ignored once a local install is in use.
- *
- * @param {object} opts
- * @param {string}         opts.cwd     - Project directory (used for local install detection)
- * @param {string}         [opts.homeDir]  - Home directory (defaults to os.homedir())
- * @param {object}         [opts.env]   - Environment object (defaults to process.env)
- * @param {object}         [opts.fs]    - fs module (injectable for tests, defaults to require('fs'))
- * @returns {string} Banner string ('\x1b[33m⬆ /gsd:update\x1b[0m │ ') or ''
+ * @param {object} opts - cwd (project dir), homeDir, env, and fs are all injectable for tests.
+ * @returns {string}
  */
 function renderUpdateBanner({ cwd, homeDir, env, fs: fsArg }) {
   try {
@@ -166,15 +152,10 @@ function renderUpdateBanner({ cwd, homeDir, env, fs: fsArg }) {
     const hd = homeDir || os.homedir();
     const e = env || process.env;
 
-    // No helper → fall back to silent '' (statusline must never crash)
     if (!_cachePathLib) return '';
-
     const { resolveUpdateCacheFile, detectConfigDir } = _cachePathLib;
 
-    // 1. Derive the cache file path (local-before-global)
     const cacheFile = resolveUpdateCacheFile({ cwd, homeDir: hd, env: e });
-
-    // 2. Read and parse cache — missing or corrupt → no banner
     if (!fsLib.existsSync(cacheFile)) return '';
     let cache;
     try {
@@ -184,24 +165,21 @@ function renderUpdateBanner({ cwd, homeDir, env, fs: fsArg }) {
     }
     if (!cache.update_available) return '';
 
-    // 3. Staleness guard: compare cache.installed against the live local VERSION.
-    //    If they differ the install was updated mid-session — suppress until next TTL.
     const localConfigDir = detectConfigDir(cwd, e);
     if (localConfigDir) {
       try {
         const liveVersion = fsLib
           .readFileSync(path.join(localConfigDir, 'gsd-ng', 'VERSION'), 'utf8')
           .trim();
-        if (cache.installed !== liveVersion) return '';
+        if (cache.installed !== liveVersion) return ''; // updated mid-session — suppress until next TTL
       } catch (_) {
-        // VERSION not readable — suppress to be safe
-        return '';
+        return ''; // VERSION unreadable — suppress to be safe
       }
     }
 
     return '\x1b[33m⬆ /gsd:update\x1b[0m │ ';
   } catch (_) {
-    return ''; // final safety net — statusline must never throw
+    return '';
   }
 }
 

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -5,6 +5,26 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+
+// ── Locate shared cache-path module ──────────────────────────────────────────
+// Dual-candidate pattern: supports deployed layout (.claude/gsd-ng/hooks/ →
+// .claude/gsd-ng/bin/lib/) and source layout (gsd-ng/hooks/ → gsd-ng/gsd-ng/bin/lib/).
+// Wrapped in try/catch — statusline must never throw on any import failure.
+let _cachePathLib = null;
+try {
+  const candidates = [
+    path.join(__dirname, '..', 'bin', 'lib', 'cache-path.cjs'),
+    path.join(__dirname, '..', 'gsd-ng', 'bin', 'lib', 'cache-path.cjs'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      _cachePathLib = require(p);
+      break;
+    }
+  }
+} catch (e) {
+  // Silent fail — statusline must never crash; banner simply won't show
+}
 const { execSync } = require('child_process');
 
 // ─── Utility: TTL-based file cache ──────────────────────────────────────────
@@ -20,12 +40,20 @@ function withCache(cacheFile, ttlSeconds, computeFn) {
       const ageMs = Date.now() - fs.statSync(cacheFile).mtimeMs;
       if (ageMs / 1000 < ttlSeconds) return fs.readFileSync(cacheFile, 'utf8');
     }
-  } catch (e) { /* cache read failed — fall through to compute */ }
+  } catch (e) {
+    /* cache read failed — fall through to compute */
+  }
   try {
     const value = computeFn();
-    try { fs.writeFileSync(cacheFile, value); } catch (e) { /* cache write failed — return value uncached */ }
+    try {
+      fs.writeFileSync(cacheFile, value);
+    } catch (e) {
+      /* cache write failed — return value uncached */
+    }
     return value;
-  } catch (e) { return ''; }
+  } catch (e) {
+    return '';
+  }
 }
 
 // ─── Token formatting ────────────────────────────────────────────────────────
@@ -61,10 +89,12 @@ function renderGitBranch(data, config) {
   const cacheFile = path.join(os.tmpdir(), 'gsd-statusline-git.cache');
   return withCache(cacheFile, 5, () => {
     const cwd = data.workspace?.current_dir || process.cwd();
-    const branch = execSync(
-      'git branch --show-current',
-      { encoding: 'utf8', timeout: 1500, cwd, stdio: ['pipe', 'pipe', 'ignore'] }
-    ).trim();
+    const branch = execSync('git branch --show-current', {
+      encoding: 'utf8',
+      timeout: 1500,
+      cwd,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    }).trim();
     if (!branch) return '';
     return formatBranchDisplay(branch);
   });
@@ -105,6 +135,76 @@ function renderCrossModelWarning(data, config) {
   return `\x1b[33m[>200k]\x1b[0m`;
 }
 
+// ─── GSD update banner ───────────────────────────────────────────────────────
+
+/**
+ * Render the GSD update-available banner segment.
+ *
+ * Uses the shared cache-path.cjs helper to derive the cache file path with
+ * local-before-global precedence, so both writer (gsd-check-update.js) and
+ * reader always use the same cache location and can never drift.
+ *
+ * Staleness guard: re-reads the live local VERSION (cheap file read, no network).
+ * If cache.installed !== liveVersion the banner is suppressed — this guards the
+ * within-session post-update gap where the cache still shows the pre-update state.
+ *
+ * Migration note: because the reader now resolves the LOCAL cache path, the old
+ * global cache (~/.claude/cache/gsd-update-check.json) is simply never read for
+ * a local install. Any stale "update_available: true" in the global cache is
+ * therefore automatically ignored once a local install is in use.
+ *
+ * @param {object} opts
+ * @param {string}         opts.cwd     - Project directory (used for local install detection)
+ * @param {string}         [opts.homeDir]  - Home directory (defaults to os.homedir())
+ * @param {object}         [opts.env]   - Environment object (defaults to process.env)
+ * @param {object}         [opts.fs]    - fs module (injectable for tests, defaults to require('fs'))
+ * @returns {string} Banner string ('\x1b[33m⬆ /gsd:update\x1b[0m │ ') or ''
+ */
+function renderUpdateBanner({ cwd, homeDir, env, fs: fsArg }) {
+  try {
+    const fsLib = fsArg || fs;
+    const hd = homeDir || os.homedir();
+    const e = env || process.env;
+
+    // No helper → fall back to silent '' (statusline must never crash)
+    if (!_cachePathLib) return '';
+
+    const { resolveUpdateCacheFile, detectConfigDir } = _cachePathLib;
+
+    // 1. Derive the cache file path (local-before-global)
+    const cacheFile = resolveUpdateCacheFile({ cwd, homeDir: hd, env: e });
+
+    // 2. Read and parse cache — missing or corrupt → no banner
+    if (!fsLib.existsSync(cacheFile)) return '';
+    let cache;
+    try {
+      cache = JSON.parse(fsLib.readFileSync(cacheFile, 'utf8'));
+    } catch (_) {
+      return '';
+    }
+    if (!cache.update_available) return '';
+
+    // 3. Staleness guard: compare cache.installed against the live local VERSION.
+    //    If they differ the install was updated mid-session — suppress until next TTL.
+    const localConfigDir = detectConfigDir(cwd, e);
+    if (localConfigDir) {
+      try {
+        const liveVersion = fsLib
+          .readFileSync(path.join(localConfigDir, 'gsd-ng', 'VERSION'), 'utf8')
+          .trim();
+        if (cache.installed !== liveVersion) return '';
+      } catch (_) {
+        // VERSION not readable — suppress to be safe
+        return '';
+      }
+    }
+
+    return '\x1b[33m⬆ /gsd:update\x1b[0m │ ';
+  } catch (_) {
+    return ''; // final safety net — statusline must never throw
+  }
+}
+
 // ─── Main statusline ──────────────────────────────────────────────────────────
 
 // Read JSON from stdin
@@ -113,7 +213,7 @@ let input = '';
 // Windows/Git Bash), exit silently instead of hanging. See #775.
 const stdinTimeout = setTimeout(() => process.exit(0), 3000);
 process.stdin.setEncoding('utf8');
-process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('data', (chunk) => (input += chunk));
 process.stdin.on('end', () => {
   clearTimeout(stdinTimeout);
   try {
@@ -130,8 +230,16 @@ process.stdin.on('end', () => {
     let ctx = '';
     if (remaining != null) {
       // Normalize: subtract buffer from remaining, scale to usable range
-      const usableRemaining = Math.max(0, ((remaining - AUTO_COMPACT_BUFFER_PCT) / (100 - AUTO_COMPACT_BUFFER_PCT)) * 100);
-      const used = Math.max(0, Math.min(100, Math.round(100 - usableRemaining)));
+      const usableRemaining = Math.max(
+        0,
+        ((remaining - AUTO_COMPACT_BUFFER_PCT) /
+          (100 - AUTO_COMPACT_BUFFER_PCT)) *
+          100,
+      );
+      const used = Math.max(
+        0,
+        Math.min(100, Math.round(100 - usableRemaining)),
+      );
 
       // Write context metrics to bridge file for the context-monitor PostToolUse hook.
       // The monitor reads this file to inject agent-facing warnings when context is low.
@@ -140,12 +248,15 @@ process.stdin.on('end', () => {
         // in sandbox, but guard added per locked degradation pattern for all hook writes)
         if (!process.env.GSD_SIMULATE_SANDBOX) {
           try {
-            const bridgePath = path.join(os.tmpdir(), `claude-ctx-${session}.json`);
+            const bridgePath = path.join(
+              os.tmpdir(),
+              `claude-ctx-${session}.json`,
+            );
             const bridgeData = JSON.stringify({
               session_id: session,
               remaining_percentage: remaining,
               used_pct: used,
-              timestamp: Math.floor(Date.now() / 1000)
+              timestamp: Math.floor(Date.now() / 1000),
             });
             fs.writeFileSync(bridgePath, bridgeData);
           } catch (e) {
@@ -170,26 +281,21 @@ process.stdin.on('end', () => {
       }
     }
 
-    // Respect CLAUDE_CONFIG_DIR for custom config directory setups (#870)
-    const claudeDir = process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
-
-    // GSD update available?
-    let gsdUpdate = '';
-    const cacheFile = path.join(claudeDir, 'cache', 'gsd-update-check.json');
-    if (fs.existsSync(cacheFile)) {
-      try {
-        const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf8'));
-        if (cache.update_available) {
-          gsdUpdate = '\x1b[33m⬆ /gsd:update\x1b[0m │ ';
-        }
-      } catch (e) {}
-    }
+    // GSD update available? (local-before-global cache precedence + staleness guard)
+    const gsdUpdate = renderUpdateBanner({
+      cwd: dir,
+      homeDir: os.homedir(),
+      env: process.env,
+    });
 
     // Load config for statusline component toggles
     // Direct JSON.parse — avoid spawning gsd-tools (process spawn overhead per anti-pattern docs)
     let config = {};
     try {
-      const projectDir = data.workspace?.project_dir || data.workspace?.current_dir || process.cwd();
+      const projectDir =
+        data.workspace?.project_dir ||
+        data.workspace?.current_dir ||
+        process.cwd();
       const configPath = path.join(projectDir, '.planning', 'config.json');
       if (fs.existsSync(configPath)) {
         config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
@@ -223,7 +329,7 @@ process.stdin.on('end', () => {
       dirBranchSeg,
       ctxCombined,
       tokenBreakdown,
-    ].filter(s => s !== '');
+    ].filter((s) => s !== '');
 
     process.stdout.write(segments.join(' \u2502 '));
   } catch (e) {
@@ -233,5 +339,13 @@ process.stdin.on('end', () => {
 
 // Exports for testing (not used by Claude Code — hook reads stdin, writes stdout)
 if (typeof module !== 'undefined') {
-  module.exports = { formatTokenCount, formatBranchDisplay, renderTokenBreakdown, renderCrossModelWarning, renderGitBranch, withCache };
+  module.exports = {
+    formatTokenCount,
+    formatBranchDisplay,
+    renderTokenBreakdown,
+    renderCrossModelWarning,
+    renderGitBranch,
+    withCache,
+    renderUpdateBanner,
+  };
 }

--- a/tests/c8-ignore-baseline.json
+++ b/tests/c8-ignore-baseline.json
@@ -1,5 +1,6 @@
 {
   "gsd-ng/bin/lib/allowlist.cjs": 0,
+  "gsd-ng/bin/lib/cache-path.cjs": 0,
   "gsd-ng/bin/lib/commands.cjs": 6,
   "gsd-ng/bin/lib/config.cjs": 0,
   "gsd-ng/bin/lib/confusables.cjs": 0,

--- a/tests/cache-path.test.cjs
+++ b/tests/cache-path.test.cjs
@@ -1,0 +1,190 @@
+'use strict';
+// Unit tests for gsd-ng/gsd-ng/bin/lib/cache-path.cjs
+// Proves local-before-global cache path precedence for the update-check cache.
+// Writer (gsd-check-update.js) and reader (gsd-statusline.js) both use this
+// helper so the cache path is derived identically and can never drift.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+const { resolveUpdateCacheFile, resolveUpdateCacheDir, detectConfigDir } =
+  require('../gsd-ng/bin/lib/cache-path.cjs');
+
+// Helper: write a VERSION file under <base>/<variant>/gsd-ng/VERSION
+function seedInstall(base, variant = '.claude', version = '1.0.0-dev.1') {
+  const dir = path.join(base, variant, 'gsd-ng');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'VERSION'), version, 'utf8');
+}
+
+// ── Test A: local-only ───────────────────────────────────────────────────────
+test('A: local-only install — cache path under <project>/.claude/cache, NOT homeDir', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    seedInstall(project, '.claude');
+    // no install in home
+    const result = resolveUpdateCacheFile({ cwd: project, homeDir: home, env: {} });
+    assert.ok(
+      result.startsWith(path.join(project, '.claude', 'cache')),
+      `Expected cache under project dir, got: ${result}`
+    );
+    assert.ok(
+      !result.startsWith(home),
+      `Cache must NOT be under homeDir, got: ${result}`
+    );
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── Test B: local wins over global ───────────────────────────────────────────
+test('B: local wins when BOTH project and home have .claude/gsd-ng/VERSION', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    seedInstall(project, '.claude');
+    seedInstall(home, '.claude');
+    const result = resolveUpdateCacheFile({ cwd: project, homeDir: home, env: {} });
+    assert.ok(
+      result.startsWith(path.join(project, '.claude', 'cache')),
+      `Expected local cache under project, got: ${result}`
+    );
+    assert.ok(
+      !result.startsWith(home),
+      `Cache must NOT be under homeDir when local install present, got: ${result}`
+    );
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── Test C: two projects stay isolated ───────────────────────────────────────
+test('C: two distinct projects have different cache paths (no shared cache)', () => {
+  const projectA = createTempProject();
+  const projectB = createTempProject();
+  const home = createTempProject();
+  try {
+    seedInstall(projectA, '.claude');
+    seedInstall(projectB, '.claude');
+    const pathA = resolveUpdateCacheFile({ cwd: projectA, homeDir: home, env: {} });
+    const pathB = resolveUpdateCacheFile({ cwd: projectB, homeDir: home, env: {} });
+    assert.notStrictEqual(pathA, pathB, 'Two different projects must produce different cache paths');
+    assert.ok(pathA.startsWith(projectA), `pathA should be under projectA, got: ${pathA}`);
+    assert.ok(pathB.startsWith(projectB), `pathB should be under projectB, got: ${pathB}`);
+  } finally {
+    cleanup(projectA);
+    cleanup(projectB);
+    cleanup(home);
+  }
+});
+
+// ── Test D: global-only ──────────────────────────────────────────────────────
+test('D: global-only install — cache path under <homeDir>/.claude/cache', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    // no local install — only global
+    seedInstall(home, '.claude');
+    const result = resolveUpdateCacheFile({ cwd: project, homeDir: home, env: {} });
+    assert.ok(
+      result.startsWith(path.join(home, '.claude', 'cache')),
+      `Expected cache under home dir, got: ${result}`
+    );
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── Test E: env override takes top precedence ────────────────────────────────
+test('E: CLAUDE_CONFIG_DIR with VERSION takes top precedence over local project install', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  const envConfigDir = createTempProject();
+  try {
+    seedInstall(project, '.claude');         // local install present
+    seedInstall(home, '.claude');            // global install present
+    // Seed VERSION directly under envConfigDir/gsd-ng/VERSION
+    const envGsdDir = path.join(envConfigDir, 'gsd-ng');
+    fs.mkdirSync(envGsdDir, { recursive: true });
+    fs.writeFileSync(path.join(envGsdDir, 'VERSION'), '2.0.0', 'utf8');
+
+    const result = resolveUpdateCacheFile({
+      cwd: project,
+      homeDir: home,
+      env: { CLAUDE_CONFIG_DIR: envConfigDir },
+    });
+    assert.ok(
+      result.startsWith(path.join(envConfigDir, 'cache')),
+      `Expected env override cache, got: ${result}`
+    );
+    assert.ok(
+      !result.startsWith(project),
+      `Must not use local project cache when CLAUDE_CONFIG_DIR overrides, got: ${result}`
+    );
+  } finally {
+    cleanup(project);
+    cleanup(home);
+    cleanup(envConfigDir);
+  }
+});
+
+// ── Test F: copilot variant honored ─────────────────────────────────────────
+test('F: project with .github/gsd-ng/VERSION → cache under <project>/.github/cache', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    seedInstall(project, '.github');  // Copilot local variant
+    // no .claude install
+    const result = resolveUpdateCacheFile({ cwd: project, homeDir: home, env: {} });
+    assert.ok(
+      result.startsWith(path.join(project, '.github', 'cache')),
+      `Expected .github cache dir, got: ${result}`
+    );
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── Exports shape ────────────────────────────────────────────────────────────
+describe('module exports', () => {
+  test('resolveUpdateCacheFile is a function', () => {
+    assert.strictEqual(typeof resolveUpdateCacheFile, 'function');
+  });
+  test('resolveUpdateCacheDir is a function', () => {
+    assert.strictEqual(typeof resolveUpdateCacheDir, 'function');
+  });
+  test('detectConfigDir is a function', () => {
+    assert.strictEqual(typeof detectConfigDir, 'function');
+  });
+  test('resolveUpdateCacheFile result ends with gsd-update-check.json', () => {
+    const project = createTempProject();
+    const home = createTempProject();
+    try {
+      seedInstall(home, '.claude');
+      const result = resolveUpdateCacheFile({ cwd: project, homeDir: home, env: {} });
+      assert.ok(result.endsWith('gsd-update-check.json'), `Expected .json suffix, got: ${result}`);
+    } finally {
+      cleanup(project);
+      cleanup(home);
+    }
+  });
+  test('resolveUpdateCacheDir result is parent of resolveUpdateCacheFile result', () => {
+    const home = createTempProject();
+    try {
+      seedInstall(home, '.claude');
+      const dir = resolveUpdateCacheDir({ cwd: home, homeDir: home, env: {} });
+      const file = resolveUpdateCacheFile({ cwd: home, homeDir: home, env: {} });
+      assert.strictEqual(path.dirname(file), dir, 'cacheFile must be inside cacheDir');
+    } finally {
+      cleanup(home);
+    }
+  });
+});

--- a/tests/cache-path.test.cjs
+++ b/tests/cache-path.test.cjs
@@ -153,6 +153,46 @@ test('F: project with .github/gsd-ng/VERSION → cache under <project>/.github/c
   }
 });
 
+// ── Test G: detectConfigDir env-override branch ──────────────────────────────
+// The statusline staleness guard calls detectConfigDir directly, so its
+// CLAUDE_CONFIG_DIR branch must resolve independently of resolveUpdateCacheDir.
+test('G: detectConfigDir returns CLAUDE_CONFIG_DIR when it holds gsd-ng/VERSION', () => {
+  const project = createTempProject();
+  const envConfigDir = createTempProject();
+  try {
+    seedInstall(project, '.claude');  // local install also present
+    const envGsdDir = path.join(envConfigDir, 'gsd-ng');
+    fs.mkdirSync(envGsdDir, { recursive: true });
+    fs.writeFileSync(path.join(envGsdDir, 'VERSION'), '2.0.0', 'utf8');
+
+    const result = detectConfigDir(project, { CLAUDE_CONFIG_DIR: envConfigDir });
+    assert.strictEqual(result, envConfigDir, `Expected env dir, got: ${result}`);
+  } finally {
+    cleanup(project);
+    cleanup(envConfigDir);
+  }
+});
+
+// ── Test H: env argument defaults to process.env ─────────────────────────────
+// Both functions fall back to process.env when called without an env argument.
+test('H: detectConfigDir / resolveUpdateCacheDir default env to process.env', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;  // neutralize ambient override
+  try {
+    seedInstall(project, '.claude');
+    assert.strictEqual(detectConfigDir(project), path.join(project, '.claude'));
+    const dir = resolveUpdateCacheDir({ cwd: project, homeDir: home });
+    assert.strictEqual(dir, path.join(project, '.claude', 'cache'));
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
 // ── Exports shape ────────────────────────────────────────────────────────────
 describe('module exports', () => {
   test('resolveUpdateCacheFile is a function', () => {

--- a/tests/check-update-cache-path.test.cjs
+++ b/tests/check-update-cache-path.test.cjs
@@ -79,3 +79,139 @@ test('buildChildSource with a local cache path does not embed the old global pat
     'buildChildSource must NOT embed the old global cache path when local path is passed',
   );
 });
+
+// ── Hook detectConfigDir — behavior-preservation tests (primary path) ─────────
+// These tests prove the hook's wrapper matches the OLD inline logic across all
+// branches. detectConfigDir is exported under GSD_TEST_MODE (Task 2 adds the
+// export). Tests are written first (RED) to enforce TDD.
+
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+// Helper: write a VERSION file under <base>/<variant>/gsd-ng/VERSION
+function seedInstall(base, variant = '.claude') {
+  const dir = path.join(base, variant, 'gsd-ng');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'VERSION'), '1.0.0', 'utf8');
+}
+
+// Destructure detectConfigDir alongside existing exports — will be undefined
+// until Task 2 adds it to the GSD_TEST_MODE export block.
+const { detectConfigDir } = require('../hooks/gsd-check-update.js');
+
+test('detectConfigDir export shape: must be a function', () => {
+  assert.strictEqual(typeof detectConfigDir, 'function',
+    'detectConfigDir must be exported from the hook under GSD_TEST_MODE');
+});
+
+test('detectConfigDir (env override): CLAUDE_CONFIG_DIR with VERSION wins over local .claude', () => {
+  const base = createTempProject();
+  const envDir = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    seedInstall(base, '.claude');
+    // Seed VERSION directly under envDir/gsd-ng/VERSION (not under a variant)
+    fs.mkdirSync(path.join(envDir, 'gsd-ng'), { recursive: true });
+    fs.writeFileSync(path.join(envDir, 'gsd-ng', 'VERSION'), '2.0.0', 'utf8');
+    process.env.CLAUDE_CONFIG_DIR = envDir;
+    assert.strictEqual(detectConfigDir(base), envDir,
+      'env override must win over local .claude when it holds gsd-ng/VERSION');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+    cleanup(envDir);
+  }
+});
+
+test('detectConfigDir (.claude variant): returns join(baseDir, .claude) when only .claude is seeded', () => {
+  const base = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  try {
+    seedInstall(base, '.claude');
+    assert.strictEqual(detectConfigDir(base), path.join(base, '.claude'),
+      'must return baseDir/.claude when that variant has gsd-ng/VERSION');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+  }
+});
+
+test('detectConfigDir (.github variant): returns join(baseDir, .github) when only .github is seeded', () => {
+  const base = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  try {
+    seedInstall(base, '.github');
+    assert.strictEqual(detectConfigDir(base), path.join(base, '.github'),
+      'must return baseDir/.github when that variant has gsd-ng/VERSION');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+  }
+});
+
+test('detectConfigDir (.copilot variant): returns join(baseDir, .copilot) when only .copilot is seeded', () => {
+  const base = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  try {
+    seedInstall(base, '.copilot');
+    assert.strictEqual(detectConfigDir(base), path.join(base, '.copilot'),
+      'must return baseDir/.copilot when that variant has gsd-ng/VERSION');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+  }
+});
+
+test('detectConfigDir (variant order .claude wins): .claude beats .github when both are seeded', () => {
+  const base = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  try {
+    seedInstall(base, '.claude');
+    seedInstall(base, '.github');
+    assert.strictEqual(detectConfigDir(base), path.join(base, '.claude'),
+      '.claude must win over .github (proves shared order is honored, not duplicated)');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+  }
+});
+
+test('detectConfigDir (no-match fallback, env set but no VERSION): returns env dir value', () => {
+  const base = createTempProject();
+  const envDir = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  try {
+    // envDir has NO gsd-ng/VERSION; base has no variants seeded
+    process.env.CLAUDE_CONFIG_DIR = envDir;
+    assert.strictEqual(detectConfigDir(base), envDir,
+      'when env dir is set but lacks VERSION and no variant matches, must return env dir (old step 6)');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+    cleanup(envDir);
+  }
+});
+
+test('detectConfigDir (no-match fallback, env unset): returns join(baseDir, .claude)', () => {
+  const base = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  try {
+    // No env, no variants seeded
+    assert.strictEqual(detectConfigDir(base), path.join(base, '.claude'),
+      'when no env and no variant matches, must return join(baseDir, .claude) as default');
+  } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+  }
+});

--- a/tests/check-update-cache-path.test.cjs
+++ b/tests/check-update-cache-path.test.cjs
@@ -1,0 +1,81 @@
+'use strict';
+// Tests that gsd-check-update.js derives its cacheFile from the shared
+// cache-path.cjs helper rather than hardcoding path.join(globalConfigDir, 'cache').
+// Writer and reader are proved to share a single source of truth.
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+// Set GSD_TEST_MODE BEFORE requiring the hook so it exports utilities
+// and does NOT execute (no spawn, no stdin, no network).
+process.env.GSD_TEST_MODE = '1';
+const { buildChildSource } = require('../hooks/gsd-check-update.js');
+
+const HOOK_SRC = fs.readFileSync(
+  path.resolve(__dirname, '../hooks/gsd-check-update.js'),
+  'utf8',
+);
+
+// ── Source-grep tests ────────────────────────────────────────────────────────
+
+test('hook source references cache-path.cjs (uses shared helper, not inline path)', () => {
+  assert.ok(
+    HOOK_SRC.includes('cache-path.cjs'),
+    'hook must require cache-path.cjs — proves it uses the shared helper',
+  );
+});
+
+test('hook source calls resolveUpdateCacheFile or resolveUpdateCacheDir (from shared helper)', () => {
+  assert.ok(
+    HOOK_SRC.includes('resolveUpdateCacheFile') || HOOK_SRC.includes('resolveUpdateCacheDir'),
+    'hook must call resolveUpdateCacheFile or resolveUpdateCacheDir from cache-path.cjs',
+  );
+});
+
+test('hook source no longer contains path.join(globalConfigDir, "cache") (old hardcoded path removed)', () => {
+  assert.ok(
+    !HOOK_SRC.includes("path.join(globalConfigDir, 'cache')"),
+    'hook must NOT have the old hardcoded global cache path — it was the bug being fixed',
+  );
+});
+
+// ── buildChildSource embeds the passed cacheFile ─────────────────────────────
+
+test('buildChildSource embeds the exact cacheFile path passed to it', () => {
+  const localCacheFile = '/some/project/.claude/cache/gsd-update-check.json';
+  const childSrc = buildChildSource({
+    cacheFile: localCacheFile,
+    projectVersionFile: '/some/project/.claude/gsd-ng/VERSION',
+    globalVersionFile: '/home/user/.claude/gsd-ng/VERSION',
+    semverUtilsPath: '/some/path/semver-utils.cjs',
+    githubOwner: 'test-owner',
+    githubRepo: 'test-repo',
+    githubTtl: 3600,
+    assetName: 'gsd-ng.tar.gz',
+  });
+  assert.ok(
+    childSrc.includes(JSON.stringify(localCacheFile)),
+    `buildChildSource must embed the exact cacheFile as a JSON string; got: ${childSrc.slice(0, 200)}`,
+  );
+});
+
+test('buildChildSource with a local cache path does not embed the old global path', () => {
+  const localCacheFile = '/my/local/project/.claude/cache/gsd-update-check.json';
+  const globalCacheFile = '/home/user/.claude/cache/gsd-update-check.json';
+  const childSrc = buildChildSource({
+    cacheFile: localCacheFile,
+    projectVersionFile: '/my/local/project/.claude/gsd-ng/VERSION',
+    globalVersionFile: '/home/user/.claude/gsd-ng/VERSION',
+    semverUtilsPath: '/some/path/semver-utils.cjs',
+    githubOwner: 'test-owner',
+    githubRepo: 'test-repo',
+    githubTtl: 3600,
+    assetName: 'gsd-ng.tar.gz',
+  });
+  assert.ok(
+    !childSrc.includes(JSON.stringify(globalCacheFile)),
+    'buildChildSource must NOT embed the old global cache path when local path is passed',
+  );
+});

--- a/tests/check-update-cache-path.test.cjs
+++ b/tests/check-update-cache-path.test.cjs
@@ -94,9 +94,8 @@ function seedInstall(base, variant = '.claude') {
   fs.writeFileSync(path.join(dir, 'VERSION'), '1.0.0', 'utf8');
 }
 
-// Destructure detectConfigDir alongside existing exports — will be undefined
-// until Task 2 adds it to the GSD_TEST_MODE export block.
-const { detectConfigDir } = require('../hooks/gsd-check-update.js');
+// Destructure detectConfigDir and the test-only seam alongside existing exports.
+const { detectConfigDir, _setSharedDetectConfigDir } = require('../hooks/gsd-check-update.js');
 
 test('detectConfigDir export shape: must be a function', () => {
   assert.strictEqual(typeof detectConfigDir, 'function',
@@ -210,6 +209,46 @@ test('detectConfigDir (no-match fallback, env unset): returns join(baseDir, .cla
     assert.strictEqual(detectConfigDir(base), path.join(base, '.claude'),
       'when no env and no variant matches, must return join(baseDir, .claude) as default');
   } finally {
+    if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+    else process.env.CLAUDE_CONFIG_DIR = saved;
+    cleanup(base);
+  }
+});
+
+// ── Hook detectConfigDir — degraded no-module path test ───────────────────────
+// This test pins the degraded contract when the shared module is unavailable.
+// Uses the GSD_TEST_MODE-only _setSharedDetectConfigDir seam to simulate the
+// no-module condition. The variant array lives ONLY in cache-path.cjs; the
+// degraded path must NOT probe .github/.copilot.
+
+test('detectConfigDir (no-module degraded fallback): returns .claude even when only .github is seeded', () => {
+  const base = createTempProject();
+  const saved = process.env.CLAUDE_CONFIG_DIR;
+  delete process.env.CLAUDE_CONFIG_DIR;
+  // Capture the real shared fn to restore after the test
+  const realSharedFn = _setSharedDetectConfigDir ? null : null; // unused — see restore below
+  try {
+    // Seed ONLY .github — the OLD inline logic would have returned .github here.
+    // The degraded path must NOT probe variants, so it must return .claude instead.
+    seedInstall(base, '.github');
+    // Simulate shared module unavailable
+    _setSharedDetectConfigDir(null);
+    assert.strictEqual(detectConfigDir(base), path.join(base, '.claude'),
+      'degraded path must return baseDir/.claude (non-probing) even when .github is seeded — ' +
+      'variant array must NOT appear outside cache-path.cjs');
+    // Also assert env override is honoured on the degraded path
+    const envDir = createTempProject();
+    try {
+      process.env.CLAUDE_CONFIG_DIR = envDir;
+      assert.strictEqual(detectConfigDir(base), envDir,
+        'degraded path must return CLAUDE_CONFIG_DIR when set, even without VERSION');
+    } finally {
+      cleanup(envDir);
+    }
+  } finally {
+    // Restore the real shared detectConfigDir so subsequent tests in the process are unaffected
+    const realFn = require('../gsd-ng/bin/lib/cache-path.cjs').detectConfigDir;
+    _setSharedDetectConfigDir(realFn);
     if (saved === undefined) delete process.env.CLAUDE_CONFIG_DIR;
     else process.env.CLAUDE_CONFIG_DIR = saved;
     cleanup(base);

--- a/tests/statusline-update-banner.test.cjs
+++ b/tests/statusline-update-banner.test.cjs
@@ -1,0 +1,151 @@
+'use strict';
+// Tests for renderUpdateBanner in gsd-statusline.js.
+// Proves the reader uses the shared cache-path.cjs helper and suppresses the
+// banner on cache.installed vs live VERSION mismatch (post-update gap guard).
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+const { renderUpdateBanner } = require('../hooks/gsd-statusline.js');
+
+// Helper: write a VERSION file under <base>/<variant>/gsd-ng/VERSION
+function seedInstall(base, version, variant = '.claude') {
+  const dir = path.join(base, variant, 'gsd-ng');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'VERSION'), version, 'utf8');
+}
+
+// Helper: write the update-check cache under <base>/<variant>/cache/gsd-update-check.json
+function seedCache(base, data, variant = '.claude') {
+  const cacheDir = path.join(base, variant, 'cache');
+  fs.mkdirSync(cacheDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(cacheDir, 'gsd-update-check.json'),
+    JSON.stringify(data),
+    'utf8',
+  );
+}
+
+// ── Banner shown ─────────────────────────────────────────────────────────────
+test('banner shown: local install, cache {update_available:true, installed matches live VERSION}', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    const version = '1.0.0-dev.5';
+    seedInstall(project, version);
+    seedCache(project, { update_available: true, installed: version, latest: '1.0.0-dev.6' });
+    const result = renderUpdateBanner({
+      cwd: project,
+      homeDir: home,
+      env: {},
+      fs,
+    });
+    assert.ok(result.includes('⬆'), `Expected banner with ⬆, got: ${JSON.stringify(result)}`);
+    assert.ok(
+      result.includes('/gsd:update'),
+      `Expected /gsd:update in banner, got: ${JSON.stringify(result)}`,
+    );
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── Banner suppressed on VERSION mismatch (post-update gap) ──────────────────
+test('banner suppressed: cache.installed mismatches live VERSION', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    const liveVersion = '1.0.0-dev.6';
+    const cachedInstalled = '1.0.0-dev.5'; // stale — update was installed
+    seedInstall(project, liveVersion);
+    seedCache(project, {
+      update_available: true,
+      installed: cachedInstalled,
+      latest: '1.0.0-dev.6',
+    });
+    const result = renderUpdateBanner({
+      cwd: project,
+      homeDir: home,
+      env: {},
+      fs,
+    });
+    assert.strictEqual(result, '', `Banner must be suppressed on version mismatch, got: ${JSON.stringify(result)}`);
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── Banner suppressed when update_available is false ────────────────────────
+test('banner suppressed: update_available is false', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    const version = '1.0.0-dev.5';
+    seedInstall(project, version);
+    seedCache(project, { update_available: false, installed: version, latest: version });
+    const result = renderUpdateBanner({
+      cwd: project,
+      homeDir: home,
+      env: {},
+      fs,
+    });
+    assert.strictEqual(result, '', `Banner must be empty when update_available is false, got: ${JSON.stringify(result)}`);
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── No cache file → no banner, no crash ─────────────────────────────────────
+test('no cache file → returns empty string, no crash', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    seedInstall(project, '1.0.0-dev.5');
+    // no cache file
+    const result = renderUpdateBanner({
+      cwd: project,
+      homeDir: home,
+      env: {},
+      fs,
+    });
+    assert.strictEqual(result, '', `Banner must be empty when no cache exists, got: ${JSON.stringify(result)}`);
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});
+
+// ── Reads LOCAL cache, not global ────────────────────────────────────────────
+test('reader uses LOCAL cache, not global — different contents, local wins', () => {
+  const project = createTempProject();
+  const home = createTempProject();
+  try {
+    const version = '1.0.0-dev.5';
+    seedInstall(project, version);
+    seedInstall(home, version);
+    // Local cache: update_available=true, installed matches
+    seedCache(project, { update_available: true, installed: version, latest: '1.0.0-dev.6' });
+    // Global cache: update_available=false (different)
+    seedCache(home, { update_available: false, installed: version, latest: version });
+    const result = renderUpdateBanner({
+      cwd: project,
+      homeDir: home,
+      env: {},
+      fs,
+    });
+    // Reader must use LOCAL cache (update_available=true) → banner shown
+    assert.ok(
+      result.includes('⬆'),
+      `Reader must use local cache (update_available=true), got: ${JSON.stringify(result)}`,
+    );
+  } finally {
+    cleanup(project);
+    cleanup(home);
+  }
+});


### PR DESCRIPTION
## Summary

A locally-installed GSD showed a false `⬆ /gsd:update` banner even when the project was already on the latest version. The update-check cache lived in the **global** config dir, but the installed version is **per-project**, so one workspace (or the same workspace before it was updated) writing `update_available: true` poisoned the banner for every local install.

This makes the cache path **follow the install location, local-before-global**:

1. `CLAUDE_CONFIG_DIR` (with `gsd-ng/VERSION` present) → top precedence
2. Local install under the project (`.claude`/`.github`/`.copilot` `gsd-ng/VERSION`) → `<project>/…/cache/` — **wins even if a global install also exists**
3. Otherwise → global cache

Writer (`gsd-check-update.js`) and reader (`gsd-statusline.js`) now derive the path from a **single shared helper** (`bin/lib/cache-path.cjs`) so they can't drift, mirroring the existing `semver-utils.cjs` precedent.

## Also

- **Within-session staleness guard:** the statusline re-reads the live local `VERSION` and suppresses the banner when `cache.installed` differs — closes the gap right after `/gsd:update` before the next TTL refresh. Cheap file read, no network/spawn.
- **Migration:** a stale global cache from older versions is simply never read for a local install (the reader resolves the local path), so old false banners clear on their own. Noted in CHANGELOG.

## Not touched

- TTL / 304 / etag refresh logic (`shouldRunUpdateCheck`, `GITHUB_TTL`, conditional requests) — unchanged, still exercised against the new path.
- `install.js` — verified it copies the whole tree and has no global-cache assumption; no change needed.

## Tests (TDD — failing first, then green)

`tests/cache-path.test.cjs`, `tests/check-update-cache-path.test.cjs`, `tests/statusline-update-banner.test.cjs` cover all six handoff scenarios: local writes/reads under the project dir; local-wins-over-global; two projects don't cross-poison; global-only still uses global; `CLAUDE_CONFIG_DIR` top precedence; banner suppressed on live-VERSION mismatch. Full suite green (3356 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
