### PR TITLE
ci: publish the release draft by tag instead of hunting its id

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,5 +96,4 @@ jobs:
           TAG: ${{ steps.resolve.outputs.ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          RELEASE_ID=$(gh api "repos/${{ github.repository }}/releases" --jq ".[] | select(.tag_name==\"${TAG}\") | .id")
-          gh api "repos/${{ github.repository }}/releases/${RELEASE_ID}" --method PATCH -f draft=false
+          gh release edit "${TAG}" --draft=false


### PR DESCRIPTION
The `Publish release` step in `release.yml` looked the just-created draft up by listing releases and filtering on `tag_name`, then PATCHed `/releases/<id>`. The list is unpaginated and the empty result unguarded, so a missed filter left `RELEASE_ID` empty and the PATCH hit `/releases/` → **404**. That left the GitHub Release stuck as a draft on **v1.0.0-dev.19** (npm published fine), so it had to be published by hand.

## Fix

```
gh release edit "${TAG}" --draft=false
```

`gh release edit <tag>` resolves a *draft* release by tag through gh's purpose-built lookup (verified against gh 2.96.0), so there is no list-visibility/pagination gap and no empty-id URL. It is the exact command that published dev.19's stuck draft by hand. Idempotent on re-run; leaves the `prerelease` flag (set at create time) untouched.

The draft-then-publish dance is kept deliberately — it is the immutable-release / tag-burn workaround, not incidental.

Reviewed for correctness and over-engineering: the one line is the right amount. A publish-step retry and a `concurrency:` guard were considered and left out as speculative — separate concerns, not this PR.

actionlint + shellcheck clean; can only be fully proven at the next release cut.