### PR TITLE
feat: add a `todo add` verb to gsd-tools CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- A `todo add` verb (`gsd-tools todo add --title "…" --area "…"`), so filing a todo no longer means hand-authoring markdown. Every caller previously re-implemented the same slug + ISO timestamp + YAML frontmatter recipe, and the shape drifted as a result. The verb owns the mechanics — it derives the canonical date-prefixed `.planning/todos/pending/<date>-<slug>.md` filename, emits `created`/`title`/`area` plus optional `phase`/`files`/`related`/`recurring`/`interval`, and never authors `last_completed` (that stays `todo complete`'s job on first completion). It prints the created path by default and structured fields under the existing global `--json`. `--interval` is validated against the same `parseDuration` helper `recurring-due` already uses and is rejected without `--recurring`, since an interval alone is inert; `--area` stays free-text. Notably, a filename collision is now an **error naming the existing file rather than a silent overwrite** — a real gap, because the hand-rolled `Write` path it replaces clobbered the existing todo without warning.
+
+### Changed
+
+- `/gsd:add-todo` and `/gsd:note` now delegate the todo file write to `todo add` instead of hand-rolling filenames and frontmatter. The reasoning half stays in the workflows — dedup scanning, area inference, and the reverse `related:` backlink on the *existing* todo are unchanged, and the CLI does no cross-file mutation. This normalizes `/gsd:note promote`, which had drifted furthest: it invented sequential `{NNN}-{slug}` filenames and a `status`/`priority`/`source`/`theme` schema that nothing read. Promoted notes now land on the canonical date-prefixed `<date>-<slug>` filename with `created`/`title`/`area`, with the `theme` folded into `--area` and the "promoted from note" provenance carried in the body prose it already wrote. Existing `{NNN}-*.md` todos on disk are untouched and continue to list normally.
+- The unknown-`todo`-subcommand error no longer redirects to `/gsd:add-todo` as the only way to add a todo. That hint fires on a CLI typo, where the correct repair is now `todo add` — which the `Available:` list advertises on its own.
+
 ### Fixed
 
 - `resolve-effort` no longer strips the `xhigh` and `max` effort tiers from agents resolved to `fable` or `sonnet`. The model-tier compatibility gate accepted only `opus`, so an agent pointed at either model silently fell back to the session default effort — with a warning only when the effort came from an explicit `effort_overrides` entry. Both now support the same high reasoning tiers as Opus: `fable` always did, and `sonnet` gained `xhigh` when the alias moved to Sonnet 5 (the first Sonnet-tier model with it, and the recommended setting there for the hardest coding and agentic work). The gate matches on the bare aliases the harness resolves, so a version-pinned string such as `sonnet-4-6` is still correctly rejected. The warning text now names all three accepted models.

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -285,7 +285,7 @@ const SUBCOMMANDS = {
   phase: ['next-decimal', 'add', 'insert', 'remove', 'complete'],
   milestone: ['complete'],
   validate: ['consistency', 'health'],
-  todo: ['complete', 'list-by-phase', 'scan-phase-linked'],
+  todo: ['add', 'complete', 'list-by-phase', 'scan-phase-linked'],
   init: [
     'execute-phase',
     'plan-phase',
@@ -417,6 +417,20 @@ const ARG_SCHEMAS = {
     health: { positional: { min: 0, max: 0 }, flags: ['--repair'] },
   },
   todo: {
+    add: {
+      positional: { min: 0, max: 0 },
+      flags: [
+        '--title',
+        '--area',
+        '--phase',
+        '--files',
+        '--related',
+        '--body',
+        '--body-file',
+        '--recurring',
+        '--interval',
+      ],
+    },
     complete: { positional: { min: 1, max: 1 }, flags: [] },
     'list-by-phase': { positional: { min: 1, max: 1 }, flags: [] },
     'scan-phase-linked': { positional: { min: 1, max: 1 }, flags: [] },
@@ -1719,7 +1733,27 @@ async function main() {
     case 'todo': {
       const subcommand = args[1];
       validateArgs('todo', subcommand, args.slice(2));
-      if (subcommand === 'complete') {
+      if (subcommand === 'add') {
+        const titleIdx = args.indexOf('--title');
+        const areaIdx = args.indexOf('--area');
+        const phaseIdx = args.indexOf('--phase');
+        const filesIdx = args.indexOf('--files');
+        const relatedIdx = args.indexOf('--related');
+        const bodyIdx = args.indexOf('--body');
+        const bodyFileIdx = args.indexOf('--body-file');
+        const intervalIdx = args.indexOf('--interval');
+        commands.cmdTodoAdd(cwd, {
+          title: titleIdx !== -1 ? args[titleIdx + 1] : null,
+          area: areaIdx !== -1 ? args[areaIdx + 1] : null,
+          phase: phaseIdx !== -1 ? args[phaseIdx + 1] : null,
+          files: filesIdx !== -1 ? args[filesIdx + 1] : null,
+          related: relatedIdx !== -1 ? args[relatedIdx + 1] : null,
+          body: bodyIdx !== -1 ? args[bodyIdx + 1] : null,
+          body_file: bodyFileIdx !== -1 ? args[bodyFileIdx + 1] : null,
+          recurring: args.includes('--recurring'),
+          interval: intervalIdx !== -1 ? args[intervalIdx + 1] : null,
+        });
+      } else if (subcommand === 'complete') {
         commands.cmdTodoComplete(cwd, args[2]);
       } else if (subcommand === 'list-by-phase') {
         commands.cmdTodoListByPhase(cwd, args[2]);

--- a/gsd-ng/bin/gsd-tools.cjs
+++ b/gsd-ng/bin/gsd-tools.cjs
@@ -91,6 +91,7 @@
  *   progress [json|table|bar]          Render progress in various formats
  *
  * Todos:
+ *   todo add --title T [--area A]      Create a pending todo
  *   todo complete <filename>           Move todo from pending to completed
  *
  * Scaffolding:
@@ -1761,21 +1762,18 @@ async function main() {
         commands.cmdTodoScanPhaseLinked(cwd, args[2]);
       } else {
         // Only use same-namespace suggestions to avoid misleading
-        // cross-namespace matches (e.g. "todo add" suggesting "phase add").
+        // cross-namespace matches (e.g. "todo insert" suggesting "phase insert").
         const suggestions = suggestSubcommand(subcommand, 'todo');
-        // Hint users toward the /gsd:add-todo skill for create operations.
-        const skillHint =
-          '\nTo add a todo, use `/gsd:add-todo` (a workflow skill).';
         if (suggestions.sameNamespace.length > 0) {
           const parts = suggestions.sameNamespace
             .slice(0, 2)
             .map((s) => `todo ${s}`);
           error(
-            `Unknown todo subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.todo.join(', ')}${skillHint}`,
+            `Unknown todo subcommand '${subcommand}'. Did you mean: ${parts.join(', ')}?\nAvailable: ${SUBCOMMANDS.todo.join(', ')}`,
           );
         } else {
           error(
-            `Unknown todo subcommand '${subcommand}'. Available: ${SUBCOMMANDS.todo.join(', ')}${skillHint}`,
+            `Unknown todo subcommand '${subcommand}'. Available: ${SUBCOMMANDS.todo.join(', ')}`,
           );
         }
       }

--- a/gsd-ng/bin/lib/commands.cjs
+++ b/gsd-ng/bin/lib/commands.cjs
@@ -26,6 +26,7 @@ const {
   findPhaseInternal,
   planningPaths,
   getEngineRuntime,
+  readTextArgOrFile,
 } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { MODEL_PROFILES, EFFORT_PROFILES } = require('./model-profiles.cjs');
@@ -673,6 +674,99 @@ function isRecurringDue(todoData) {
     ? new Date(todoData.last_completed).getTime()
     : 0;
   return Date.now() - lastCompleted >= intervalMs;
+}
+
+const DEFAULT_TODO_BODY = '## Problem\n\n## Solution\n';
+
+function yamlScalar(value) {
+  const str = String(value);
+  return /[:#]|^["'\s]|\s$/.test(str) ? JSON.stringify(str) : str;
+}
+
+function splitList(value) {
+  return String(value || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function cmdTodoAdd(cwd, opts = {}) {
+  const title = (opts.title || '').trim();
+  if (!title) {
+    error('--title is required for todo add');
+  }
+
+  if (opts.interval && !opts.recurring) {
+    error('--interval requires --recurring — an interval alone is inert');
+  }
+
+  if (opts.interval && !parseDuration(opts.interval)) {
+    error(
+      `Invalid --interval '${opts.interval}' — expected Nd/Nw/Nm/Ny (e.g. 30d)`,
+    );
+  }
+
+  let body;
+  try {
+    body = readTextArgOrFile(cwd, opts.body, opts.body_file, 'body');
+  } catch (e) {
+    error(e.message);
+  }
+  const bodyText = body == null || body === '' ? DEFAULT_TODO_BODY : body;
+
+  const slug = generateSlugInternal(title);
+  if (!slug) {
+    error(`--title '${title}' contains no slug-able characters`);
+  }
+
+  const now = new Date();
+  const created = now.toISOString();
+  const date = created.split('T')[0];
+  const filename = `${date}-${slug}.md`;
+
+  const { todosPending } = planningPaths(cwd);
+  fs.mkdirSync(todosPending, { recursive: true });
+
+  const target = path.join(todosPending, filename);
+  if (fs.existsSync(target)) {
+    error(
+      `Todo already exists: ${filename} — retitle or edit .planning/todos/pending/${filename}`,
+    );
+  }
+
+  const area = (opts.area || '').trim() || 'general';
+  const files = splitList(opts.files);
+  const related = splitList(opts.related);
+
+  const lines = [
+    `created: ${created}`,
+    `title: ${yamlScalar(title)}`,
+    `area: ${yamlScalar(area)}`,
+  ];
+  if (opts.phase) lines.push(`phase: ${yamlScalar(opts.phase)}`);
+  if (files.length) {
+    lines.push('files:', ...files.map((f) => `  - ${yamlScalar(f)}`));
+  }
+  if (related.length) {
+    lines.push('related:', ...related.map((r) => `  - ${yamlScalar(r)}`));
+  }
+  if (opts.recurring) lines.push('recurring: true');
+  if (opts.interval) lines.push(`interval: ${opts.interval}`);
+
+  const content = `---\n${lines.join('\n')}\n---\n\n${bodyText.replace(/\n*$/, '\n')}`;
+  fs.writeFileSync(target, content, 'utf-8');
+
+  const relPath = toPosixPath(path.relative(cwd, target));
+  output(
+    {
+      created: true,
+      file: filename,
+      path: relPath,
+      title,
+      area,
+    },
+    relPath,
+  );
 }
 
 function cmdTodoComplete(cwd, filename) {
@@ -4908,6 +5002,7 @@ module.exports = {
   cmdProgressRender,
   parseDuration,
   isRecurringDue,
+  cmdTodoAdd,
   cmdTodoComplete,
   cmdTodoListByPhase,
   cmdTodoScanPhaseLinked,

--- a/gsd-ng/bin/lib/core.cjs
+++ b/gsd-ng/bin/lib/core.cjs
@@ -710,6 +710,19 @@ function pathExistsInternal(cwd, targetPath) {
   }
 }
 
+function readTextArgOrFile(cwd, value, filePath, label) {
+  if (!filePath) return value;
+
+  const resolvedPath = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(cwd, filePath);
+  try {
+    return fs.readFileSync(resolvedPath, 'utf-8').trimEnd();
+  } catch {
+    throw new Error(`${label} file not found: ${filePath}`);
+  }
+}
+
 function generateSlugInternal(text, maxLen = 50) {
   if (!text) return null;
   let slug = text
@@ -894,6 +907,7 @@ module.exports = {
   resolveModelInternal,
   resolveEffortInternal,
   pathExistsInternal,
+  readTextArgOrFile,
   generateSlugInternal,
   getMilestoneInfo,
   getMilestonePhaseFilter,

--- a/gsd-ng/bin/lib/state.cjs
+++ b/gsd-ng/bin/lib/state.cjs
@@ -12,6 +12,7 @@ const {
   output,
   error,
   planningPaths,
+  readTextArgOrFile,
 } = require('./core.cjs');
 const {
   extractFrontmatter,
@@ -147,19 +148,6 @@ function cmdStateGet(cwd, section) {
     output({ error: `Section or field "${section}" not found` }, '');
   } catch {
     error('STATE.md not found');
-  }
-}
-
-function readTextArgOrFile(cwd, value, filePath, label) {
-  if (!filePath) return value;
-
-  const resolvedPath = path.isAbsolute(filePath)
-    ? filePath
-    : path.join(cwd, filePath);
-  try {
-    return fs.readFileSync(resolvedPath, 'utf-8').trimEnd();
-  } catch {
-    throw new Error(`${label} file not found: ${filePath}`);
   }
 }
 

--- a/gsd-ng/workflows/add-todo.md
+++ b/gsd-ng/workflows/add-todo.md
@@ -24,7 +24,7 @@ if ! node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" guard init-valid "$INIT" 2>/d
 fi
 ```
 
-Extract from init JSON: `commit_docs`, `date`, `timestamp`, `todo_count`, `todos`, `pending_dir`, `todos_dir_exists`.
+Extract from init JSON: `commit_docs`, `todo_count`, `todos`, `pending_dir`, `todos_dir_exists`.
 
 Ensure directories exist:
 ```bash
@@ -103,27 +103,9 @@ Note: If "Link as related" was selected, `$LINK_AS_RELATED` is set to `true` and
 </step>
 
 <step name="create_file">
-Use values from init context: `timestamp` and `date` are already available.
-
-Generate slug for the title:
-```bash
-slug=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" generate-slug "$title")
-```
-
-Write to `.planning/todos/pending/${date}-${slug}.md`:
+Write the body to a temp file:
 
 ```markdown
----
-created: [timestamp]
-title: [title]
-area: [area]
-files:
-  - [file:lines]
-# Optional — for recurring reminders:
-# recurring: true
-# interval: 30d
----
-
 ## Problem
 
 [problem description - enough context for future Claude to understand weeks later]
@@ -133,9 +115,20 @@ files:
 [approach hints or "TBD"]
 ```
 
-**Recurring todos:** If the user specifies this should be a recurring or permanent reminder, add `recurring: true` and `interval: {duration}` to the frontmatter (uncomment and fill those fields). Valid interval formats: `7d`, `14d`, `30d`, `90d` (any Nd/Nw/Nm/Ny format — d=days, w=weeks, m=months, y=years). Do NOT add `last_completed` — it will be set automatically on first completion. Recurring todos stay in `pending/` after completion and resurface when their interval elapses.
+Then create the todo with a single call — the CLI derives the `YYYY-MM-DD-<slug>.md` filename and writes the frontmatter. Capture the reported filename for later steps rather than reconstructing it:
 
-The `--recurring` and `--interval` flags are recognized when invoking via arguments:
+```bash
+NEW_TODO_FILE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo add \
+  --title "$title" --area "$area" --body-file /tmp/todo-body.md --pick file)
+```
+
+Optional flags: `--files "path/to/a.ts:12,path/to/b.ts:40"` (comma-separated), `--phase N`, and `--related "$EXISTING_TODO_FOR_LINK"` when `$LINK_AS_RELATED` is true (see `git_commit`).
+
+If the title collides with an existing todo for today, `todo add` errors instead of overwriting. Retitle, or treat it as a duplicate and revisit `check_duplicates`.
+
+**Recurring todos:** If the user specifies this should be a recurring or permanent reminder, pass `--recurring --interval {duration}`. Valid interval formats: `7d`, `14d`, `30d`, `90d` (any Nd/Nw/Nm/Ny format — d=days, w=weeks, m=months, y=years). Never author `last_completed` — the CLI omits it and `todo complete` sets it on first completion. Recurring todos stay in `pending/` after completion and resurface when their interval elapses.
+
+The `--recurring` and `--interval` flags are recognized when invoking via arguments, and pass straight through:
 - `{{COMMAND_PREFIX}}add-todo Check upstream changes --recurring --interval 30d`
 </step>
 
@@ -147,15 +140,11 @@ If `.planning/STATE.md` exists:
 </step>
 
 <step name="git_commit">
-**If `$LINK_AS_RELATED` is true**, run the auto-backlink BEFORE committing:
+**If `$LINK_AS_RELATED` is true**, run the reverse backlink BEFORE committing. The forward link was already written by `todo add --related` in `create_file`; only the existing todo still needs updating:
 
 ```bash
-# NEW_TODO_FILE is the filename just created (e.g., "2026-03-29-my-new-todo.md")
+# NEW_TODO_FILE is the filename reported by todo add (e.g., "2026-03-29-my-new-todo.md")
 # EXISTING_TODO_FOR_LINK is the similar todo found during duplicate check (basename only)
-
-# Append to related: on the new todo (creates the array if missing)
-node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter array-append \
-  ".planning/todos/pending/$NEW_TODO_FILE" --field related --value "$EXISTING_TODO_FOR_LINK"
 
 # Append to related: on the existing todo (dedupe-aware; coerces scalar/missing to array)
 node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" frontmatter array-append \
@@ -171,7 +160,7 @@ if [[ "$LINK_AS_RELATED" == "true" ]]; then
   node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title] (linked to $EXISTING_TODO_FOR_LINK)" \
     --files ".planning/todos/pending/$NEW_TODO_FILE" ".planning/todos/pending/$EXISTING_TODO_FOR_LINK" .planning/STATE.md
 else
-  node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title]" --files .planning/todos/pending/[filename] .planning/STATE.md
+  node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" commit "docs: capture todo - [title]" --files ".planning/todos/pending/$NEW_TODO_FILE" .planning/STATE.md
 fi
 ```
 
@@ -184,7 +173,7 @@ Confirm: "Committed: docs: capture todo - [title]"
 Display the saved todo summary:
 
 ```
-Todo saved: .planning/todos/pending/[filename]
+Todo saved: .planning/todos/pending/$NEW_TODO_FILE
 
   [title]
   Area: [area]

--- a/gsd-ng/workflows/note.md
+++ b/gsd-ng/workflows/note.md
@@ -1,6 +1,7 @@
 <purpose>
 Zero-friction idea capture. One Write call, one confirmation line. No questions, no prompts.
-Runs inline — no Task, no AskUserQuestion, no Bash.
+Runs inline — no Task, no AskUserQuestion. Capture and list use no Bash; promote shells out to
+`gsd-tools todo add` so the promoted todo matches every other todo on disk.
 </purpose>
 
 <required_reading>
@@ -100,21 +101,10 @@ If a scope has no directory or no entries, show: `(no notes)`
 2. Find entry N from the numbered list
 3. If N is invalid or refers to an already-promoted note, tell the user and stop
 4. **Requires `.planning/` directory** — if it doesn't exist, warn: "Todos require a GSD project. Run `{{COMMAND_PREFIX}}new-project` to initialize one."
-5. Ensure `.planning/todos/pending/` directory exists
-6. Generate todo ID: `{NNN}-{slug}` where NNN is the next sequential number (scan both `.planning/todos/pending/` and `.planning/todos/completed/` for the highest existing number, increment by 1, zero-pad to 3 digits) and slug is the first ~4 meaningful words of the note text
-7. Extract the note text from the source file (body after frontmatter)
-8. Create `.planning/todos/pending/{id}.md`:
+5. Extract the note text from the source file (body after frontmatter)
+6. Write the todo body to a temp file:
 
-```yaml
----
-title: "{note text}"
-status: pending
-priority: P2
-source: "promoted from {{COMMAND_PREFIX}}note"
-created: {YYYY-MM-DD}
-theme: general
----
-
+```markdown
 ## Goal
 
 {note text}
@@ -128,8 +118,17 @@ Promoted from quick note captured on {original date}.
 - [ ] {primary criterion derived from note text}
 ```
 
-9. Mark the source note file as promoted: update its frontmatter to `promoted: true`
-10. Confirm: `Promoted note {N} to todo {id}: {note text}`
+7. Create the todo. `todo add` creates `.planning/todos/pending/` if needed, derives the `YYYY-MM-DD-{slug}.md` filename, and writes the canonical `created`/`title`/`area` frontmatter:
+
+```bash
+TODO_FILE=$(node "$HOME/.claude/gsd-ng/bin/gsd-tools.cjs" todo add \
+  --title "{note text}" --area general --body-file /tmp/note-promote-body.md --pick file)
+```
+
+If a todo with the same slug already exists for today, `todo add` errors rather than overwriting — report the collision and stop.
+
+8. Mark the source note file as promoted: update its frontmatter to `promoted: true`
+9. Confirm: `Promoted note {N} to todo {TODO_FILE}: {note text}`
 </step>
 
 </process>

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1189,6 +1189,29 @@ describe('todo add command', () => {
     );
   });
 
+  test('unknown subcommand error does not point at the add-todo skill', () => {
+    const result = runGsdTools('todo bogus', tmpDir);
+    assert.ok(!result.success, 'should fail');
+    assert.ok(
+      !result.error.includes('add-todo'),
+      'must not advertise /gsd:add-todo as the way to add',
+    );
+    assert.ok(
+      !result.error.includes('workflow skill'),
+      'must not call add a workflow skill',
+    );
+  });
+
+  test('unknown subcommand error advertises add as available', () => {
+    const result = runGsdTools('todo bogus', tmpDir);
+    assert.ok(!result.success, 'should fail');
+    assert.match(
+      result.error,
+      /Available:[^\n]*\badd\b/,
+      'Available list should include add',
+    );
+  });
+
   test('created todo is visible to list-todos', () => {
     const added = runGsdTools(
       'todo add --title "Listed todo" --area tooling',

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -865,6 +865,348 @@ describe('todo complete command', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// todo add command
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('todo add command', () => {
+  let tmpDir;
+
+  const today = () => new Date().toISOString().split('T')[0];
+  const pendingPath = (dir, file) =>
+    path.join(dir, '.planning', 'todos', 'pending', file);
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('creates a todo with canonical filename and frontmatter', () => {
+    const result = runGsdTools(
+      'todo add --title "Add dark mode" --area ui',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const target = pendingPath(tmpDir, `${today()}-add-dark-mode.md`);
+    assert.ok(fs.existsSync(target), 'todo file should exist');
+
+    const content = fs.readFileSync(target, 'utf-8');
+    assert.match(content, /^---\n/, 'starts with frontmatter fence');
+    assert.match(content, /^created: .*T.*$/m, 'created is an ISO timestamp');
+    assert.match(content, /^title: Add dark mode$/m, 'title written');
+    assert.match(content, /^area: ui$/m, 'area written');
+  });
+
+  test('creates the pending directory when absent', () => {
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    assert.ok(!fs.existsSync(pendingDir), 'precondition: pending/ absent');
+
+    const result = runGsdTools('todo add --title "Fresh start"', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.ok(fs.existsSync(pendingDir), 'pending/ should be created');
+  });
+
+  test('defaults area to general when --area omitted', () => {
+    const result = runGsdTools('todo add --title "No area given"', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-no-area-given.md`),
+      'utf-8',
+    );
+    assert.match(content, /^area: general$/m, 'area defaults to general');
+  });
+
+  test('prints the relative posix path by default (not JSON)', () => {
+    const result = runGsdTools(
+      'todo add --title "Add dark mode" --area ui',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(
+      result.output,
+      `.planning/todos/pending/${today()}-add-dark-mode.md`,
+    );
+  });
+
+  test('--json emits structured fields', () => {
+    const result = runGsdTools(
+      'todo add --title "Add dark mode" --area ui --json',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.file, `${today()}-add-dark-mode.md`);
+    assert.strictEqual(
+      parsed.path,
+      `.planning/todos/pending/${today()}-add-dark-mode.md`,
+    );
+    assert.strictEqual(parsed.title, 'Add dark mode');
+    assert.strictEqual(parsed.area, 'ui');
+  });
+
+  test('fails when --title is missing', () => {
+    const result = runGsdTools('todo add --area ui', tmpDir);
+    assert.ok(!result.success, 'should fail');
+    assert.ok(result.error.includes('--title'), 'error mentions --title');
+  });
+
+  test('fails on a whitespace-only --title', () => {
+    const result = runGsdTools('todo add --title "   " --area ui', tmpDir);
+    assert.ok(!result.success, 'should fail');
+
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    const written = fs.existsSync(pendingDir) ? fs.readdirSync(pendingDir) : [];
+    assert.deepStrictEqual(written, [], 'no file should be written');
+  });
+
+  test('fails when the title slugs to nothing', () => {
+    const result = runGsdTools('todo add --title "???" --area ui', tmpDir);
+    assert.ok(!result.success, 'should fail');
+
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    const written = fs.existsSync(pendingDir) ? fs.readdirSync(pendingDir) : [];
+    assert.deepStrictEqual(written, [], 'no file should be written');
+  });
+
+  test('errors on collision without overwriting the existing todo', () => {
+    const first = runGsdTools(
+      'todo add --title "Add dark mode" --area ui --body "original body"',
+      tmpDir,
+    );
+    assert.ok(first.success, `First add failed: ${first.error}`);
+
+    const target = pendingPath(tmpDir, `${today()}-add-dark-mode.md`);
+    const before = fs.readFileSync(target, 'utf-8');
+
+    const second = runGsdTools(
+      'todo add --title "Add dark mode" --area ui --body "clobbering body"',
+      tmpDir,
+    );
+    assert.ok(!second.success, 'second add should fail');
+    assert.ok(
+      second.error.includes(`${today()}-add-dark-mode.md`),
+      'error names the existing file',
+    );
+
+    const after = fs.readFileSync(target, 'utf-8');
+    assert.strictEqual(after, before, 'existing todo must be untouched');
+    assert.ok(after.includes('original body'), 'original body preserved');
+  });
+
+  test('--body is written verbatim after the frontmatter', () => {
+    const result = runGsdTools(
+      'todo add --title "Custom body" --body "This is the custom text."',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-custom-body.md`),
+      'utf-8',
+    );
+    assert.ok(
+      content.includes('This is the custom text.'),
+      'body appears verbatim',
+    );
+  });
+
+  test('--body-file contents are used as the body', () => {
+    const bodyPath = path.join(tmpDir, 'body.md');
+    fs.writeFileSync(bodyPath, '## From file\n\nBody loaded from disk.\n');
+
+    const result = runGsdTools(
+      'todo add --title "File body" --body-file body.md',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-file-body.md`),
+      'utf-8',
+    );
+    assert.ok(content.includes('Body loaded from disk.'), 'file body used');
+  });
+
+  test('fails cleanly when --body-file does not exist', () => {
+    const result = runGsdTools(
+      'todo add --title "Missing body" --body-file nope.md',
+      tmpDir,
+    );
+    assert.ok(!result.success, 'should fail');
+    assert.ok(result.error.includes('nope.md'), 'error mentions the path');
+    assert.ok(
+      !result.error.includes('at Object.'),
+      'should not be an unhandled stack trace',
+    );
+  });
+
+  test('falls back to the default skeleton body', () => {
+    const result = runGsdTools('todo add --title "Skeleton please"', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-skeleton-please.md`),
+      'utf-8',
+    );
+    assert.ok(content.includes('## Problem'), 'has Problem heading');
+    assert.ok(content.includes('## Solution'), 'has Solution heading');
+  });
+
+  test('--recurring --interval writes both fields and no last_completed', () => {
+    const result = runGsdTools(
+      'todo add --title "Check upstream" --recurring --interval 30d',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-check-upstream.md`),
+      'utf-8',
+    );
+    assert.match(content, /^recurring: true$/m, 'recurring written');
+    assert.match(content, /^interval: 30d$/m, 'interval written');
+    assert.ok(
+      !content.includes('last_completed'),
+      'last_completed must never be authored',
+    );
+  });
+
+  test('--recurring alone is allowed and writes no interval', () => {
+    const result = runGsdTools(
+      'todo add --title "Recurring bare" --recurring',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-recurring-bare.md`),
+      'utf-8',
+    );
+    assert.match(content, /^recurring: true$/m, 'recurring written');
+    assert.ok(!content.includes('interval:'), 'no interval field');
+  });
+
+  test('fails on --interval without --recurring', () => {
+    const result = runGsdTools(
+      'todo add --title "Inert interval" --interval 30d',
+      tmpDir,
+    );
+    assert.ok(!result.success, 'should fail');
+    assert.ok(result.error.includes('--recurring'), 'error mentions --recurring');
+  });
+
+  test('fails on a malformed --interval', () => {
+    const result = runGsdTools(
+      'todo add --title "Bad interval" --recurring --interval bogus',
+      tmpDir,
+    );
+    assert.ok(!result.success, 'should fail');
+    assert.ok(result.error.includes('30d'), 'error names a valid format');
+  });
+
+  test('--phase writes the phase field', () => {
+    const result = runGsdTools(
+      'todo add --title "Phase linked" --phase 42',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-phase-linked.md`),
+      'utf-8',
+    );
+    assert.match(content, /^phase: 42$/m, 'phase written');
+  });
+
+  test('--files writes a YAML list', () => {
+    const result = runGsdTools(
+      'todo add --title "Touches files" --files a.js,b.js',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-touches-files.md`),
+      'utf-8',
+    );
+    assert.match(content, /^files:\n {2}- a\.js\n {2}- b\.js$/m, 'YAML list');
+  });
+
+  test('--related writes only the new file own related list', () => {
+    const pendingDir = path.join(tmpDir, '.planning', 'todos', 'pending');
+    fs.mkdirSync(pendingDir, { recursive: true });
+    const siblingPath = path.join(pendingDir, 'other.md');
+    fs.writeFileSync(siblingPath, '---\ntitle: Other\narea: ui\n---\n\nBody\n');
+    const siblingBefore = fs.readFileSync(siblingPath, 'utf-8');
+
+    const result = runGsdTools(
+      'todo add --title "Links out" --related other.md',
+      tmpDir,
+    );
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(
+      pendingPath(tmpDir, `${today()}-links-out.md`),
+      'utf-8',
+    );
+    assert.match(content, /^related:\n {2}- other\.md$/m, 'related list');
+
+    assert.strictEqual(
+      fs.readFileSync(siblingPath, 'utf-8'),
+      siblingBefore,
+      'the CLI must not mutate the related todo',
+    );
+  });
+
+  test('rejects an unknown flag', () => {
+    const result = runGsdTools(
+      'todo add --title "Valid" --bogus something',
+      tmpDir,
+    );
+    assert.ok(!result.success, 'should fail');
+    assert.ok(result.error.includes('--bogus'), 'error names the unknown flag');
+  });
+
+  test('round-trips through todo complete', () => {
+    const added = runGsdTools(
+      'todo add --title "Round trip" --area tooling --json',
+      tmpDir,
+    );
+    assert.ok(added.success, `Add failed: ${added.error}`);
+    const { file } = JSON.parse(added.output);
+
+    const completed = runGsdTools(`todo complete ${file} --json`, tmpDir);
+    assert.ok(completed.success, `Complete failed: ${completed.error}`);
+    assert.strictEqual(JSON.parse(completed.output).completed, true);
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, '.planning', 'todos', 'completed', file)),
+      'todo should land in completed/',
+    );
+  });
+
+  test('created todo is visible to list-todos', () => {
+    const added = runGsdTools(
+      'todo add --title "Listed todo" --area tooling',
+      tmpDir,
+    );
+    assert.ok(added.success, `Add failed: ${added.error}`);
+
+    const listed = runGsdTools('list-todos --json', tmpDir);
+    assert.ok(listed.success, `List failed: ${listed.error}`);
+
+    const parsed = JSON.parse(listed.output);
+    const found = parsed.todos.find((t) => t.title === 'Listed todo');
+    assert.ok(found, 'created todo should be listed');
+    assert.strictEqual(found.area, 'tooling');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // scaffold command
 // ─────────────────────────────────────────────────────────────────────────────
 

--- a/tests/dispatcher.test.cjs
+++ b/tests/dispatcher.test.cjs
@@ -503,9 +503,9 @@ describe('sync-agents command', () => {
   });
 });
 
-// ─── skill-redirect hints in error messages ──────────────────────────────────
+// ─── todo unknown-subcommand error messaging ─────────────────────────────────
 
-describe('skill-redirect hints in gsd-tools error messages', () => {
+describe('todo unknown subcommand error messaging', () => {
   let tmpDir;
 
   beforeEach(() => {
@@ -516,12 +516,12 @@ describe('skill-redirect hints in gsd-tools error messages', () => {
     cleanup(tmpDir);
   });
 
-  test('F-SKILL-HINT: todo unknown subcommand error includes /gsd:add-todo hint', () => {
+  test('F-SKILL-HINT: todo unknown subcommand error does not redirect to /gsd:add-todo', () => {
     const result = runGsdTools('todo unknown-sub', tmpDir);
     assert.strictEqual(result.success, false, 'Should exit non-zero');
     assert.ok(
-      result.error.includes('/gsd:add-todo'),
-      `F-SKILL-HINT: Expected /gsd:add-todo hint in stderr, got: ${result.error}`,
+      !result.error.includes('/gsd:add-todo'),
+      `F-SKILL-HINT: 'todo add' is a real subcommand — the error must not send CLI users to the skill, got: ${result.error}`,
     );
   });
 
@@ -530,7 +530,7 @@ describe('skill-redirect hints in gsd-tools error messages', () => {
     assert.strictEqual(result.success, false, 'Should exit non-zero');
     assert.ok(
       result.error.includes('Available:'),
-      `Expected "Available:" in stderr alongside skill hint, got: ${result.error}`,
+      `Expected "Available:" in stderr, got: ${result.error}`,
     );
   });
 });


### PR DESCRIPTION
## Problem

`gsd-tools.cjs` exposed `todo complete`, `todo list-by-phase`, `todo scan-phase-linked`, and `list-todos` — but no create verb. Filing a todo meant hand-authoring markdown with correct YAML frontmatter and a slugged `YYYY-MM-DD-<slug>.md` filename, so every caller re-implemented the same recipe and the shape drifted. `add-todo.md` inlined the whole thing; `note.md` had drifted furthest, inventing sequential `{NNN}-{slug}` filenames and a `status`/`priority`/`source`/`theme` schema.

## Change

Adds `todo add`, owning the **mechanical** half only — slug, timestamp, frontmatter, write. The reasoning half (dedup scan, area inference, the reverse `related:` backlink) stays in the skills, per the carve-out in `feedback_workflows-over-cli-for-ai.md`: convert "truly mechanical operations", and "strengthen the gsd-tools data layer so workflows stay thin orchestrators".

```
gsd-tools todo add --title "…" [--area A] [--phase N] [--files a,b]
  [--related x.md] [--body "…"|--body-file path] [--recurring] [--interval 30d]
```

Behavior decisions:

- **Collision is an error, never an overwrite.** Fixes a real gap — the hand-rolled `Write` path it replaces clobbered an existing todo silently. The error names the existing file.
- **Output**: created path by default; structured fields under the **existing global `--json`** (stripped in `main()` before `validateArgs`, so no new flag was needed).
- **Validation is format, not vocabulary**: `--title` required and must slug to something; `--interval` validated by the *existing* `parseDuration` and rejected without `--recurring` (an interval alone is inert); `--area` stays free-text; `last_completed` is never authored (that stays `todo complete`'s job).
- **No cross-file mutation** — `--related` writes only the new file's own field; the reverse backlink stays in the skill. A test asserts a sibling todo's bytes are unchanged.

Zero parallel helpers: `parseDuration`, `generateSlugInternal`, `output`, `planningPaths`, `toPosixPath` all reused. `readTextArgOrFile` was defined at `state.cjs:153` but never exported — relocated to `core.cjs` (which `state.cjs` and `commands.cjs` both already import; verified non-circular) rather than duplicated. It now exists in exactly one place.

## Behavior change — `note promote` normalization

`/gsd:note promote` now emits canonical `<date>-<slug>.md` with `created`/`title`/`area` instead of `{NNN}-{slug}` with `status`/`priority`/`source`/`theme`. Verified safe by grepping every consumer: `cmdListTodos`, `cmdInitTodos`, and `cmdTodoComplete` read only `created`/`title`/`area` (plus `phase`/`recurring`/`interval`/`external_ref`) — nothing reads the four dropped fields. `theme` folds into `--area`; the "promoted from note" provenance moves into body prose the step already wrote. Existing `{NNN}-*.md` todos on disk are untouched and still list fine (both readers glob `*.md`).

## Tests

TDD — RED commit (`279bd93`, 22 failing) then GREEN (`352d99e`). **3409 passing / 0 failing** (baseline 3384, +25).

Covers: creation and frontmatter shape, default-vs-`--json` output, collision (asserting the original's bytes are unchanged), missing/blank/unsluggable `--title`, `--body`/`--body-file`/missing-file, recurring + interval validation both ways, `--phase`/`--files`/`--related`, no cross-file mutation, unknown-flag rejection, and a `todo add` → `todo complete` round-trip proving the emitted frontmatter is consumable.

Smoke-tested end-to-end in a scratch repo beyond the suite.

## Notable deviation

`tests/dispatcher.test.cjs:519` (`F-SKILL-HINT`) hard-asserted the `/gsd:add-todo` hint this PR removes — the plan's file list missed it. The assertion was **inverted rather than deleted**, keeping the traceability ID attached to live behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)