### PR TITLE
fix(effort): correct the xhigh/max model-tier allowlist (fable + sonnet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- `resolve-effort` no longer strips the `xhigh` and `max` effort tiers from agents resolved to `fable`. The model-tier compatibility gate accepted only `opus` for those tiers, so an agent pointed at `fable` via `model_overrides` silently fell back to the session default effort. Fable supports the same high reasoning tiers as Opus, so both models are now accepted (and the warning text names both).
+- `resolve-effort` no longer strips the `xhigh` and `max` effort tiers from agents resolved to `fable` or `sonnet`. The model-tier compatibility gate accepted only `opus`, so an agent pointed at either model silently fell back to the session default effort — with a warning only when the effort came from an explicit `effort_overrides` entry. Both now support the same high reasoning tiers as Opus: `fable` always did, and `sonnet` gained `xhigh` when the alias moved to Sonnet 5 (the first Sonnet-tier model with it, and the recommended setting there for the hardest coding and agentic work). The gate matches on the bare aliases the harness resolves, so a version-pinned string such as `sonnet-4-6` is still correctly rejected. The warning text now names all three accepted models.
+
+  In practice this only bit an explicit `effort_overrides` entry on a `sonnet`-resolved agent — for example `effort_overrides.gsd-executor: xhigh` under the `balanced` profile — since no profile assigns `xhigh`/`max` to an agent that resolves below the Opus tier.
 
 ## [1.0.0-dev.17] - 2026-06-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `resolve-effort` no longer strips the `xhigh` and `max` effort tiers from agents resolved to `fable`. The model-tier compatibility gate accepted only `opus` for those tiers, so an agent pointed at `fable` via `model_overrides` silently fell back to the session default effort. Fable supports the same high reasoning tiers as Opus, so both models are now accepted (and the warning text names both).
+
 ## [1.0.0-dev.17] - 2026-06-07
 
 ### Added

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -662,11 +662,17 @@ function resolveEffortInternal(cwd, agentType) {
   }
 
   // Model-tier compatibility: haiku does not support effort at all; xhigh and max
-  // are high reasoning tiers supported only by opus and fable. When the resolved
-  // model is known and incompatible with the resolved effort, suppress (return
-  // null) and warn only on explicit overrides.
+  // are high reasoning tiers. When the resolved model is known and incompatible
+  // with the resolved effort, suppress (return null) and warn only on explicit
+  // overrides.
   // resolveModelInternal returns null for session-inherit — leave those alone.
-  const HIGH_TIER_EFFORT_MODELS = ['opus', 'fable'];
+  //
+  // These are the bare aliases the harness resolves (opus→Opus 4.8,
+  // sonnet→Sonnet 5, fable→Fable 5), all of which accept xhigh/max. A model
+  // string outside this set — e.g. a version-pinned `sonnet-4-6` via
+  // model_overrides — is treated as unsupported, since xhigh did not exist
+  // below the Opus tier before Sonnet 5.
+  const HIGH_TIER_EFFORT_MODELS = ['opus', 'fable', 'sonnet'];
   const resolvedModel = resolveModelInternal(cwd, agentType);
   const haikuSkip = resolvedModel === 'haiku';
   const highEffortSkip =
@@ -678,7 +684,7 @@ function resolveEffortInternal(cwd, agentType) {
       const overrideValue = config.effort_overrides[agentType];
       const reason = haikuSkip
         ? 'haiku does not support effort: frontmatter'
-        : `${effort} requires opus or fable (resolved model: ${resolvedModel})`;
+        : `${effort} requires opus, fable, or sonnet (resolved model: ${resolvedModel})`;
       fs.writeSync(
         2,
         `Warning: effort_overrides.${agentType}="${overrideValue}" ignored — ${reason}\n`,

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -662,21 +662,23 @@ function resolveEffortInternal(cwd, agentType) {
   }
 
   // Model-tier compatibility: haiku does not support effort at all; xhigh and max
-  // are opus-only tiers. When the resolved model is known and incompatible with the
-  // resolved effort, suppress (return null) and warn only on explicit overrides.
+  // are high reasoning tiers supported only by opus and fable. When the resolved
+  // model is known and incompatible with the resolved effort, suppress (return
+  // null) and warn only on explicit overrides.
   // resolveModelInternal returns null for session-inherit — leave those alone.
+  const HIGH_TIER_EFFORT_MODELS = ['opus', 'fable'];
   const resolvedModel = resolveModelInternal(cwd, agentType);
   const haikuSkip = resolvedModel === 'haiku';
-  const opusOnlySkip =
+  const highEffortSkip =
     resolvedModel &&
-    resolvedModel !== 'opus' &&
+    !HIGH_TIER_EFFORT_MODELS.includes(resolvedModel) &&
     (effort === 'xhigh' || effort === 'max');
-  if (haikuSkip || opusOnlySkip) {
+  if (haikuSkip || highEffortSkip) {
     if (hasExplicitOverride && effort !== null) {
       const overrideValue = config.effort_overrides[agentType];
       const reason = haikuSkip
         ? 'haiku does not support effort: frontmatter'
-        : `${effort} requires opus (resolved model: ${resolvedModel})`;
+        : `${effort} requires opus or fable (resolved model: ${resolvedModel})`;
       fs.writeSync(
         2,
         `Warning: effort_overrides.${agentType}="${overrideValue}" ignored — ${reason}\n`,

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -1450,10 +1450,12 @@ describe('resolveEffortInternal', () => {
     );
   });
 
-  test('Test 14: explicit override max + sonnet model — skip + warn (max requires opus)', () => {
+  test('Test 14: explicit override max + non-tier model — skip + warn (max needs a high-tier model)', () => {
+    // 'sonnet-4-6' is a version-pinned model string, legal because model_overrides
+    // is free-text. Sonnet 4.6 predates xhigh in the Sonnet tier, so max is dropped.
     writeConfig({
       model_profile: 'balanced',
-      model_overrides: { 'gsd-executor': 'sonnet' },
+      model_overrides: { 'gsd-executor': 'sonnet-4-6' },
       effort_overrides: { 'gsd-executor': 'max' },
     });
     startStderrCapture();
@@ -1462,7 +1464,7 @@ describe('resolveEffortInternal', () => {
     assert.strictEqual(
       result,
       null,
-      'max effort dropped because sonnet is not opus',
+      'max effort dropped because sonnet-4-6 is not a high-tier model',
     );
     assert.ok(
       captured.includes('max'),
@@ -1470,7 +1472,7 @@ describe('resolveEffortInternal', () => {
     );
     assert.ok(
       captured.includes('opus'),
-      `Warning should mention opus requirement, got: ${captured}`,
+      `Warning should name the required models, got: ${captured}`,
     );
     assert.ok(
       captured.includes('gsd-executor'),
@@ -1478,10 +1480,10 @@ describe('resolveEffortInternal', () => {
     );
   });
 
-  test('Test 15: explicit override xhigh + sonnet model — skip + warn (xhigh requires opus)', () => {
+  test('Test 15: explicit override xhigh + non-tier model — skip + warn (xhigh needs a high-tier model)', () => {
     writeConfig({
       model_profile: 'balanced',
-      model_overrides: { 'gsd-executor': 'sonnet' },
+      model_overrides: { 'gsd-executor': 'sonnet-4-6' },
       effort_overrides: { 'gsd-executor': 'xhigh' },
     });
     startStderrCapture();
@@ -1490,7 +1492,7 @@ describe('resolveEffortInternal', () => {
     assert.strictEqual(
       result,
       null,
-      'xhigh effort dropped because sonnet is not opus',
+      'xhigh effort dropped because sonnet-4-6 is not a high-tier model',
     );
     assert.ok(
       captured.includes('xhigh'),
@@ -1498,16 +1500,17 @@ describe('resolveEffortInternal', () => {
     );
     assert.ok(
       captured.includes('opus'),
-      `Warning should mention opus requirement, got: ${captured}`,
+      `Warning should name the required models, got: ${captured}`,
     );
   });
 
-  test('Test 16: profile-derived max + sonnet via model_overrides — silent skip, no warning', () => {
-    // Quality profile gives gsd-planner effort=max; force model to sonnet via override.
-    // Effort is profile-derived (no effort_overrides), so the skip is silent.
+  test('Test 16: profile-derived max + non-tier model via model_overrides — silent skip, no warning', () => {
+    // Quality profile gives gsd-planner effort=max; force the model to a version-pinned
+    // sonnet-4-6 via override. Effort is profile-derived (no effort_overrides), so the
+    // skip is silent.
     writeConfig({
       model_profile: 'quality',
-      model_overrides: { 'gsd-planner': 'sonnet' },
+      model_overrides: { 'gsd-planner': 'sonnet-4-6' },
     });
     startStderrCapture();
     const result = resolveEffortInternal(tmpDir, 'gsd-planner');
@@ -1515,7 +1518,7 @@ describe('resolveEffortInternal', () => {
     assert.strictEqual(
       result,
       null,
-      'profile-derived max effort dropped silently for sonnet model',
+      'profile-derived max effort dropped silently for a non-tier model',
     );
     assert.strictEqual(
       captured,
@@ -1581,6 +1584,32 @@ describe('resolveEffortInternal', () => {
         captured,
         '',
         `No warning for fable + ${effort}, got: ${captured}`,
+      );
+    }
+  });
+
+  test('Test 18c: sonnet model + xhigh/max effort — passes through (compatible)', () => {
+    // The bare `sonnet` alias resolves to Sonnet 5, which supports the full
+    // low/medium/high/xhigh/max range. Effort must survive rather than being
+    // stripped back to the session default.
+    for (const effort of ['xhigh', 'max']) {
+      writeConfig({
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-executor': 'sonnet' },
+        effort_overrides: { 'gsd-executor': effort },
+      });
+      startStderrCapture();
+      const result = resolveEffortInternal(tmpDir, 'gsd-executor');
+      const captured = stopStderrCapture();
+      assert.strictEqual(
+        result,
+        effort,
+        `${effort} passes through when model is sonnet`,
+      );
+      assert.strictEqual(
+        captured,
+        '',
+        `No warning for sonnet + ${effort}, got: ${captured}`,
       );
     }
   });

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -1562,6 +1562,29 @@ describe('resolveEffortInternal', () => {
     );
   });
 
+  test('Test 18b: fable model + xhigh/max effort — passes through (compatible)', () => {
+    for (const effort of ['xhigh', 'max']) {
+      writeConfig({
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-executor': 'fable' },
+        effort_overrides: { 'gsd-executor': effort },
+      });
+      startStderrCapture();
+      const result = resolveEffortInternal(tmpDir, 'gsd-executor');
+      const captured = stopStderrCapture();
+      assert.strictEqual(
+        result,
+        effort,
+        `${effort} passes through when model is fable`,
+      );
+      assert.strictEqual(
+        captured,
+        '',
+        `No warning for fable + ${effort}, got: ${captured}`,
+      );
+    }
+  });
+
   test('Test 19: profile=inherit with explicit max override — no skip (model unknown)', () => {
     writeConfig({
       model_profile: 'inherit',


### PR DESCRIPTION
## Problem

`resolveEffortInternal` gated the `xhigh` and `max` effort tiers to `opus` alone:

```js
resolvedModel !== 'opus' && (effort === 'xhigh' || effort === 'max')
```

Any other resolved model had its effort frontmatter stripped back to the session default — silently, with a warning only when the effort came from an explicit `effort_overrides` entry. That allowlist is now wrong for **two** models, so this PR fixes the gate rather than just porting a patch. Both commits are kept separate: the fable half is a faithful port, the sonnet half is a new fix.

## 1. `fable` — ported from anvil (`9247bc2`)

Fable supports the same high reasoning tiers as Opus. An agent pointed at `fable` via `model_overrides` lost its `xhigh`/`max` effort.

`model_overrides` values are unvalidated free-text (`config.model_overrides?.[agentType]` returns the string as-is), so `fable` is reachable today even though no profile in `model-profiles.cjs` names it. This is not dead code.

Ported from a patch applied directly to the deployed copy in the anvil workspace (`.claude/gsd-ng/bin/lib/core.cjs`, anvil commit `72bf312`). It never reached gsd-ng source, so the next `--local --runtime` install would have silently overwritten it. An audit of anvil's full deployed tree (128 files, normalizing install-time template substitution) found this was its **only** local patch.

## 2. `sonnet` — new fix (`3f9ee1b`)

The gate predates Sonnet 5. When the newest Sonnet was 4.6, `xhigh` did not exist below the Opus tier and the gate was correct. The bare `sonnet` alias now resolves to **Sonnet 5**, which supports the full `low`/`medium`/`high`/`xhigh`/`max` range — and `xhigh` is the recommended setting there for the hardest coding and agentic work, which is exactly what `gsd-executor` and `gsd-plan-checker` do (both resolve to `sonnet` under `balanced`).

**Verified empirically, not assumed.** An agent spawned with `model="sonnet"` in the current harness reports verbatim: *"You are powered by the model named Sonnet 5. The exact model ID is `claude-sonnet-5`."*

### Result

```js
const HIGH_TIER_EFFORT_MODELS = ['opus', 'fable', 'sonnet'];
```

The gate matches the **bare aliases** the harness resolves, not concrete model IDs — so a version-pinned `sonnet-4-6` passed through free-text `model_overrides` is still correctly rejected. `haiku` keeps its own separate skip path: Haiku 4.5 supports no effort at all, so that remains correct.

### Scope — how narrow this actually is

No profile assigns `xhigh`/`max` to an agent resolving below the Opus tier (`quality` puts `max` only on planner/roadmapper/debugger/verifier, all of which resolve to `opus`; `balanced` is all `inherit`; `budget` is high/medium). So the sonnet half only bit an explicit `effort_overrides` entry on a sonnet-resolved agent — e.g. `effort_overrides.gsd-executor: xhigh` under `balanced`. Real, but narrow.

### Known limitation

The alias→model mapping is overridable via `ANTHROPIC_DEFAULT_SONNET_MODEL` (and its opus/haiku/fable siblings). A user who pins `sonnet` to `claude-sonnet-4-6` would get `xhigh` passed to a model that doesn't accept it. This is inherent to gating on aliases and **already true for `opus` today** (pinning it to Opus 4.5, which supports only low/medium/high, has the same hole). Deliberately not addressed here — the gate is a best-effort guard on the default mapping, and making it precise would mean resolving concrete model IDs, which GSD never sees.

## Tests

**3386 passing / 0 failing.**

- `Test 18b` (fable) and `Test 18c` (sonnet) cover `xhigh` and `max` passing through. Both verified as genuine regression guards — each fails against the unpatched gate and passes with the fix.
- `Tests 14/15/16` encoded the old "sonnet is not opus" assumption and asserted the strip path *using* `sonnet`. They now use `sonnet-4-6`, which still genuinely lacks the tier — so the strip path keeps its coverage rather than being deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)